### PR TITLE
Replace a use of keySet() with entrySet()

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerResult.java
@@ -67,10 +67,10 @@ public class TestRunnerResult<I, O> {
 
         sb.append("Test: ").append(inputWord).append(System.lineSeparator());
 
-        for (Word<O> answer : generatedOutputs.keySet()) {
-            sb.append(generatedOutputs.get(answer))
+        for (Map.Entry<Word<O>, Integer> entry : generatedOutputs.entrySet()) {
+            sb.append(entry.getValue())
                 .append(" times outputs: ")
-                .append(answer.toString())
+                .append(entry.getKey().toString())
                 .append(System.lineSeparator());
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
@@ -37,10 +37,10 @@ public class TimingProbe {
      * @return     the string representation
      */
     public static String present(Map<String, Integer> map) {
-        return map.keySet()
+        return map.entrySet()
                     .stream()
-                    .map(key -> key + "=" + map.get(key))
-                    .collect(Collectors.joining(", ", "{", "}"));
+                    .map(entry -> entry.getKey() + ": " + entry.getValue())
+                    .collect(Collectors.joining(", ", "{ ", " }"));
     }
 
     /**


### PR DESCRIPTION
It's pointless to construct (and iterate over) the set of all keys of a Map data structure if the intention is to iterate over all the entries. This is what the entrySet allows and is there for.