### PR TITLE
Post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,29 +70,37 @@ A main class can be like this:
 ```java
 public class Main {
     public static void main(String[] args) {
-        // multibuilder implements all necessary builders
+        // Multibuilder implements all necessary builders
         MultiBuilder mb = new MultiBuilder();
 
-        // single parentLogger, since Main resides in the outmost package
+        // single parentLogger, if Main resides in the outermost package
         String[] parentLoggers = {Main.class.getPackageName()};
 
         CommandLineParser commandLineParser = new CommandLineParser(mb, mb, mb, mb);
         commandLineParser.setExternalParentLoggers(parentLoggers);
-        commandLineParser.parse(args);
+
+        List<LearnerResult> results = commandLineParser.parse(args, true);
+
+        // further process the results if needed
     }
 }
 ```
 
-The basic class is
-[CommandLineParser](src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java)
-that is one entrypoint to the ProtocolState-Fuzzer.
-The constructor of the class takes as parameters a number of builders,
-which are implemented in the `MultiBuilder` class defined below.
-The last parameter of the constructor is a list of Logger names, whose logging
-level behavior can be changed by ProtocolState-Fuzzer. Since Main resides in the outmost
-package, in this example, its package name is (normally) contained in the prefix of the
-Logger name of any subpackage, meaning that a change to the logging level of this
-'parent Logger' affects any other Logger with this prefix in its name.
+Notes:
+
+* The [CommandLineParser](src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java)
+  class is one entrypoint to the ProtocolState-Fuzzer. Its constructor needs some builders,
+  which are implemented in the `MultiBuilder` class defined below.
+
+* The package name of the *Main* class suffices as the *external parent logger* of the
+  application, when the Main class resides in the outermost package. The `setExternalParentLoggers`
+  method is used in order to have the application's log level follow the ProtocolState-Fuzzer's
+  log level in case the arguments `-debug` or `-quiet` are encountered.
+
+* There are different `parse` methods in `CommandLineParser`, which can parse
+  and execute the provided arguments, export the learned `DOT` files to `PDF` and
+  use specified `Consumers` on the results. The `parse` method used above, exports the
+  learned `DOT` files to `PDF`.
 
 ```java
 public class MultiBuilder implements
@@ -146,7 +154,7 @@ public class MultiBuilder implements
 }
 ```
 
