### PR TITLE
Do not return mixed mutable/immutable results

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
@@ -293,6 +293,6 @@ public class ObservationTree<I, O> {
         List<O> outputs = new ArrayList<>(inputs.size());
         outputs.add(output);
         outputs.addAll(nextOutputs);
-        return outputs;
+        return Collections.unmodifiableList(outputs);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
@@ -272,7 +272,7 @@ public class ObservationTree<I, O> {
      */
     @Nullable public List<O> answerInputChain(List<I> inputs, boolean allowIncompleteAnswer) {
         if (inputs.isEmpty()) {
-            return Collections.emptyList();
+            return new ArrayList();
         }
 
         I input = inputs.get(0);
@@ -293,6 +293,6 @@ public class ObservationTree<I, O> {
         List<O> outputs = new ArrayList<>(inputs.size());
         outputs.add(output);
         outputs.addAll(nextOutputs);
-        return Collections.unmodifiableList(outputs);
+        return outputs;
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -235,11 +235,13 @@ public class AbstractOutput extends AbstractSymbol {
      * @return  the list of output symbol instances
      */
     public List<AbstractOutput> getAtomicOutputs(int unrollRepeating) {
+        List<AbstractOutput> outputs = new ArrayList<>();
+
         if (isAtomic() && !isRepeating()) {
-            return new ArrayList<>(Collections.singletonList(this));
+            outputs.add(this);
+            return outputs;
         }
 
-        List<AbstractOutput> outputs = new ArrayList<>();
         for (String absOutput : getAtomicAbstractionStrings(unrollRepeating)) {
             AbstractOutput output = new AbstractOutput(absOutput);
             outputs.add(output);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -218,7 +218,7 @@ public class AbstractOutput extends AbstractSymbol {
     }
 
     /**
-     * Returns an immutable list of output symbols, one for each individual message in the output,
+     * Returns a list of output symbols, one for each individual message in the output,
      * unrolling repeating messages only one time.
      *
      * @return  the list of output symbol instances
@@ -228,7 +228,7 @@ public class AbstractOutput extends AbstractSymbol {
     }
 
     /**
-     * Returns an immutable list of output symbols, one for each individual message in the output,
+     * Returns a list of output symbols, one for each individual message in the output,
      * unrolling repeating messages the given number of times.
      *
      * @param unrollRepeating  the number of times a repeating output should be unrolled
@@ -236,15 +236,15 @@ public class AbstractOutput extends AbstractSymbol {
      */
     public List<AbstractOutput> getAtomicOutputs(int unrollRepeating) {
         if (isAtomic() && !isRepeating()) {
-            return Collections.singletonList(this);
+            return new ArrayList<>(Collections.singletonList(this));
         }
 
-        List<AbstractOutput> outputs = new LinkedList<>();
+        List<AbstractOutput> outputs = new ArrayList<>();
         for (String absOutput : getAtomicAbstractionStrings(unrollRepeating)) {
             AbstractOutput output = new AbstractOutput(absOutput);
             outputs.add(output);
         }
-        return Collections.unmodifiableList(outputs);
+        return outputs;
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -218,7 +218,7 @@ public class AbstractOutput extends AbstractSymbol {
     }
 
     /**
-     * Returns a list of output symbols, one for each individual message in the output,
+     * Returns an immutable list of output symbols, one for each individual message in the output,
      * unrolling repeating messages only one time.
      *
      * @return  the list of output symbol instances
@@ -228,7 +228,7 @@ public class AbstractOutput extends AbstractSymbol {
     }
 
     /**
-     * Returns a list of output symbols, one for each individual message in the output,
+     * Returns an immutable list of output symbols, one for each individual message in the output,
      * unrolling repeating messages the given number of times.
      *
      * @param unrollRepeating  the number of times a repeating output should be unrolled
@@ -244,7 +244,7 @@ public class AbstractOutput extends AbstractSymbol {
             AbstractOutput output = new AbstractOutput(absOutput);
             outputs.add(output);
         }
-        return outputs;
+        return Collections.unmodifiableList(outputs);
     }
 
     /**


### PR DESCRIPTION
A function returning either an immutable (`Collections.singletonList`) or mutable (`LinkedList`) data structure may become quite confusing to its callers.  Since the offending functions are intended mainly (only?) for reading, this PR opted to make the results immutable (with a call to `unmoodifiableList`).  It's possible that this conversion has a cost. An alternative would have been to use some other construct instead of `singetonList` for the simple case or a direct way to construct an immutable list (using some incremental/buffering-like construction).