### PR TITLE
Prefer ArrayList over LinkedList

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -7,7 +7,6 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractInput;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestParser;
-import com.google.common.collect.Lists;
 import de.learnlib.acex.analyzers.AcexAnalyzers;
 import de.learnlib.algorithms.kv.mealy.KearnsVaziraniMealy;
 import de.learnlib.algorithms.lstar.ce.ObservationTableCEXHandlers;
@@ -27,6 +26,7 @@ import net.automatalib.words.Alphabet;
 import net.automatalib.words.Word;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -51,7 +51,7 @@ public class LearningSetupFactory {
 
         return switch (config.getLearningAlgorithm()) {
             case LSTAR ->
-                new ExtensibleLStarMealy<>(alphabet, sulOracle, Lists.newArrayList(),
+                new ExtensibleLStarMealy<>(alphabet, sulOracle, new ArrayList<>(),
                     ObservationTableCEXHandlers.CLASSIC_LSTAR, ClosingStrategies.CLOSE_SHORTEST);
 
             case TTT ->
@@ -62,7 +62,7 @@ public class LearningSetupFactory {
                     .create();
 
             case RS ->
-                new ExtensibleLStarMealy<>(alphabet, sulOracle, Lists.newArrayList(),
+                new ExtensibleLStarMealy<>(alphabet, sulOracle, new ArrayList<>(),
                     ObservationTableCEXHandlers.RIVEST_SCHAPIRE, ClosingStrategies.CLOSE_SHORTEST);
 
             case KV ->

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
@@ -73,7 +73,7 @@ public class ObservationTree<I, O> {
      */
     protected List<O> getOutputChain() {
         if (this.parent == null) {
-            return new LinkedList<>();
+            return new ArrayList<>();
         }
 
         List<O> parentChain = this.parent.getOutputChain();
@@ -88,7 +88,7 @@ public class ObservationTree<I, O> {
      */
     protected List<I> getInputChain() {
         if (this.parent == null) {
-            return new LinkedList<>();
+            return new ArrayList<>();
         }
 
         List<I> parentChain = this.parent.getInputChain();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
@@ -206,7 +206,7 @@ public class WpEQSequenceGenerator<I, D, S> {
 
     /**
      * Returns a random access sequence of the given state using
-     * {@link #getRandomAccessSequence(UniversalDeterministicAutomaton, Collection, Object, Random, Object, Set, LinkedList)}.
+     * {@link #getRandomAccessSequence(UniversalDeterministicAutomaton, Collection, Object, Random, Object, Set, List)}.
      *
      * @param automaton  the automaton to be used
      * @param inputs     the inputs of the automaton
@@ -225,7 +225,7 @@ public class WpEQSequenceGenerator<I, D, S> {
         Set<S> hs = new HashSet<>();
         hs.add(toState);
 
-        Word<I> accessSequence = getRandomAccessSequence(automaton, inputs, toState, rand, toState, hs, new LinkedList<>());
+        Word<I> accessSequence = getRandomAccessSequence(automaton, inputs, toState, rand, toState, hs, new ArrayList<>());
 
         if (accessSequence == null) {
             throw new IllegalStateException("Access sequence could not be generated");
@@ -253,7 +253,7 @@ public class WpEQSequenceGenerator<I, D, S> {
         Random rand,
         S visiting,
         Set<S> visited,
-        LinkedList<I> sequence) {
+        List<I> sequence) {
 
         if (visiting.equals(automaton.getInitialState())) {
             return Word.fromList(sequence);
@@ -268,7 +268,7 @@ public class WpEQSequenceGenerator<I, D, S> {
             for (PredStruct<S, I> predStruct : predStructs) {
                 if (!visited.contains(predStruct.getState())) {
                     visited.add(predStruct.getState());
-                    sequence.addFirst(predStruct.getInput());
+                    sequence.add(0, predStruct.getInput());
 
                     Word<I> result = getRandomAccessSequence(
                         automaton, inputs, toState, rand, predStruct.getState(), visited, sequence
@@ -279,7 +279,7 @@ public class WpEQSequenceGenerator<I, D, S> {
                     }
 
                     visited.remove(predStruct.getState());
-                    sequence.removeFirst();
+                    sequence.remove(0);
                 }
             }
         }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
@@ -30,10 +30,10 @@ public class WpEQSequenceGenerator<I, D, S> {
     protected Collection<? extends I> inputs;
 
     /** The list of global suffixes. */
-    protected ArrayList<Word<I>> globalSuffixes;
+    protected List<Word<I>> globalSuffixes;
 
     /** The set of local suffixes. */
-    protected MutableMapping<S, ArrayList<Word<I>>> localSuffixSets;
+    protected MutableMapping<S, List<Word<I>>> localSuffixSets;
 
     /** The map holding the predecessors of {@link #inputs}. */
     protected Map<S, List<PredStruct<S, I>>> predMap;
@@ -88,11 +88,11 @@ public class WpEQSequenceGenerator<I, D, S> {
      * @param inputs     the inputs of the automaton
      * @return           the list of global suffixes
      */
-    protected ArrayList<Word<I>> computeGlobalSuffixes(
+    protected List<Word<I>> computeGlobalSuffixes(
         UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
         Collection<? extends I> inputs) {
 
-        ArrayList<Word<I>> globalSuffixes = new ArrayList<>();
+        List<Word<I>> globalSuffixes = new ArrayList<>();
         Automata.characterizingSet(automaton, inputs, globalSuffixes);
         return globalSuffixes;
     }
@@ -104,13 +104,13 @@ public class WpEQSequenceGenerator<I, D, S> {
      * @param inputs     the inputs of the automaton
      * @return           the list of local suffixes
      */
-    protected MutableMapping<S, ArrayList<Word<I>>> computeLocalSuffixSets(
+    protected MutableMapping<S, List<Word<I>>> computeLocalSuffixSets(
         UniversalDeterministicAutomaton<S, I, ?, ?,?> automaton,
         Collection<? extends I> inputs) {
 
-        MutableMapping<S, ArrayList<Word<I>>> localSuffixSets = automaton.createStaticStateMapping();
+        MutableMapping<S, List<Word<I>>> localSuffixSets = automaton.createStaticStateMapping();
         for (S state : automaton.getStates()) {
-            ArrayList<Word<I>> suffixSet = new ArrayList<>();
+            List<Word<I>> suffixSet = new ArrayList<>();
             Automata.stateCharacterizingSet(automaton, inputs, state, suffixSet);
             localSuffixSets.put(state, suffixSet);
         }
@@ -126,7 +126,7 @@ public class WpEQSequenceGenerator<I, D, S> {
      * @return             the constructed middle sequence
      */
     public Word<I> getRandomMiddleSequence(int minimalSize, int rndLength, Random rand) {
-        ArrayList<I> arrayAlphabet = new ArrayList<>(inputs);
+        List<I> arrayAlphabet = new ArrayList<>(inputs);
         WordBuilder<I> wb = new WordBuilder<>();
         int size = minimalSize;
 
@@ -179,7 +179,7 @@ public class WpEQSequenceGenerator<I, D, S> {
         } else {
             // local
             S state2 = automaton.getState(fromSequence);
-            ArrayList<Word<I>> localSuffixes = localSuffixSets.get(state2);
+            List<Word<I>> localSuffixes = localSuffixSets.get(state2);
             if (!localSuffixes.isEmpty()) {
                 wb.append(localSuffixes.get(rand.nextInt(localSuffixes.size())));
             }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -268,7 +268,7 @@ public class AbstractOutput extends AbstractSymbol {
      */
     public List<String> getAtomicAbstractionStrings(int unrollRepeating) {
         String[] atoms = getName().split("\\" + MESSAGE_SEPARATOR, -1);
-        List<String> newAtoms = new LinkedList<>();
+        List<String> newAtoms = new ArrayList<>();
         for (String atom : atoms) {
             if (atom.endsWith(REPEATING_INDICATOR)) {
                 String repeatingAtom = atom.substring(0, atom.length() - REPEATING_INDICATOR.length());

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapper.java
@@ -5,7 +5,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abst
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -125,12 +125,12 @@ public abstract class OutputMapper {
 
         assert(output1.isRecordResponse() && output2.isRecordResponse());
 
-        List<String> absOutputStrings = new LinkedList<>(output1.getAtomicAbstractionStrings(2));
+        List<String> absOutputStrings = new ArrayList<>(output1.getAtomicAbstractionStrings(2));
         absOutputStrings.addAll(output2.getAtomicAbstractionStrings(2));
         abstraction = mergeRepeatingMessages(absOutputStrings);
 
         if (output1.hasMessages() && output2.hasMessages()) {
-            messages = new LinkedList<>(output1.getMessages());
+            messages = new ArrayList<>(output1.getMessages());
             messages.addAll(output2.getMessages());
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -18,9 +18,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Vector;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -144,7 +144,7 @@ public class CommandLineParser {
             parseAndExecuteCommand(args);
         }
 
-        Vector<LearnerResult> results = new Vector<>(1, 4);
+        ArrayList<LearnerResult> results = new ArrayList<>();
         while (args.length > endCmd) {
             startCmd = endCmd;
             while (args.length > endCmd && !args[endCmd].equals("--")) {
@@ -166,7 +166,7 @@ public class CommandLineParser {
                 }
             }
 
-            results.addElement(result);
+            results.add(result);
             endCmd++;
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -144,7 +144,7 @@ public class CommandLineParser {
             parseAndExecuteCommand(args);
         }
 
-        ArrayList<LearnerResult> results = new ArrayList<>();
+        List<LearnerResult> results = new ArrayList<>();
         while (args.length > endCmd) {
             startCmd = endCmd;
             while (args.length > endCmd && !args[endCmd].equals("--")) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestParser.java
@@ -115,8 +115,8 @@ public class TestParser {
                 .flatMap(Arrays::stream)
                 .toList();
 
-        List<Word<AbstractInput>> tests = new LinkedList<>();
-        LinkedList<String> currentTestStrings = new LinkedList<>();
+        List<Word<AbstractInput>> tests = new ArrayList<>();
+        ArrayList<String> currentTestStrings = new ArrayList<>();
         for (String inputString : flattenedInputStrings) {
             if (inputString.equals("reset")) {
                 tests.add(readTest(alphabet, currentTestStrings));
@@ -144,7 +144,7 @@ public class TestParser {
      */
     protected List<String> parseTestFile(String filename) throws IOException {
         String line;
-        List<String> trace = new LinkedList<>();
+        List<String> trace = new ArrayList<>();
 
         try (BufferedReader bfr = new BufferedReader(new FileReader(filename, StandardCharsets.UTF_8))) {
             while ((line = bfr.readLine()) != null) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestParser.java
@@ -116,7 +116,7 @@ public class TestParser {
                 .toList();
 
         List<Word<AbstractInput>> tests = new ArrayList<>();
-        ArrayList<String> currentTestStrings = new ArrayList<>();
+        List<String> currentTestStrings = new ArrayList<>();
         for (String inputString : flattenedInputStrings) {
             if (inputString.equals("reset")) {
                 tests.add(readTest(alphabet, currentTestStrings));

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunner.java
@@ -20,9 +20,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -175,7 +175,7 @@ public class TestRunner {
             tests = List.of(testParser.readTest(alphabet, Arrays.asList(testStrings)));
         }
 
-        List<TestRunnerResult<AbstractInput, AbstractOutput>> results = new LinkedList<>();
+        List<TestRunnerResult<AbstractInput, AbstractOutput>> results = new ArrayList<>();
         for (Word<AbstractInput> test : tests) {
             TestRunnerResult<AbstractInput, AbstractOutput> result = runTest(test);
             results.add(result);
@@ -218,7 +218,7 @@ public class TestRunner {
             sb.append(System.lineSeparator());
 
             for (int i = 0; i < result.getInputWord().size(); i++) {
-                List<AbstractOutput> atomicOutputs = new LinkedList<>(answer.getSymbol(i).getAtomicOutputs(2));
+                List<AbstractOutput> atomicOutputs = new ArrayList<>(answer.getSymbol(i).getAtomicOutputs(2));
 
                 if (getSulConfig().isFuzzingClient()
                      && i == 0

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/CleanupTasks.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/CleanupTasks.java
@@ -1,6 +1,6 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.utils;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -15,7 +15,7 @@ public class CleanupTasks {
      * Constructs a new instance with an empty {@link #tasks} list.
      */
     public CleanupTasks() {
-        tasks = new LinkedList<>();
+        tasks = new ArrayList<>();
     }
 
     /**


### PR DESCRIPTION
Substitute most uses of `LinkedList` and one of `Vector` with the more efficient `ArrayList`.

There is one more occurrence of `LinkedList` (in file `WpEQSequenceGenerator.java`) that can be changed, but that one is a bit more tricky.  Help is needed there.