### PR TITLE
Integrate maven plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,5 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: spotbugs
-        run: mvn compile spotbugs:check
-      - name: test install
+      - name: Spotless check, Spotbugs check and Install
         run: mvn install

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,13 @@
                         </indent>
                     </java>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- Static code analysis -->
@@ -187,6 +194,13 @@
                 <configuration>
                     <threshold>High</threshold>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- Create and install javadoc.jar file -->


### PR DESCRIPTION
Integrate the execution of `spotless:check` and `spotbugs:check` in the maven's **verify** phase, which precedes the **install** phase. 

Also, disable the execution of `spotless action`, because it is executed during `mvn install`. The best way to enable/disable the execution of the workflow (without altering the file) is from **```actions -> spotless -> disable workflow```**.