### PR TITLE
Fix some equality checks

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -355,14 +355,14 @@ public class AbstractOutput extends AbstractSymbol {
             return true;
         }
 
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null || !(o instanceof AbstractOutput)) {
             return false;
         }
 
         AbstractOutput that = (AbstractOutput) o;
         return Objects.equals(getName(), that.getName())
-                && Objects.equals(alive, that.alive)
-                && Objects.equals(messages, that.messages);
+            && (alive == that.alive)
+            && Objects.equals(messages, that.messages);
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/Flow.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/Flow.java
@@ -267,7 +267,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
             return false;
         }
 
-        if (getClass() != obj.getClass()) {
+        if (! (obj instanceof Flow)) {
             return false;
         }
 


### PR DESCRIPTION
Prefer `instanceof` to `getClass` when implementing `equals`. Rationale and more info: https://errorprone.info/bugpattern/EqualsGetClass

While at it, simplify one equality check so as to avoid boxing for primitive types.