### PR TITLE
Avoid surprising behaviour of string.split(String)

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/InputResponseTimeoutConverter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/InputResponseTimeoutConverter.java
@@ -19,10 +19,10 @@ public class InputResponseTimeoutConverter implements IStringConverter<InputResp
     public InputResponseTimeoutMap convert(String value) {
         InputResponseTimeoutMap inputResponseTimeout = new InputResponseTimeoutMap();
         String resolvedValue = PropertyResolver.resolve(value);
-        String[] inputValuePairs = resolvedValue.split("\\,");
+        String[] inputValuePairs = resolvedValue.split("\\,", -1);
 
         for (String inputValuePair : inputValuePairs) {
-            String[] split = inputValuePair.split("\\:");
+            String[] split = inputValuePair.split("\\:", -1);
 
             if (split.length != 2) {
                 throw new ParameterException(errMessage(resolvedValue));

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -265,7 +265,7 @@ public class AbstractOutput extends AbstractSymbol {
      * @return                 the list of output strings
      */
     public List<String> getAtomicAbstractionStrings(int unrollRepeating) {
-        String[] atoms = getName().split("\\" + MESSAGE_SEPARATOR);
+        String[] atoms = getName().split("\\" + MESSAGE_SEPARATOR, -1);
         List<String> newAtoms = new LinkedList<>();
         for (String atom : atoms) {
             if (atom.endsWith(REPEATING_INDICATOR)) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
@@ -100,7 +100,7 @@ public class TimingProbe {
      */
     public Map<String, Integer> findDeterministicTimesValues() throws IOException, ProbeException {
         Map<String, Integer> map = new HashMap<>();
-        String[] cmds = timingProbeConfig.getProbeCmd().split(",");
+        String[] cmds = timingProbeConfig.getProbeCmd().split(",", -1);
 
         for (String cmd : cmds) {
             setTimingParameter(cmd, timingProbeConfig.getProbeHi());
@@ -145,7 +145,7 @@ public class TimingProbe {
      * @return  {@code true} if all specified commands {@link #timingProbeConfig} are valid
      */
     public boolean isValid() {
-        String[] cmds = timingProbeConfig.getProbeCmd().split(",");
+        String[] cmds = timingProbeConfig.getProbeCmd().split(",", -1);
 
         for (String cmd : cmds) {
             if (!isValid(cmd)) {


### PR DESCRIPTION
Set an explicit limit to `-1` to match the behaviour of `Splitter`. More about the issues: https://errorprone.info/bugpattern/StringSplitter