-Some additional notes:
+Notes:
 
 * `AlphabetPojoXmlImpl` should *extend* the
   [AlphabetPojoXml](src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetPojoXml.java) abstract class

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
@@ -11,9 +11,10 @@ import java.util.List;
 /**
  * Used to store information about the learning process.
  * <p>
- * An 'empty' LearnerResult is used to indicate an error. A normal LearnerResult
- * can be converted to 'empty' using {@link #toEmpty()} and can be checked
- * for emptiness using {@link #isEmpty()}.
+ * An empty LearnerResult is used to indicate an error. A normal LearnerResult
+ * can be converted to empty using {@link #toEmpty()} and can be checked
+ * for emptiness using {@link #isEmpty()}. An empty LearnerResult can be
+ * converted back to normal using {@link #toNormal()}.
  */
 public class LearnerResult {
 
@@ -74,12 +75,27 @@ public class LearnerResult {
     }
 
     /**
-     * Adds a hypothesis to {@link #hypotheses} if the underlying list is not null.
+     * Returns a reference to the same instance after converting an empty
+     * LearnerResult back to normal.
+     * <p>
+     * An already normal LearnerResult remains unaffected.
+     *
+     * @return  a reference to the same instance
+     */
+    public LearnerResult toNormal() {
+        if (isEmpty()) {
+            hypotheses = new ArrayList<>();
+        }
+        return this;
+    }
+
+    /**
+     * Adds a hypothesis to {@link #hypotheses} if this instance is not empty.
      *
      * @param hypothesis  the hypothesis to be added
      */
     public void addHypothesis(StateMachine hypothesis) {
-        if (hypotheses != null) {
+        if (!isEmpty()) {
             hypotheses.add(hypothesis);
         }
     }
@@ -103,12 +119,14 @@ public class LearnerResult {
     }
 
     /**
-     * Sets the value of {@link #learnedModel}.
+     * Sets the value of {@link #learnedModel}, if this instance is not empty.
      *
      * @param learnedModel  the learned model to be set
      */
     public void setLearnedModel(StateMachine learnedModel) {
-        this.learnedModel = learnedModel;
+        if (!isEmpty()) {
+            this.learnedModel = learnedModel;
+        }
     }
 
     /**
@@ -121,12 +139,14 @@ public class LearnerResult {
     }
 
     /**
-     * Sets the value of {@link #learnedModelFile}.
+     * Sets the value of {@link #learnedModelFile}, if this instance is not empty.
      *
      * @param learnedModelFile  the file of the learned model to be set
      */
     public void setLearnedModelFile(File learnedModelFile) {
-        this.learnedModelFile = learnedModelFile;
+        if (!isEmpty()) {
+            this.learnedModelFile = learnedModelFile;
+        }
     }
 
     /**
@@ -139,12 +159,14 @@ public class LearnerResult {
     }
 
     /**
-     * Sets the value of {@link #statistics}.
+     * Sets the value of {@link #statistics}, if this instance is not empty.
      *
      * @param statistics  the statistics to be set
      */
     public void setStatistics(Statistics statistics) {
-        this.statistics = statistics;
+        if (!isEmpty()) {
+            this.statistics = statistics;
+        }
     }
 
     /**
@@ -157,12 +179,13 @@ public class LearnerResult {
     }
 
     /**
-     * Sets the value of {@link #stateFuzzerEnabler}.
+     * Sets the value of {@link #stateFuzzerEnabler}, if this instance is not empty.
      *
      * @param stateFuzzerEnabler  the StateFuzzerEnabler to be set
      */
     public void setStateFuzzerEnabler(StateFuzzerEnabler stateFuzzerEnabler) {
-        this.stateFuzzerEnabler = stateFuzzerEnabler;
+        if (!isEmpty()) {
+            this.stateFuzzerEnabler = stateFuzzerEnabler;
+        }
     }
-
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
@@ -1,6 +1,7 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.components.learner;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.Statistics;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerEnabler;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,6 +29,9 @@ public class LearnerResult {
     /** Stores the collected statistics of the learning process. */
     protected Statistics statistics;
 
+    /** Stores the StateFuzzerEnabler used in the learning process. */
+    protected StateFuzzerEnabler stateFuzzerEnabler;
+
     /**
      * Constructs a new instance, initializing parameters to null except for the
      * {@link #hypotheses}.
@@ -37,6 +41,7 @@ public class LearnerResult {
         learnedModel = null;
         learnedModelFile = null;
         statistics = null;
+        stateFuzzerEnabler = null;
     }
 
     /**
@@ -51,6 +56,7 @@ public class LearnerResult {
         learnedModel = null;
         learnedModelFile = null;
         statistics = null;
+        stateFuzzerEnabler = null;
         return this;
     }
 
@@ -63,7 +69,8 @@ public class LearnerResult {
         return hypotheses == null
             && learnedModel == null
             && learnedModelFile == null
-            && statistics == null;
+            && statistics == null
+            && stateFuzzerEnabler == null;
     }
 
     /**
@@ -139,4 +146,23 @@ public class LearnerResult {
     public void setStatistics(Statistics statistics) {
         this.statistics = statistics;
     }
+
+    /**
+     * Returns the stored value of {@link #stateFuzzerEnabler}.
+     *
+     * @return  the stored value of {@link #stateFuzzerEnabler}
+     */
+    public StateFuzzerEnabler getStateFuzzerEnabler() {
+        return stateFuzzerEnabler;
+    }
+
+    /**
+     * Sets the value of {@link #stateFuzzerEnabler}.
+     *
+     * @param stateFuzzerEnabler  the StateFuzzerEnabler to be set
+     */
+    public void setStateFuzzerEnabler(StateFuzzerEnabler stateFuzzerEnabler) {
+        this.stateFuzzerEnabler = stateFuzzerEnabler;
+    }
+
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/StateMachine.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/StateMachine.java
@@ -62,43 +62,12 @@ public class StateMachine {
      * the option to also generate a PDF file if the dot utility is found in the system.
      *
      * @param graphFile    the destination file that is created
-     * @param generatePdf  {@code true} if also a PDF file should be generated
-     *                     using the system's dot utility
      */
-    public void export(File graphFile, boolean generatePdf) {
-        try {
-            graphFile.createNewFile();
-            export(new FileWriter(graphFile, StandardCharsets.UTF_8));
+    public void export(File graphFile) {
+        try (FileWriter fWriter = new FileWriter(graphFile, StandardCharsets.UTF_8)) {
+            GraphDOT.write(mealyMachine, alphabet, fWriter);
         } catch (IOException e) {
-            LOGGER.warn("Could not create file {}", graphFile.getAbsolutePath());
-        }
-
-        if (generatePdf) {
-            String dotFilename = graphFile.getAbsolutePath();
-            String pdfFilename = dotFilename.endsWith(".dot") ? dotFilename.replace(".dot", ".pdf") :
-                    dotFilename + ".pdf";
-            String[] cmdArray = new String[]{"dot", "-Tpdf", dotFilename, "-o", pdfFilename};
-            try {
-                Runtime.getRuntime().exec(cmdArray);
-            } catch (IOException e) {
-                LOGGER.warn("Could not export model to pdf");
-            }
-        }
-
-    }
-
-    /**
-     * Exports the StateMachine using the specified Writer, which is closed after
-     * the successful export.
-     *
-     * @param writer  the Writer to be used for the export
-     */
-    protected void export(Writer writer) {
-        try {
-            GraphDOT.write(mealyMachine, alphabet, writer);
-            writer.close();
-        } catch (IOException e) {
-            LOGGER.warn("Could not export model to dot file");
+            LOGGER.warn("Could not export model to file: {}", graphFile.getAbsolutePath());
         }
     }
 
@@ -120,8 +89,12 @@ public class StateMachine {
      */
     @Override
     public String toString() {
-        StringWriter sw = new StringWriter();
-        export(sw);
-        return sw.toString();
+        try (StringWriter sWriter = new StringWriter()) {
+            GraphDOT.write(mealyMachine, alphabet, sWriter);
+            return sWriter.toString();
+        } catch (IOException e) {
+            LOGGER.warn("Could not convert model to string");
+            return "";
+        }
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -124,17 +124,64 @@ public class CommandLineParser {
     }
 
     /**
-     * Parses the arguments provided and executes the specified commands.
-     * <p>
-     * Multiple independent commands can be separated using {@literal --}.
-     * <p>
-     * It uses the {@link #parseAndExecuteCommand(String[])}.
+     * Parses and executes the arguments, optionally converts the learned DOT
+     * models to PDF and uses the provided consumers consecutively on the results.
+     *
+     * @param args         the command-line arguments to be parsed
+     * @param exportToPDF  {@code true} if the DOT models should be exported to PDF
+     * @param consumers    the list of consumers to be used consecutively on the results
+     * @return             the learning results
+     */
+    public List<LearnerResult> parse(String[] args, boolean exportToPDF, List<Consumer<LearnerResult>> consumers) {
+        List<LearnerResult> results = parseAndExecuteCommands(args);
+
+        for (LearnerResult res : results) {
+            if (exportToPDF) {
+                DotProcessor.exportToPDF(res);
+            }
+
+            for (Consumer<LearnerResult> con: consumers) {
+                if (con != null) {
+                    con.accept(res);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Parses and executes the arguments and optionally converts the learned
+     * DOT models to PDF.
+     *
+     * @param args         the command-line arguments to be parsed
+     * @param exportToPDF  {@code true} if the DOT models should be exported to PDF
+     * @return             the learning results
+     */
+    public List<LearnerResult> parse(String[] args, boolean exportToPDF) {
+        return parse(args, exportToPDF, List.of());
+    }
+
+
+    /**
+     * Parses and executes the arguments and returns the results.
+     *
+     * @param args  the command-line arguments to be parsed
+     * @return      the learning results
+     */
+    public List<LearnerResult> parse(String[] args) {
+        return parse(args, false, List.of());
+    }
+
+    /**
+     * Parses the arguments provided and executes the specified commands, allowing
+     * multiple independent commands to be separated using {@literal --}.
      *
      * @param args  the command-line arguments to be parsed
      * @return      a possibly empty list that can contain possibly empty
      *              LearnerResults of the parsed and executed commands
      */
-    public List<LearnerResult> parse(String[] args){
+    protected List<LearnerResult> parseAndExecuteCommands(String[] args){
         int startCmd;
         int endCmd = 0;
         String[] cmdArgs;
@@ -154,46 +201,6 @@ public class CommandLineParser {
             LearnerResult result = parseAndExecuteCommand(cmdArgs);
             results.addElement(result);
             endCmd++;
-        }
-
-        return results;
-    }
-
-    /**
-     * Parses the arguments using {@link #parse(String[])} and uses the
-     * {@link DotProcessor#exportToPDF(LearnerResult)} afterwards to convert
-     * the resulting DOT file to PDF.
-     *
-     * @param args  the command-line arguments to be parsed
-     * @return      the results from {@link #parse(String[])}
-     */
-    public List<LearnerResult> parseAndExport(String[] args) {
-        List<LearnerResult> results = parse(args);
-
-        for (LearnerResult res : results) {
-            DotProcessor.exportToPDF(res);
-        }
-
-        return results;
-    }
-
-    /**
-     * Parses the arguments using {@link #parse(String[])} and
-     * uses the provided consumers consecutively on the results.
-     *
-     * @param args       the command-line arguments to be parsed
-     * @param consumers  the list of consumers to be used consecutively on the results
-     * @return           the results from {@link #parse(String[])}
-     */
-    public List<LearnerResult> parseAndConsume(String[] args, List<Consumer<LearnerResult>> consumers) {
-        List<LearnerResult> results = parse(args);
-
-        for (LearnerResult res : results) {
-            for (Consumer<LearnerResult> con: consumers) {
-                if (con != null) {
-                    con.accept(res);
-                }
-            }
         }
 
         return results;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -7,6 +7,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.StateFuzz
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.*;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.TimingProbeBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.utils.DotProcessor;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -129,7 +131,6 @@ public class CommandLineParser {
      * It uses the {@link #parseAndExecuteCommand(String[])}.
      *
      * @param args  the command-line arguments to be parsed
-     *
      * @return      a possibly empty list that can contain possibly empty
      *              LearnerResults of the parsed and executed commands
      */
@@ -153,6 +154,46 @@ public class CommandLineParser {
             LearnerResult result = parseAndExecuteCommand(cmdArgs);
             results.addElement(result);
             endCmd++;
+        }
+
+        return results;
+    }
+
+    /**
+     * Parses the arguments using {@link #parse(String[])} and uses the
+     * {@link DotProcessor#exportToPDF(LearnerResult)} afterwards to convert
+     * the resulting DOT file to PDF.
+     *
+     * @param args  the command-line arguments to be parsed
+     * @return      the results from {@link #parse(String[])}
+     */
+    public List<LearnerResult> parseAndExport(String[] args) {
+        List<LearnerResult> results = parse(args);
+
+        for (LearnerResult res : results) {
+            DotProcessor.exportToPDF(res);
+        }
+
+        return results;
+    }
+
+    /**
+     * Parses the arguments using {@link #parse(String[])} and
+     * uses the provided consumers consecutively on the results.
+     *
+     * @param args       the command-line arguments to be parsed
+     * @param consumers  the list of consumers to be used consecutively on the results
+     * @return           the results from {@link #parse(String[])}
+     */
+    public List<LearnerResult> parseAndConsume(String[] args, List<Consumer<LearnerResult>> consumers) {
+        List<LearnerResult> results = parse(args);
+
+        for (LearnerResult res : results) {
+            for (Consumer<LearnerResult> con: consumers) {
+                if (con != null) {
+                    con.accept(res);
+                }
+            }
         }
 
         return results;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
@@ -127,7 +127,7 @@ public class StateFuzzerStandard implements StateFuzzer {
                 learnerResult.addHypothesis(stateMachine);
                 // it is useful to print intermediate hypothesis as learning is running
                 String hypName = "hyp" + current_round + ".dot";
-                exportHypothesis(stateMachine, new File(outputDir, hypName), false);
+                exportHypothesis(stateMachine, new File(outputDir, hypName));
                 statisticsTracker.newHypothesis(stateMachine);
                 LOGGER.info("Generated new hypothesis: " + hypName);
 
@@ -204,7 +204,7 @@ public class StateFuzzerStandard implements StateFuzzer {
         // exporting to output files
         File learnedModelFile = new File(outputDir, LEARNED_MODEL_FILENAME);
         learnerResult.setLearnedModelFile(learnedModelFile);
-        exportHypothesis(stateMachine, learnedModelFile, true);
+        exportHypothesis(stateMachine, learnedModelFile);
 
         try {
             statistics.export(new FileWriter(new File(outputDir, STATISTICS_FILENAME), StandardCharsets.UTF_8));
@@ -292,15 +292,12 @@ public class StateFuzzerStandard implements StateFuzzer {
      *
      * @param hypothesis   the state machine hypothesis to be exported
      * @param destination  the destination file
-     * @param genPdf       {@code true} if the hypothesis needs to be exported
-     *                     also in a pdf format
      */
-    protected void exportHypothesis(StateMachine hypothesis, File destination, boolean genPdf) {
+    protected void exportHypothesis(StateMachine hypothesis, File destination) {
         if (hypothesis == null) {
             LOGGER.warn("Provided null hypothesis to be exported");
             return;
         }
-
-        hypothesis.export(destination, genPdf);
+        hypothesis.export(destination);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
@@ -193,6 +193,7 @@ public class StateFuzzerStandard implements StateFuzzer {
 
         // building results
         learnerResult.setLearnedModel(stateMachine);
+        learnerResult.setStateFuzzerEnabler(stateFuzzerEnabler);
 
         statisticsTracker.finishedLearning(stateMachine, finished, notFinishedReason);
         Statistics statistics = statisticsTracker.generateStatistics();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DotProcessor.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DotProcessor.java
@@ -1,5 +1,6 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.utils;
 
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.LearnerResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -31,5 +32,26 @@ public class DotProcessor {
         } catch (IOException e) {
             LOGGER.warn("Could not export {} to {}: {}", dotFilename, pdfFilename, e.getMessage());
         }
+    }
+
+    /**
+     * Exports the learned file contained in the provided non-empty LearnerResult to PDF
+     * using {@link DotProcessor#exportToPDF(File)}.
+     * <p>
+     * If the contained DOT file is null, then a warning is logged.
+     *
+     * @param learnerResult  the LearnerResult to be used
+     */
+    public static void exportToPDF(LearnerResult learnerResult) {
+        if (learnerResult.isEmpty()) {
+            return;
+        }
+
+        if (learnerResult.getLearnedModelFile() == null) {
+            LOGGER.warn("The provided LearnerResult contains null DOT file");
+            return;
+        }
+
+        exportToPDF(learnerResult.getLearnedModelFile());
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DotProcessor.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DotProcessor.java
@@ -1,0 +1,35 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Class for processing DOT files.
+ */
+public class DotProcessor {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Exports the provided DOT file to PDF using the {@code dot} utility in
+     * the system's PATH.
+     * <p>
+     * If the {@code dot} utility is not present in the system's PATH, then
+     * a warning is logged.
+     *
+     * @param dotInput  the DOT input file to be exported to PDF
+     */
+    public static void exportToPDF(File dotInput) {
+        String dotFilename = dotInput.getAbsolutePath();
+        String pdfFilename = dotFilename.endsWith(".dot") ? dotFilename.replace(".dot", ".pdf") : dotFilename + ".pdf";
+
+        try {
+            String[] cmdArray = new String[]{"dot", "-Tpdf", dotFilename, "-o", pdfFilename};
+            Runtime.getRuntime().exec(cmdArray);
+        } catch (IOException e) {
+            LOGGER.warn("Could not export {} to {}: {}", dotFilename, pdfFilename, e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
The concept of this PR is to keep only the necessary functionality and reduce external dependencies from the normal usage of *ProtocolState-Fuzzer*. So I propose the following: 

* *ProtocolState-Fuzzer* outputs only the learned `DOT` model and does not attempt to convert it to `PDF` via the `dot` utility in system's PATH.

* The conversion, though, is handy to have available, so I created the `DotProcessor` class, which can be used from the user.

* The `LearnerResult` is enhanced with the corresponding `StateFuzzerEnabler` containing the configs used, which have useful information.

The `DotProcessor` class is supposed to be used after the learning on the data received from `LearnerResult`. This means that this class and other user-defined ones concern the post-processing of `LearnerResults`.

---
For example, this concept can be used to operate on the learned `DOT` model in order to convert it to `PDF` and consecutively beautify it (whatever this means in the user's context). 

```java
List<LearnerResult> results = commandLineParser.parse(args);
for (LearnerResult res : results) {
    CustomDotProcessor.exportToPDF(res);
    CustomDotProcessor.beautify(res);
}
```
For example, the `CustomDotProcessor.exportToPDF(LearnerResult)` function uses the `DotProcessor.exportToPDF(File)` function after checking if the provided `LearnerResult` is not null.

---
Essentially, *ProtocolState-Fuzzer* is concerned only with the output of the learned `DOT` model, without having any external dependency to `dot` utility and the post-processing of this learned `DOT` file is left to the user.