### PR TITLE
Prefer string.repeat to Strings.repeat

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ExportableResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ExportableResult.java
@@ -1,7 +1,5 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.utils;
 
-import com.google.common.base.Strings;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -13,10 +11,10 @@ import java.io.Writer;
 public abstract class ExportableResult {
 
     /** Delimiter that surrounds the section titles. */
-    protected static final String SECTION_TITLE_DELIM = Strings.repeat("-", 80);
+    protected static final String SECTION_TITLE_DELIM = "-".repeat(80);
 
     /** Delimiter that surrounds the results' title. */
-    protected static final String TITLE_DELIM = Strings.repeat("=", 80);
+    protected static final String TITLE_DELIM = "=".repeat(80);
 
     /**
      * Uses the {@link #doExport(PrintWriter)} method and closes the writer


### PR DESCRIPTION
JDK11 (and later) has a repeat function to build copies of a source string, so prefer it rather than resorting to an external package.