### PR TITLE
Add program name and learner result

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
@@ -1,0 +1,142 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.learner;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.Statistics;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Used to store information about the learning process.
+ * <p>
+ * An 'empty' LearnerResult is used to indicate an error. A normal LearnerResult
+ * can be converted to 'empty' using {@link #toEmpty()} and can be checked
+ * for emptiness using {@link #isEmpty()}.
+ */
+public class LearnerResult {
+
+    /** Stores the list of intermediate hypothesis. */
+    protected List<StateMachine> hypotheses;
+
+    /** Stores the learned model. */
+    protected StateMachine learnedModel;
+
+    /** Stores the file, in which the learned model has been outputted. */
+    protected File learnedModelFile;
+
+    /** Stores the collected statistics of the learning process. */
+    protected Statistics statistics;
+
+    /**
+     * Constructs a new instance, initializing parameters to null except for the
+     * {@link #hypotheses}.
+     */
+    public LearnerResult() {
+        hypotheses = new ArrayList<>();
+        learnedModel = null;
+        learnedModelFile = null;
+        statistics = null;
+    }
+
+    /**
+     * Returns a reference to the same instance after initializing every parameter to null.
+     * <p>
+     * The {@code get} methods will return null after this.
+     *
+     * @return  a reference to the same instance
+     */
+    public LearnerResult toEmpty() {
+        hypotheses = null;
+        learnedModel = null;
+        learnedModelFile = null;
+        statistics = null;
+        return this;
+    }
+
+    /**
+     * Checks if this instance is empty.
+     *
+     * @return  {@code true} if this instance is empty
+     */
+    public boolean isEmpty() {
+        return hypotheses == null
+            && learnedModel == null
+            && learnedModelFile == null
+            && statistics == null;
+    }
+
+    /**
+     * Adds a hypothesis to {@link #hypotheses} if the underlying list is not null.
+     *
+     * @param hypothesis  the hypothesis to be added
+     */
+    public void addHypothesis(StateMachine hypothesis) {
+        if (hypotheses != null) {
+            hypotheses.add(hypothesis);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable list of non-null {@link #hypotheses} or null.
+     *
+     * @return  an unmodifiable list of non-null {@link #hypotheses} or null
+     */
+    public List<StateMachine> getHypotheses() {
+        return hypotheses == null ? null : Collections.unmodifiableList(hypotheses);
+    }
+
+    /**
+     * Returns the stored value of {@link #learnedModel}.
+     *
+     * @return  the stored value of {@link #learnedModel}
+     */
+    public StateMachine getLearnedModel() {
+        return learnedModel;
+    }
+
+    /**
+     * Sets the value of {@link #learnedModel}.
+     *
+     * @param learnedModel  the learned model to be set
+     */
+    public void setLearnedModel(StateMachine learnedModel) {
+        this.learnedModel = learnedModel;
+    }
+
+    /**
+     * Returns the stored value of {@link #learnedModelFile}.
+     *
+     * @return  the stored value of {@link #learnedModelFile}
+     */
+    public File getLearnedModelFile() {
+        return learnedModelFile;
+    }
+
+    /**
+     * Sets the value of {@link #learnedModelFile}.
+     *
+     * @param learnedModelFile  the file of the learned model to be set
+     */
+    public void setLearnedModelFile(File learnedModelFile) {
+        this.learnedModelFile = learnedModelFile;
+    }
+
+    /**
+     * Returns the stored value of {@link #statistics}.
+     *
+     * @return  the stored value of {@link #statistics}
+     */
+    public Statistics getStatistics() {
+        return statistics;
+    }
+
+    /**
+     * Sets the value of {@link #statistics}.
+     *
+     * @param statistics  the statistics to be set
+     */
+    public void setStatistics(Statistics statistics) {
+        this.statistics = statistics;
+    }
+}

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -2,6 +2,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.entrypoints;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.LearnerResult;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.StateFuzzerBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.*;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerBuilder;
@@ -17,6 +18,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -112,13 +115,18 @@ public class CommandLineParser {
     }
 
     /**
-     * Parses the arguments provided and executes the specified command.
+     * Parses the arguments provided and executes the specified commands.
+     * <p>
+     * Multiple independent commands can be separated using {@literal --}.
      * <p>
      * It uses the {@link #parseAndExecuteCommand(String[])}.
      *
      * @param args  the command-line arguments to be parsed
+     *
+     * @return      a possibly empty list that can contain possibly empty
+     *              LearnerResults of the parsed and executed commands
      */
-    public void parse(String[] args){
+    public List<LearnerResult> parse(String[] args){
         int startCmd;
         int endCmd = 0;
         String[] cmdArgs;
@@ -128,15 +136,19 @@ public class CommandLineParser {
             parseAndExecuteCommand(args);
         }
 
+        Vector<LearnerResult> results = new Vector<>(1, 1);
         while (args.length > endCmd) {
             startCmd = endCmd;
             while (args.length > endCmd && !args[endCmd].equals("--")) {
                 endCmd++;
             }
             cmdArgs = Arrays.copyOfRange(args, startCmd, endCmd);
-            parseAndExecuteCommand(cmdArgs);
+            LearnerResult result = parseAndExecuteCommand(cmdArgs);
+            results.addElement(result);
             endCmd++;
         }
+
+        return results;
     }
 
     /**
@@ -145,13 +157,16 @@ public class CommandLineParser {
      * It uses the {@link #parseCommand(String[])} and {@link #executeCommand(ParseResult)}.
      *
      * @param args  the command-line arguments to be parsed
+     * @return      if the command involves state fuzzing then the corresponding LearnerResult,
+     *              which can be empty if fuzzing fails, otherwise an empty LearnerResult
      */
-    protected void parseAndExecuteCommand(String[] args) {
+    protected LearnerResult parseAndExecuteCommand(String[] args) {
         try {
-            executeCommand(parseCommand(args));
+            return executeCommand(parseCommand(args));
         } catch (Exception e) {
             LOGGER.error("Encountered an exception, see below for more info");
             e.printStackTrace();
+            return new LearnerResult().toEmpty();
         }
     }
 
@@ -214,23 +229,27 @@ public class CommandLineParser {
      *
      * @param parseResult  the ParseResult with the parsed arguments and the
      *                     JCommander instance used
+     * @return             if the command involves state fuzzing then the
+     *                     corresponding LearnerResult, which can be empty if
+     *                     fuzzing fails, otherwise an empty LearnerResult
      */
-    protected void executeCommand(ParseResult parseResult) {
+    protected LearnerResult executeCommand(ParseResult parseResult) {
+        LearnerResult emptyLearnerResult = new LearnerResult().toEmpty();
 
         if (parseResult == null || !parseResult.isValid()) {
-            return;
+            return emptyLearnerResult;
         }
 
         String parsedCommand = parseResult.getCommander().getParsedCommand();
         if (parsedCommand == null) {
             parseResult.getCommander().usage();
-            return;
+            return emptyLearnerResult;
         }
 
         StateFuzzerConfig stateFuzzerConfig = (StateFuzzerConfig) parseResult.getObjectFromParsedCommand();
         if (stateFuzzerConfig == null || stateFuzzerConfig.isHelp()) {
             parseResult.getCommander().usage();
-            return;
+            return emptyLearnerResult;
         }
 
         LOGGER.info("Processing command {}", parsedCommand);
@@ -255,15 +274,17 @@ public class CommandLineParser {
                 LOGGER.info("Running test runner");
                 testRunnerBuilder.build(stateFuzzerConfig).run();
             }
-        } else {
-            // run state fuzzer
-            LOGGER.info("State-fuzzing a {} implementation", stateFuzzerConfig.getSulConfig().getFuzzingRole());
 
-            // this is an extra step done to store the running arguments
-            prepareOutputDir(parseResult.getArgs(), stateFuzzerConfig.getOutputDir());
-
-            stateFuzzerBuilder.build(stateFuzzerConfig).startFuzzing();
+            return emptyLearnerResult;
         }
+
+        // run state fuzzer
+        LOGGER.info("State-fuzzing a {} implementation", stateFuzzerConfig.getSulConfig().getFuzzingRole());
+
+        // this is an extra step done to store the running arguments
+        prepareOutputDir(parseResult.getArgs(), stateFuzzerConfig.getOutputDir());
+
+        return stateFuzzerBuilder.build(stateFuzzerConfig).startFuzzing();
     }
 
     /**
@@ -279,7 +300,7 @@ public class CommandLineParser {
      *                                    used in the second parse
      * @param stateFuzzerServerConfig     the configuration of the server fuzzing command
      *                                    used in the second parse
-     * @return  a new instance of the specified JCommander
+     * @return                            a new instance of the specified JCommander
      */
     protected JCommander buildCommander(boolean parseOnlyDynamicParameters,
         StateFuzzerClientConfig stateFuzzerClientConfig,

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzer.java
@@ -1,5 +1,7 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core;
 
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.LearnerResult;
+
 /**
  * Interface for the StateFuzzer implementing the state fuzzing process.
  */
@@ -23,6 +25,10 @@ public interface StateFuzzer {
     /** The filename, where the state status will be stored. */
     String LEARNING_STATE_FILENAME = "state.log";
 
-    /** Used by the fuzzer to start the state fuzzing. */
-    void startFuzzing();
+    /**
+     * Used by the StateFuzzer to start the fuzzing.
+     *
+     * @return  the corresponding LearnerResult, which can be empty
+     */
+    LearnerResult startFuzzing();
 }


### PR DESCRIPTION
Addresses the minor issue #12 and the larger issue #13.

Note that in the usage of `LearnerResult`, I indicate the logic of an erroneous learning run (or anything unrelated) using *empty* `LearnerResults` instead of using `null` values. I think it is better using the `isEmpty()` method of a non-null `LearnerResult` instance than dealing with a null object in place of a `LearnerResult`.

Of course, any other suggestion is welcome.