### PR TITLE
Refactor tests

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -231,14 +231,23 @@ public class CommandLineParser {
      * for the acquisition of different JCommanders per parse.
      *
      * @param args  the command-line arguments to be parsed
-     * @return      the ParseResult that contains the arguments and the
+     * @return      null or the ParseResult that contains the arguments and the
      *              JCommander instance used to parse them
      */
     protected ParseResult parseCommand(String[] args) {
         PropertyResolver.initializeParsing();
 
         StateFuzzerClientConfig stateFuzzerClientConfig = stateFuzzerConfigBuilder.buildClientConfig();
+        if (stateFuzzerClientConfig == null) {
+            LOGGER.error("Built null StateFuzzerClientConfig from provided StateFuzzerConfigBuilder");
+            return null;
+        }
+
         StateFuzzerServerConfig stateFuzzerServerConfig = stateFuzzerConfigBuilder.buildServerConfig();
+        if (stateFuzzerServerConfig == null) {
+            LOGGER.error("Built null StateFuzzerServerConfig from provided StateFuzzerConfigBuilder");
+            return null;
+        }
 
         JCommander commander = buildCommander(true, stateFuzzerClientConfig, stateFuzzerServerConfig);
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigEmpty.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigEmpty.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
@@ -20,16 +21,22 @@ public class StateFuzzerClientConfigEmpty extends StateFuzzerConfigEmpty impleme
 
     /**
      * Constructs a new instance from the default super constructor and the parameter.
+     * <p>
+     * If the provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param sulClientConfig  the non-null {@link SulClientConfig} implementing class
      */
     public StateFuzzerClientConfigEmpty(SulClientConfig sulClientConfig) {
         super();
-        this.sulClientConfig = sulClientConfig;
+        this.sulClientConfig = sulClientConfig == null ? new SulClientConfigEmpty() : sulClientConfig;
     }
 
     /**
      * Constructs a new instance from the given parameters.
+     * <p>
+     * If any provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param learnerConfig      the {@link LearnerConfig} implementing class
      * @param sulClientConfig    the {@link SulClientConfig} implementing class
@@ -40,7 +47,7 @@ public class StateFuzzerClientConfigEmpty extends StateFuzzerConfigEmpty impleme
         TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
 
         super(learnerConfig, testRunnerConfig, timingProbeConfig);
-        this.sulClientConfig = sulClientConfig;
+        this.sulClientConfig = sulClientConfig == null ? new SulClientConfigEmpty() : sulClientConfig;
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigStandard.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
@@ -20,16 +21,22 @@ public class StateFuzzerClientConfigStandard extends StateFuzzerConfigStandard i
 
     /**
      * Constructs a new instance from the default super constructor and the parameter.
+     * <p>
+     * If the provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
-     * @param sulClientConfig  the non-null {@link SulClientConfig} implementing class
+     * @param sulClientConfig  the {@link SulClientConfig} implementing class
      */
     public StateFuzzerClientConfigStandard(SulClientConfig sulClientConfig) {
         super();
-        this.sulClientConfig = sulClientConfig;
+        this.sulClientConfig = sulClientConfig == null ? new SulClientConfigEmpty() : sulClientConfig;
     }
 
     /**
      * Constructs a new instance from the given parameters.
+     * <p>
+     * If any provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param learnerConfig      the {@link LearnerConfig} implementing class
      * @param sulClientConfig    the {@link SulClientConfig} implementing class
@@ -40,7 +47,7 @@ public class StateFuzzerClientConfigStandard extends StateFuzzerConfigStandard i
         TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
 
         super(learnerConfig, testRunnerConfig, timingProbeConfig);
-        this.sulClientConfig = sulClientConfig;
+        this.sulClientConfig = sulClientConfig == null ? new SulClientConfigEmpty() : sulClientConfig;
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigEmpty.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigEmpty.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.ParametersDelegate;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
 
@@ -20,16 +21,22 @@ public class StateFuzzerServerConfigEmpty extends StateFuzzerConfigEmpty impleme
 
     /**
      * Constructs a new instance from the default super constructor and the parameter.
+     * <p>
+     * If the provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param sulServerConfig  the {@link SulServerConfig} implementing class
      */
     public StateFuzzerServerConfigEmpty(SulServerConfig sulServerConfig) {
         super();
-        this.sulServerConfig = sulServerConfig;
+        this.sulServerConfig = sulServerConfig == null ? new SulServerConfigEmpty() : sulServerConfig;
     }
 
     /**
      * Constructs a new instance from the given parameters.
+     * <p>
+     * If any provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param learnerConfig      the {@link LearnerConfig} implementing class
      * @param sulServerConfig    the {@link SulServerConfig} implementing class
@@ -40,7 +47,7 @@ public class StateFuzzerServerConfigEmpty extends StateFuzzerConfigEmpty impleme
         TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
 
         super(learnerConfig, testRunnerConfig, timingProbeConfig);
-        this.sulServerConfig = sulServerConfig;
+        this.sulServerConfig = sulServerConfig == null ? new SulServerConfigEmpty() : sulServerConfig;
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigStandard.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.ParametersDelegate;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
 
@@ -20,16 +21,22 @@ public class StateFuzzerServerConfigStandard extends StateFuzzerConfigStandard i
 
     /**
      * Constructs a new instance from the default super constructor and the parameter.
+     * <p>
+     * If the provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param sulServerConfig  the {@link SulServerConfig} implementing class
      */
     public StateFuzzerServerConfigStandard(SulServerConfig sulServerConfig) {
         super();
-        this.sulServerConfig = sulServerConfig;
+        this.sulServerConfig = sulServerConfig == null ? new SulServerConfigEmpty() : sulServerConfig;
     }
 
     /**
      * Constructs a new instance from the given parameters.
+     * <p>
+     * If any provided parameter is null, then the corresponding config is
+     * initialized with a new empty corresponding configuration.
      *
      * @param learnerConfig      the {@link LearnerConfig} implementing class
      * @param sulServerConfig    the {@link SulServerConfig} implementing class
@@ -40,7 +47,7 @@ public class StateFuzzerServerConfigStandard extends StateFuzzerConfigStandard i
         TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
 
         super(learnerConfig, testRunnerConfig, timingProbeConfig);
-        this.sulServerConfig = sulServerConfig;
+        this.sulServerConfig = sulServerConfig == null ? new SulServerConfigEmpty() : sulServerConfig;
     }
 
     @Override

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigTest.java
@@ -1,0 +1,247 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningAlgorithmName;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+public class LearnerConfigTest {
+    @Test
+    public void parseAllOptions_SFCstd_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(new LearnerConfigStandard(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(new LearnerConfigStandard(), null, null, null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(new LearnerConfigStandard(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(new LearnerConfigStandard(), null, null, null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(new LearnerConfigStandard(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(new LearnerConfigStandard(), null, null, null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(new LearnerConfigStandard(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(new LearnerConfigStandard(), null, null, null);
+                }
+            }
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        String alphabet = "alphabetFile";
+        LearningAlgorithmName learningAlgorithm = LearningAlgorithmName.LSTAR;
+        List<EquivalenceAlgorithmName> equivalenceAlgorithms = List.of(EquivalenceAlgorithmName.W_METHOD, EquivalenceAlgorithmName.WP_METHOD);
+        String equivalenceAlgorithmsString = EquivalenceAlgorithmName.W_METHOD.name() + "," + EquivalenceAlgorithmName.WP_METHOD.name();
+        int depth = 3;
+        int minLength = 4;
+        int maxLength = 5;
+        int randLength = 6;
+        int equivalenceQueryBound = 7;
+        int memQueryRuns = 8;
+        int memQueryRetries = 9;
+        double probReset = 10.0;
+        String testFile = "testFile";
+        long seed = 11L;
+        int ceReruns = 12;
+        Duration timeLimit = Duration.parse("P1DT2H3M4.5S"); // 1 day, 2 hours, 3 minutes, 4.5 seconds
+        Long testLimit = 13L;
+        Integer roundLimit = 14;
+
+        LearnerConfig[] learnerConfigs = parseWithStandard(stateFuzzerConfigBuilder, new String[]{
+            "-alphabet", alphabet,
+            "-learningAlgorithm", learningAlgorithm.name(),
+            "-equivalenceAlgorithms", equivalenceAlgorithmsString,
+            "-depth", String.valueOf(depth),
+            "-minLength", String.valueOf(minLength),
+            "-maxLength", String.valueOf(maxLength),
+            "-randLength", String.valueOf(randLength),
+            "-equivalenceQueryBound", String.valueOf(equivalenceQueryBound),
+            "-memQueryRuns", String.valueOf(memQueryRuns),
+            "-memQueryRetries", String.valueOf(memQueryRetries),
+            "-logQueries",
+            "-probReset", String.valueOf(probReset),
+            "-testFile", testFile,
+            "-seed", String.valueOf(seed),
+            "-cacheTests",
+            "-ceSanitizationDisable",
+            "-skipNonDetTests",
+            "-ceReruns", String.valueOf(ceReruns),
+            "-probabilisticSanitizationDisable",
+            "-timeLimit", timeLimit.toString(),
+            "-testLimit", String.valueOf(testLimit),
+            "-roundLimit", String.valueOf(roundLimit),
+        });
+
+        for (LearnerConfig learnerConfig : learnerConfigs) {
+            Assert.assertNotNull(learnerConfig);
+            Assert.assertEquals(alphabet, learnerConfig.getAlphabetFilename());
+            Assert.assertEquals(learningAlgorithm, learnerConfig.getLearningAlgorithm());
+            Assert.assertEquals(equivalenceAlgorithms, learnerConfig.getEquivalenceAlgorithms());
+            Assert.assertEquals(depth, learnerConfig.getMaxDepth());
+            Assert.assertEquals(minLength, learnerConfig.getMinLength());
+            Assert.assertEquals(maxLength, learnerConfig.getMaxLength());
+            Assert.assertEquals(randLength, learnerConfig.getRandLength());
+            Assert.assertEquals(equivalenceQueryBound, learnerConfig.getEquivQueryBound());
+            Assert.assertEquals(memQueryRuns, learnerConfig.getRunsPerMembershipQuery());
+            Assert.assertEquals(memQueryRetries, learnerConfig.getMembershipQueryRetries());
+            Assert.assertTrue(learnerConfig.isLogQueries());
+            Assert.assertEquals(probReset, learnerConfig.getProbReset(), 0.0);
+            Assert.assertEquals(testFile, learnerConfig.getTestFile());
+            Assert.assertEquals(seed, learnerConfig.getSeed());
+            Assert.assertTrue(learnerConfig.isCacheTests());
+            Assert.assertFalse(learnerConfig.isCeSanitization());
+            Assert.assertTrue(learnerConfig.isSkipNonDetTests());
+            Assert.assertEquals(ceReruns, learnerConfig.getCeReruns());
+            Assert.assertFalse(learnerConfig.isProbabilisticSanitization());
+            Assert.assertEquals(timeLimit, learnerConfig.getTimeLimit());
+            Assert.assertEquals(testLimit, learnerConfig.getTestLimit());
+            Assert.assertEquals(roundLimit, learnerConfig.getRoundLimit());
+        }
+    }
+
+    private LearnerConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        LearnerConfig[] learnerConfigs = new LearnerConfig[2];
+
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, partialArgs);
+        Assert.assertNotNull(clientConfig);
+        learnerConfigs[0] = clientConfig.getLearnerConfig();
+
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, partialArgs);
+        Assert.assertNotNull(serverConfig);
+        learnerConfigs[1] = serverConfig.getLearnerConfig();
+
+        return learnerConfigs;
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SFSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(new LearnerConfigEmpty(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(new LearnerConfigEmpty(), null, null, null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SFSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(new LearnerConfigEmpty(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(new LearnerConfigEmpty(), null, null, null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SFSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(new LearnerConfigEmpty(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(new LearnerConfigEmpty(), null, null, null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SFSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(new LearnerConfigEmpty(), null, null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(new LearnerConfigEmpty(), null, null, null);
+                }
+            }
+        );
+    }
+
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        String[] partialArgs = new String[] {
+            "-alphabet", "alphabetPath"
+        };
+
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulClientConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulClientConfigTest.java
@@ -1,0 +1,121 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SulClientConfigTest extends SulConfigTest {
+    @Test
+    public void parseAllOptions_SFCstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(new SulClientConfigStandard());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(new SulClientConfigStandard());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null);
+                }
+            }
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        Long clientWait = 7L;
+        Integer port = 8;
+        String fuzzingRole = "client";
+
+        SulConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder, new String[]{
+            "-clientWait", String.valueOf(clientWait),
+            "-port", String.valueOf(port)
+        });
+
+        Assert.assertTrue(sulConfig instanceof SulClientConfigStandard);
+        SulClientConfigStandard sulClientConfigStandard = (SulClientConfigStandard) sulConfig;
+
+        Assert.assertEquals(clientWait, sulClientConfigStandard.getClientWait());
+        Assert.assertEquals(port, sulClientConfigStandard.getPort());
+        Assert.assertTrue(sulClientConfigStandard.isFuzzingClient());
+        Assert.assertEquals(fuzzingRole, sulClientConfigStandard.getFuzzingRole());
+    }
+
+    @Override
+    protected SulClientConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        StateFuzzerClientConfig stateFuzzerClientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, partialArgs);
+
+        Assert.assertNotNull(stateFuzzerClientConfig);
+        Assert.assertNotNull(stateFuzzerClientConfig);
+        Assert.assertTrue(stateFuzzerClientConfig.getSulConfig() instanceof SulClientConfig);
+        return (SulClientConfig) stateFuzzerClientConfig.getSulConfig();
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd() {
+        super.invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(new SulClientConfigEmpty());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null);
+                }
+            },
+            new String[]{
+                "-port", "portValue"
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp() {
+        super.invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(new SulClientConfigEmpty());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null);
+                }
+            },
+            new String[]{
+                "-port", "portValue"
+            }
+        );
+    }
+
+    @Override
+    protected void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigTest.java
@@ -1,0 +1,63 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwrappers.ProcessLaunchTrigger;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import org.junit.Assert;
+
+public abstract class SulConfigTest {
+    protected SulConfig parseAllOptionsWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder ,String[] reqArgs) {
+        Long responseWait = 1L;
+        InputResponseTimeoutMap inputResponseTimeoutMap = new InputResponseTimeoutMap();
+        inputResponseTimeoutMap.put("IN_2", 2L);
+        inputResponseTimeoutMap.put("IN_3", 3L);
+        String inputResponseTimeoutString = "IN_2:2,IN_3:3";
+        String sulCommand = "sulCommand";
+        String terminateCommand = "terminateCommand";
+        String processDir = "processDir";
+        ProcessLaunchTrigger processTrigger = ProcessLaunchTrigger.NEW_TEST;
+        Long startWait = 4L;
+
+        String commonArgs[] = new String[]{
+            "-responseWait", String.valueOf(responseWait),
+            "-inputResponseTimeout", inputResponseTimeoutString,
+            "-command", sulCommand,
+            "-terminateCommand", terminateCommand,
+            "-processDir", processDir,
+            "-redirectOutputStreams",
+            "-processTrigger", processTrigger.name(),
+            "-startWait", String.valueOf(startWait),
+        };
+        String[] partialArgs = CommandLineParserTest.concatArgs(commonArgs, reqArgs);
+
+        SulConfig sulConfig = parseWithStandard(stateFuzzerConfigBuilder, partialArgs);
+
+        Assert.assertNotNull(sulConfig);
+        Assert.assertEquals(responseWait, sulConfig.getResponseWait());
+        Assert.assertEquals(inputResponseTimeoutMap, sulConfig.getInputResponseTimeout());
+        Assert.assertEquals(sulCommand, sulConfig.getCommand());
+        Assert.assertEquals(terminateCommand, sulConfig.getTerminateCommand());
+        Assert.assertEquals(processDir, sulConfig.getProcessDir());
+        Assert.assertTrue(sulConfig.isRedirectOutputStreams());
+        Assert.assertEquals(processTrigger, sulConfig.getProcessTrigger());
+        Assert.assertEquals(startWait, sulConfig.getStartWait());
+
+        // SulConfig constructor does not allow null configs and instantiates them
+        Assert.assertNotNull(sulConfig.getMapperConfig());
+        Assert.assertNotNull(sulConfig.getSulAdapterConfig());
+
+        return sulConfig;
+    }
+
+    protected void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] reqArgs) {
+        String commonArgs[] = new String[]{
+            "-responseWait", "responseWaitTime"
+        };
+        String[] partialArgs = CommandLineParserTest.concatArgs(commonArgs, reqArgs);
+
+        assertInvalidParseWithEmpty(stateFuzzerConfigBuilder, partialArgs);
+    }
+
+    protected abstract SulConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs);
+    protected abstract void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs);
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulServerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulServerConfigTest.java
@@ -1,0 +1,117 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SulServerConfigTest extends SulConfigTest {
+    @Test
+    public void parseAllOptions_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(new SulServerConfigStandard());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(new SulServerConfigStandard());
+                }
+            }
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        String connect = "host:1234";
+        String fuzzingRole = "server";
+
+        SulConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder, new String[]{
+                "-connect", connect
+        });
+
+        Assert.assertTrue(sulConfig instanceof SulServerConfigStandard);
+        SulServerConfigStandard sulServerConfigStandard = (SulServerConfigStandard) sulConfig;
+
+        Assert.assertEquals(connect, sulServerConfigStandard.getHost());
+        Assert.assertFalse(sulServerConfigStandard.isFuzzingClient());
+        Assert.assertEquals(fuzzingRole, sulServerConfigStandard.getFuzzingRole());
+    }
+
+    @Override
+    protected SulServerConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        StateFuzzerServerConfig stateFuzzerServerConfig = CommandLineParserTest.parseServerArgs(commandLineParser, partialArgs);
+
+        Assert.assertNotNull(stateFuzzerServerConfig);
+        Assert.assertNotNull(stateFuzzerServerConfig);
+        Assert.assertTrue(stateFuzzerServerConfig.getSulConfig() instanceof SulServerConfig);
+        return (SulServerConfig) stateFuzzerServerConfig.getSulConfig();
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFSstd() {
+        super.invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(new SulServerConfigEmpty());
+                }
+            },
+            new String[]{
+                "-connect", "connectString"
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFSemp() {
+        super.invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(new SulServerConfigEmpty());
+                }
+            },
+            new String[]{
+                "-connect", "connectString"
+            }
+        );
+    }
+    @Override
+    protected void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigTest.java
@@ -1,0 +1,664 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class MapperConfigTest {
+    public static String[] SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS = new String[] { "-port", "1234" };
+    public static String[] SUL_SERVER_CONFIG_STANDARD_REQ_ARGS = new String[] { "-connect", "host:1234" };
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigStandard(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+        String mapperConnectionConfig = "mapperConnectionConfigFile";
+        List<String> repeatingOutputs = List.of("OUT_1", "OUT_2");
+
+        String[] partialArgs = new String[] {
+            "-mapperConnectionConfig", mapperConnectionConfig,
+            "-repeatingOutputs", String.join(",", repeatingOutputs),
+            "-socketClosedAsTimeout",
+            "-disabledAsTimeout",
+            "-dontMergeRepeating"
+        };
+
+        MapperConfig[] mapperConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs, serverReqArgs);
+
+        for (MapperConfig mapperConfig : mapperConfigs) {
+            Assert.assertNotNull(mapperConfig);
+            Assert.assertEquals(mapperConnectionConfig, mapperConfig.getMapperConnectionConfig());
+            Assert.assertEquals(repeatingOutputs, mapperConfig.getRepeatingOutputs());
+            Assert.assertTrue(mapperConfig.isSocketClosedAsTimeout());
+            Assert.assertTrue(mapperConfig.isDisabledAsTimeout());
+            Assert.assertFalse(mapperConfig.isMergeRepeating());
+        }
+    }
+
+    private MapperConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs, String[] clientReqArgs, String[] serverReqArgs) {
+
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        MapperConfig[] mapperConfigs = new MapperConfig[2];
+
+        clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
+        String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, clientPartialArgs);
+        Assert.assertNotNull(clientConfig);
+        Assert.assertNotNull(clientConfig.getSulConfig());
+        mapperConfigs[0] = clientConfig.getSulConfig().getMapperConfig();
+
+        serverReqArgs = serverReqArgs == null ? new String[0] : serverReqArgs;
+        String[] serverPartialArgs = CommandLineParserTest.concatArgs(partialArgs, serverReqArgs);
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, serverPartialArgs);
+        Assert.assertNotNull(serverConfig);
+        Assert.assertNotNull(serverConfig.getSulConfig());
+        mapperConfigs[1] = serverConfig.getSulConfig().getMapperConfig();
+
+        return mapperConfigs;
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(new MapperConfigEmpty(), null), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        String[] partialArgs = new String[] {
+            "-mapperConnectionConfig", "mapperConnectionConfigPath",
+        };
+
+        clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
+        String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, clientPartialArgs);
+
+        serverReqArgs = serverReqArgs == null ? new String[0] : serverReqArgs;
+        String[] serverPartialArgs = CommandLineParserTest.concatArgs(partialArgs, serverReqArgs);
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, serverPartialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/SulAdapterConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/SulAdapterConfigTest.java
@@ -1,0 +1,659 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SulAdapterConfigTest {
+    public static String[] SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS = new String[] { "-port", "1234" };
+    public static String[] SUL_SERVER_CONFIG_STANDARD_REQ_ARGS = new String[] { "-connect", "host:1234" };
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCstd_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSstd_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SULCemp_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCstd_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSstd_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSemp_SULSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SULCemp_SFSemp_SULSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigStandard()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+        Integer adapterPort = 1;
+        String adapterAddress = "adapterAddress";
+
+        String[] partialArgs = new String[] {
+            "-adapterPort", String.valueOf(adapterPort),
+            "-adapterAddress", adapterAddress,
+        };
+
+        SulAdapterConfig[] sulAdapterConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs, serverReqArgs);
+
+        for (SulAdapterConfig sulAdapterConfig : sulAdapterConfigs) {
+            Assert.assertNotNull(sulAdapterConfig);
+            Assert.assertEquals(adapterPort, sulAdapterConfig.getAdapterPort());
+            Assert.assertEquals(adapterAddress, sulAdapterConfig.getAdapterAddress());
+        }
+    }
+
+    private SulAdapterConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs, String[] clientReqArgs, String[] serverReqArgs) {
+
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        SulAdapterConfig[] sulAdapterConfigs = new SulAdapterConfig[2];
+
+        clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
+        String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, clientPartialArgs);
+        Assert.assertNotNull(clientConfig);
+        Assert.assertNotNull(clientConfig.getSulConfig());
+        sulAdapterConfigs[0] = clientConfig.getSulConfig().getSulAdapterConfig();
+
+        serverReqArgs = serverReqArgs == null ? new String[0] : serverReqArgs;
+        String[] serverPartialArgs = CommandLineParserTest.concatArgs(partialArgs, serverReqArgs);
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, serverPartialArgs);
+        Assert.assertNotNull(serverConfig);
+        Assert.assertNotNull(serverConfig.getSulConfig());
+        sulAdapterConfigs[1] = serverConfig.getSulConfig().getSulAdapterConfig();
+
+        return sulAdapterConfigs;
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCstd_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSstd_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SULCemp_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCstd_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSstd_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSemp_SULSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SULCemp_SFSemp_SULSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigEmpty(null, new SulAdapterConfigEmpty()), null, null);
+                }
+            },
+            null,
+            null
+        );
+    }
+
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        String[] partialArgs = new String[] {
+            "-adapterPort", "adapterPortValue"
+        };
+
+        clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
+        String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, clientPartialArgs);
+
+        serverReqArgs = serverReqArgs == null ? new String[0] : serverReqArgs;
+        String[] serverPartialArgs = CommandLineParserTest.concatArgs(partialArgs, serverReqArgs);
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, serverPartialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParserTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParserTest.java
@@ -1,593 +1,89 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.entrypoints;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningAlgorithmName;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.InputResponseTimeoutMap;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwrappers.ProcessLaunchTrigger;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfigStandard;
-import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfigStandard;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.File;
-import java.time.Duration;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.List;
 
 public class CommandLineParserTest {
     @Test
-    public void parseDefaultOutput() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String prefix = "output" + File.separator + "o_";
-        String dateFormat = "yyyy-MM-dd_HH-mm-ss";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-            CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-            // SulClientConfig required options not asserted here
-            "-port", "0"
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        String outputDir = stateFuzzerClientConfig.getOutputDir();
-        Assert.assertTrue(outputDir.startsWith(prefix));
-        DateTimeFormatter.ofPattern(dateFormat).parse(outputDir.substring(prefix.length()));
-    }
-
-    @Test
-    public void parseDefaultTimestampFormat() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String prefix = "pre_";
-        String output = prefix + "${timestamp}";
-        String dateFormat = "yyyy-MM-dd_HH-mm-ss";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-            CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-            // StateFuzzerConfig options
-            "-output", output,
-            // SulClientConfig required options not asserted here
-            "-port", "0"
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        String outputDir = stateFuzzerClientConfig.getOutputDir();
-        Assert.assertTrue(outputDir.startsWith(prefix));
-        DateTimeFormatter.ofPattern(dateFormat).parse(outputDir.substring(prefix.length()));
-    }
-
-    @Test
-    public void parseDynamicTimestampFormat() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String prefix = "pre_";
-        String output = prefix + "${timestamp}";
-        String dateFormat = "yyyy-MM-dd";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                "-Dtimestamp.format=" + dateFormat,
-                // StateFuzzerConfig options
-                "-output", output,
-                // SulClientConfig required options not asserted here
-                "-port", "0"
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        String outputDir = stateFuzzerClientConfig.getOutputDir();
-        Assert.assertTrue(outputDir.startsWith(prefix));
-        DateTimeFormatter.ofPattern(dateFormat).parse(outputDir.substring(prefix.length()));
-    }
-
-    @Test
-    public void parseAllOptionsOfStateFuzzerClientConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String output = "output";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                "-help",
-                "-debug",
-                "-quiet",
-                // StateFuzzerConfig options
-                "-output", output,
-                // SulClientConfig required options not asserted here
-                "-port", "0"
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        Assert.assertTrue(stateFuzzerClientConfig.isHelp());
-        Assert.assertTrue(stateFuzzerClientConfig.isDebug());
-        Assert.assertTrue(stateFuzzerClientConfig.isQuiet());
-        Assert.assertEquals(output, stateFuzzerClientConfig.getOutputDir());
-        Assert.assertTrue(stateFuzzerClientConfig.isFuzzingClient());
-
-        // StateFuzzerConfig constructor does not allow null configs and instantiates them
-        // The same applies for the SulConfig constructor with MapperConfig and SulAdapterConfig
-        // SulClientConfig cannot be instantiated, as an abstract class, thus a subclass
-        // implementing it should be provided
-        Assert.assertNotNull(stateFuzzerClientConfig.getLearnerConfig());
-        Assert.assertNotNull(stateFuzzerClientConfig.getSulConfig());
-        Assert.assertNotNull(stateFuzzerClientConfig.getSulConfig().getMapperConfig());
-        Assert.assertNotNull(stateFuzzerClientConfig.getSulConfig().getSulAdapterConfig());
-        Assert.assertNotNull(stateFuzzerClientConfig.getTestRunnerConfig());
-        Assert.assertNotNull(stateFuzzerClientConfig.getTimingProbeConfig());
-    }
-
-    @Test
-    public void parseAllOptionsOfStateFuzzerServerConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String output = "output";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                "-help",
-                "-debug",
-                "-quiet",
-                // StateFuzzerConfig options
-                "-output", output,
-                // SulServerConfig required options not asserted here
-                "-connect", "host:1234"
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
-
-        Assert.assertTrue(stateFuzzerServerConfig.isHelp());
-        Assert.assertTrue(stateFuzzerServerConfig.isDebug());
-        Assert.assertTrue(stateFuzzerServerConfig.isQuiet());
-        Assert.assertEquals(output, stateFuzzerServerConfig.getOutputDir());
-        Assert.assertFalse(stateFuzzerServerConfig.isFuzzingClient());
-
-        // StateFuzzerConfig constructor does not allow null configs and instantiates them
-        // The same applies for the SulConfig constructor with MapperConfig and SulAdapterConfig
-        // SulServerConfig cannot be instantiated, as an abstract class, thus a subclass
-        // implementing it should be provided
-        Assert.assertNotNull(stateFuzzerServerConfig.getLearnerConfig());
-        Assert.assertNotNull(stateFuzzerServerConfig.getSulConfig());
-        Assert.assertNotNull(stateFuzzerServerConfig.getSulConfig().getMapperConfig());
-        Assert.assertNotNull(stateFuzzerServerConfig.getSulConfig().getSulAdapterConfig());
-        Assert.assertNotNull(stateFuzzerServerConfig.getTestRunnerConfig());
-        Assert.assertNotNull(stateFuzzerServerConfig.getTimingProbeConfig());
-    }
-
-    @Test
-    public void parseAllOptionsOfSulClientConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        Long responseWait = 1L;
-        InputResponseTimeoutMap inputResponseTimeoutMap = new InputResponseTimeoutMap();
-        inputResponseTimeoutMap.put("IN_2", 2L);
-        inputResponseTimeoutMap.put("IN_3", 3L);
-        String inputResponseTimeoutString = "IN_2:2,IN_3:3";
-        String sulCommand = "sulCommand";
-        String terminateCommand = "terminateCommand";
-        String processDir = "processDir";
-        ProcessLaunchTrigger processTrigger = ProcessLaunchTrigger.NEW_TEST;
-        Long startWait = 4L;
-        Long clientWait = 7L;
-        Integer port = 8;
-        String fuzzingRole = "client";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                // SulConfig options
-                "-responseWait", String.valueOf(responseWait),
-                "-inputResponseTimeout", inputResponseTimeoutString,
-                "-command", sulCommand,
-                "-terminateCommand", terminateCommand,
-                "-processDir", processDir,
-                "-redirectOutputStreams",
-                "-processTrigger", processTrigger.name(),
-                "-startWait", String.valueOf(startWait),
-                // SulClientConfig options
-                "-clientWait", String.valueOf(clientWait),
-                "-port", String.valueOf(port)
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        Assert.assertTrue(stateFuzzerClientConfig.getSulConfig() instanceof SulClientConfig);
-        SulClientConfig sulClientConfig = (SulClientConfig) stateFuzzerClientConfig.getSulConfig();
-
-        Assert.assertNotNull(sulClientConfig);
-        Assert.assertNotNull(sulClientConfig.getMapperConfig());
-        Assert.assertEquals(responseWait, sulClientConfig.getResponseWait());
-        Assert.assertEquals(inputResponseTimeoutMap, sulClientConfig.getInputResponseTimeout());
-        Assert.assertEquals(sulCommand, sulClientConfig.getCommand());
-        Assert.assertEquals(terminateCommand, sulClientConfig.getTerminateCommand());
-        Assert.assertEquals(processDir, sulClientConfig.getProcessDir());
-        Assert.assertTrue(sulClientConfig.isRedirectOutputStreams());
-        Assert.assertEquals(processTrigger, sulClientConfig.getProcessTrigger());
-        Assert.assertEquals(startWait, sulClientConfig.getStartWait());
-
-        Assert.assertEquals(clientWait, sulClientConfig.getClientWait());
-        Assert.assertEquals(port, sulClientConfig.getPort());
-        Assert.assertTrue(sulClientConfig.isFuzzingClient());
-        Assert.assertEquals(fuzzingRole, sulClientConfig.getFuzzingRole());
-    }
-
-    @Test
-    public void parseAllOptionsOfSulServerConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        Long responseWait = 1L;
-        InputResponseTimeoutMap inputResponseTimeoutMap = new InputResponseTimeoutMap();
-        inputResponseTimeoutMap.put("IN_2", 2L);
-        inputResponseTimeoutMap.put("IN_3", 3L);
-        String inputResponseTimeoutString = "IN_2:2,IN_3:3";
-        String sulCommand = "sulCommand";
-        String terminateCommand = "terminateCommand";
-        String processDir = "processDir";
-        ProcessLaunchTrigger processTrigger = ProcessLaunchTrigger.NEW_TEST;
-        Long startWait = 4L;
-        String connect = "host:1234";
-        String fuzzingRole = "server";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                // SulConfig options
-                "-responseWait", String.valueOf(responseWait),
-                "-inputResponseTimeout", inputResponseTimeoutString,
-                "-command", sulCommand,
-                "-terminateCommand", terminateCommand,
-                "-processDir", processDir,
-                "-redirectOutputStreams",
-                "-processTrigger", processTrigger.name(),
-                "-startWait", String.valueOf(startWait),
-                // SulServerConfig options
-                "-connect", connect
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
-
-        Assert.assertTrue(stateFuzzerServerConfig.getSulConfig() instanceof SulServerConfig);
-        SulServerConfig sulServerConfig = (SulServerConfig) stateFuzzerServerConfig.getSulConfig();
-
-        Assert.assertNotNull(sulServerConfig);
-        Assert.assertNotNull(sulServerConfig.getMapperConfig());
-        Assert.assertEquals(responseWait, sulServerConfig.getResponseWait());
-        Assert.assertEquals(inputResponseTimeoutMap, sulServerConfig.getInputResponseTimeout());
-        Assert.assertEquals(sulCommand, sulServerConfig.getCommand());
-        Assert.assertEquals(terminateCommand, sulServerConfig.getTerminateCommand());
-        Assert.assertEquals(processDir, sulServerConfig.getProcessDir());
-        Assert.assertTrue(sulServerConfig.isRedirectOutputStreams());
-        Assert.assertEquals(processTrigger, sulServerConfig.getProcessTrigger());
-        Assert.assertEquals(startWait, sulServerConfig.getStartWait());
-
-        Assert.assertEquals(connect, sulServerConfig.getHost());
-        Assert.assertFalse(sulServerConfig.isFuzzingClient());
-        Assert.assertEquals(fuzzingRole, sulServerConfig.getFuzzingRole());
-    }
-
-    @Test
-    public void parseAllOptionsOfLearnerConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String alphabet = "alphabetFile";
-        LearningAlgorithmName learningAlgorithm = LearningAlgorithmName.LSTAR;
-        List<EquivalenceAlgorithmName> equivalenceAlgorithms = Arrays.asList(EquivalenceAlgorithmName.W_METHOD, EquivalenceAlgorithmName.WP_METHOD);
-        String equivalenceAlgorithmsString = EquivalenceAlgorithmName.W_METHOD.name() + "," + EquivalenceAlgorithmName.WP_METHOD.name();
-        int depth = 3;
-        int minLength = 4;
-        int maxLength = 5;
-        int randLength = 6;
-        int equivalenceQueryBound = 7;
-        int memQueryRuns = 8;
-        int memQueryRetries = 9;
-        double probReset = 10.0;
-        String testFile = "testFile";
-        long seed = 11L;
-        int ceReruns = 12;
-        Duration timeLimit = Duration.parse("P1DT2H3M4.5S"); // 1 day, 2 hours, 3 minutes, 4.5 seconds
-        Long testLimit = 13L;
-        Integer roundLimit = 14;
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                // LearnerConfig options
-                "-alphabet", alphabet,
-                "-learningAlgorithm", learningAlgorithm.name(),
-                "-equivalenceAlgorithms", equivalenceAlgorithmsString,
-                "-depth", String.valueOf(depth),
-                "-minLength", String.valueOf(minLength),
-                "-maxLength", String.valueOf(maxLength),
-                "-randLength", String.valueOf(randLength),
-                "-equivalenceQueryBound", String.valueOf(equivalenceQueryBound),
-                "-memQueryRuns", String.valueOf(memQueryRuns),
-                "-memQueryRetries", String.valueOf(memQueryRetries),
-                "-logQueries",
-                "-probReset", String.valueOf(probReset),
-                "-testFile", testFile,
-                "-seed", String.valueOf(seed),
-                "-cacheTests",
-                "-ceSanitizationDisable",
-                "-skipNonDetTests",
-                "-ceReruns", String.valueOf(ceReruns),
-                "-probabilisticSanitizationDisable",
-                "-timeLimit", timeLimit.toString(),
-                "-testLimit", String.valueOf(testLimit),
-                "-roundLimit", String.valueOf(roundLimit),
-                // SulClientConfig required options not asserted here
-                "-port", "0",
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        LearnerConfig learnerConfig = stateFuzzerClientConfig.getLearnerConfig();
-
-        Assert.assertNotNull(learnerConfig);
-        Assert.assertEquals(alphabet, learnerConfig.getAlphabetFilename());
-        Assert.assertEquals(learningAlgorithm, learnerConfig.getLearningAlgorithm());
-        Assert.assertEquals(equivalenceAlgorithms, learnerConfig.getEquivalenceAlgorithms());
-        Assert.assertEquals(depth, learnerConfig.getMaxDepth());
-        Assert.assertEquals(minLength, learnerConfig.getMinLength());
-        Assert.assertEquals(maxLength, learnerConfig.getMaxLength());
-        Assert.assertEquals(randLength, learnerConfig.getRandLength());
-        Assert.assertEquals(equivalenceQueryBound, learnerConfig.getEquivQueryBound());
-        Assert.assertEquals(memQueryRuns, learnerConfig.getRunsPerMembershipQuery());
-        Assert.assertEquals(memQueryRetries, learnerConfig.getMembershipQueryRetries());
-        Assert.assertTrue(learnerConfig.isLogQueries());
-        Assert.assertEquals(probReset, learnerConfig.getProbReset(), 0.0);
-        Assert.assertEquals(testFile, learnerConfig.getTestFile());
-        Assert.assertEquals(seed, learnerConfig.getSeed());
-        Assert.assertTrue(learnerConfig.isCacheTests());
-        Assert.assertFalse(learnerConfig.isCeSanitization());
-        Assert.assertTrue(learnerConfig.isSkipNonDetTests());
-        Assert.assertEquals(ceReruns, learnerConfig.getCeReruns());
-        Assert.assertFalse(learnerConfig.isProbabilisticSanitization());
-        Assert.assertEquals(timeLimit, learnerConfig.getTimeLimit());
-        Assert.assertEquals(testLimit, learnerConfig.getTestLimit());
-        Assert.assertEquals(roundLimit, learnerConfig.getRoundLimit());
-    }
-
-    @Test
-    public void parseAllOptionsOfMapperConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String mapperConnectionConfig = "mapperConnectionConfigFile";
-        List<String> repeatingOutputs = Arrays.asList("OUT_1", "OUT_2");
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                // MapperConfig options
-                "-mapperConnectionConfig", mapperConnectionConfig,
-                "-repeatingOutputs", String.join(",", repeatingOutputs),
-                "-socketClosedAsTimeout",
-                "-disabledAsTimeout",
-                "-dontMergeRepeating",
-                // SulServerConfig required options not asserted here
-                "-connect", "host:1234",
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
-
-        Assert.assertNotNull(stateFuzzerServerConfig.getSulConfig());
-        MapperConfig mapperConfig = stateFuzzerServerConfig.getSulConfig().getMapperConfig();
-
-        Assert.assertNotNull(mapperConfig);
-        Assert.assertEquals(mapperConnectionConfig, mapperConfig.getMapperConnectionConfig());
-        Assert.assertEquals(repeatingOutputs, mapperConfig.getRepeatingOutputs());
-        Assert.assertTrue(mapperConfig.isSocketClosedAsTimeout());
-        Assert.assertTrue(mapperConfig.isDisabledAsTimeout());
-        Assert.assertFalse(mapperConfig.isMergeRepeating());
-    }
-
-    @Test
-    public void parseAllOptionsOfSulAdapterConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        Integer adapterPort = 1;
-        String adapterAddress = "adapterAddress";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                // SulAdapterConfig options
-                "-adapterPort", String.valueOf(adapterPort),
-                "-adapterAddress", adapterAddress,
-                // SulServerConfig required options not asserted here
-                "-connect", "host:1234",
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
-
-        Assert.assertNotNull(stateFuzzerServerConfig.getSulConfig());
-        SulAdapterConfig sulAdapterConfig = stateFuzzerServerConfig.getSulConfig().getSulAdapterConfig();
-
-        Assert.assertNotNull(sulAdapterConfig);
-        Assert.assertEquals(adapterPort, sulAdapterConfig.getAdapterPort());
-        Assert.assertEquals(adapterAddress, sulAdapterConfig.getAdapterAddress());
-    }
-
-    @Test
-    public void parseAllOptionsOfTestRunnerConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String test = "testFile";
-        Integer times = 2;
-        String testSpecification = "testSpecificationModel";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                // TestRunnerConfig options
-                "-test", test,
-                "-times", String.valueOf(times),
-                "-testSpecification", testSpecification,
-                "-showTransitionSequence",
-                // SulClientConfig required options not asserted here
-                "-port", "0",
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
-
-        TestRunnerConfig testRunnerConfig = stateFuzzerClientConfig.getTestRunnerConfig();
-
-        Assert.assertNotNull(testRunnerConfig);
-        Assert.assertEquals(test, testRunnerConfig.getTest());
-        Assert.assertEquals(times, testRunnerConfig.getTimes());
-        Assert.assertEquals(testSpecification, testRunnerConfig.getTestSpecification());
-        Assert.assertTrue(testRunnerConfig.isShowTransitionSequence());
-    }
-
-    @Test
-    public void parseAllOptionsOfTimingProbeConfig() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        String timingProbe = "probeCommand";
-        Integer probeMin = 1;
-        Integer probeLow = 2;
-        Integer probeHigh = 3;
-        String probeExport = "probeExportFile";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                // TimingProbeConfig options
-                "-timingProbe", timingProbe,
-                "-probeMin", String.valueOf(probeMin),
-                "-probeLow", String.valueOf(probeLow),
-                "-probeHigh", String.valueOf(probeHigh),
-                "-probeExport", probeExport,
-                // SulServerConfig required options not asserted here
-                "-connect", "host:1234",
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
-
-        TimingProbeConfig timingProbeConfig = stateFuzzerServerConfig.getTimingProbeConfig();
-
-        Assert.assertNotNull(timingProbeConfig);
-        Assert.assertEquals(timingProbe, timingProbeConfig.getProbeCmd());
-        Assert.assertEquals(probeMin, timingProbeConfig.getProbeMin());
-        Assert.assertEquals(probeLow, timingProbeConfig.getProbeLo());
-        Assert.assertEquals(probeHigh, timingProbeConfig.getProbeHi());
-        Assert.assertEquals(probeExport, timingProbeConfig.getProbeExport());
-    }
-
-    @Test
     public void parseDynamicOptionsBeforeUsage() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
+        String output = "test_out_dir";
 
-        Integer port = 1234;
+        String[] partialArgs = new String[] {
+            "-Dpre.fix=test_",
+            "-Dpostfix=_dir",
+            "-output", "${pre.fix}out${postfix}"
+        };
 
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                // dynamic options before usage
-                "-Dsul.port=1",
-                "-DportValue=34",
-                // SulClientConfig required options
-                "-port", "${sul.port}2${portValue}",
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
+        CommandLineParser commandLineParser = new CommandLineParser(new StateFuzzerConfigBuilderSimple(), null, null, null);
 
-        Assert.assertTrue(stateFuzzerClientConfig.getSulConfig() instanceof SulClientConfig);
-        SulClientConfig sulClientConfig = (SulClientConfig) stateFuzzerClientConfig.getSulConfig();
+        // parse as client command
+        StateFuzzerClientConfig stateFuzzerClientConfig = parseClientArgs(commandLineParser, partialArgs);
+        Assert.assertEquals(output, stateFuzzerClientConfig.getOutputDir());
 
-        Assert.assertNotNull(sulClientConfig);
-        Assert.assertEquals(port, sulClientConfig.getPort());
+        // parse as server command
+        StateFuzzerServerConfig stateFuzzerServerConfig = parseServerArgs(commandLineParser, partialArgs);
+        Assert.assertEquals(output, stateFuzzerServerConfig.getOutputDir());
     }
 
     @Test
     public void parseDynamicOptionsAfterUsage() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
+        String output = "test_out_dir";
 
-        String connect = "host:1234";
+        String[] partialArgs = new String[] {
+            "-output", "${pre.fix}out${postfix}",
+            "-Dpre.fix=test_",
+            "-Dpostfix=_dir"
+        };
 
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                // SulServerConfig required options
-                "-connect", "host:${sul.port}2${portValue}",
-                // dynamic options after usage
-                "-Dsul.port=1",
-                "-DportValue=34",
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
+        CommandLineParser commandLineParser = new CommandLineParser(new StateFuzzerConfigBuilderSimple(), null, null, null);
 
-        Assert.assertTrue(stateFuzzerServerConfig.getSulConfig() instanceof SulServerConfig);
-        SulServerConfig sulServerConfig = (SulServerConfig) stateFuzzerServerConfig.getSulConfig();
+        // parse as client command
+        StateFuzzerClientConfig stateFuzzerClientConfig = parseClientArgs(commandLineParser, partialArgs);
+        Assert.assertEquals(output, stateFuzzerClientConfig.getOutputDir());
 
-        Assert.assertNotNull(sulServerConfig);
-        Assert.assertEquals(connect, sulServerConfig.getHost());
+        // parse as server command
+        StateFuzzerServerConfig stateFuzzerServerConfig = parseServerArgs(commandLineParser, partialArgs);
+        Assert.assertEquals(output, stateFuzzerServerConfig.getOutputDir());
     }
 
     @Test
     public void parseDynamicOptionsBeforeAndAfterUsage() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
+        String output = "test_out_dir";
 
-        Integer port = 1234;
+        String[] partialArgs = new String[] {
+            "-Dpre.fix=test_",
+            "-output", "${pre.fix}out${postfix}",
+            "-Dpostfix=_dir"
+        };
 
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                // dynamic options before usage
-                "-Dsul.port=1",
-                // SulClientConfig required options
-                "-port", "${sul.port}2${portValue}",
-                // dynamic options after usage
-                "-DportValue=34",
-        });
-        StateFuzzerClientConfig stateFuzzerClientConfig = assertParseResultOfClient(parseResult);
+        CommandLineParser commandLineParser = new CommandLineParser(new StateFuzzerConfigBuilderSimple(), null, null, null);
 
-        Assert.assertTrue(stateFuzzerClientConfig.getSulConfig() instanceof SulClientConfig);
-        SulClientConfig sulClientConfig = (SulClientConfig) stateFuzzerClientConfig.getSulConfig();
+        // parse as client command
+        StateFuzzerClientConfig stateFuzzerClientConfig = parseClientArgs(commandLineParser, partialArgs);
+        Assert.assertEquals(output, stateFuzzerClientConfig.getOutputDir());
 
-        Assert.assertNotNull(sulClientConfig);
-        Assert.assertEquals(port, sulClientConfig.getPort());
-    }
-
-    @Test
-    public void parseDynamicExplicitConverterOptionsAfterUsage() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-
-        Duration timeLimit = Duration.parse("P1DT2H3M4.5S"); // 1 day, 2 hours, 3 minutes, 4.5 seconds
-        InputResponseTimeoutMap inputResponseTimeoutMap = new InputResponseTimeoutMap();
-        inputResponseTimeoutMap.put("IN_2", 2L);
-        inputResponseTimeoutMap.put("IN_3", 3L);
-        String inputResponseTimeoutString = "IN_2:2,IN_3:3";
-        String connect = "host:1234";
-
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                // LearnerConfig options with explicit converter
-                "-timeLimit", timeLimit.toString(),
-                // SulConfig options with explicit converter
-                "-inputResponseTimeout", inputResponseTimeoutString,
-                // SulServerConfig required options
-                "-connect", "host:${sul.port}2${portValue}",
-                // dynamic options after usage
-                "-Dsul.port=1",
-                "-DportValue=34",
-        });
-        StateFuzzerServerConfig stateFuzzerServerConfig = assertParseResultOfServer(parseResult);
-
-        LearnerConfig learnerConfig = stateFuzzerServerConfig.getLearnerConfig();
-
-        Assert.assertTrue(stateFuzzerServerConfig.getSulConfig() instanceof SulServerConfig);
-        SulServerConfig sulServerConfig = (SulServerConfig) stateFuzzerServerConfig.getSulConfig();
-
-        Assert.assertNotNull(learnerConfig);
-        Assert.assertEquals(timeLimit, learnerConfig.getTimeLimit());
-
-        Assert.assertNotNull(sulServerConfig);
-        Assert.assertEquals(inputResponseTimeoutMap, sulServerConfig.getInputResponseTimeout());
-        Assert.assertEquals(connect, sulServerConfig.getHost());
+        // parse as server command
+        StateFuzzerServerConfig stateFuzzerServerConfig = parseServerArgs(commandLineParser, partialArgs);
+        Assert.assertEquals(output, stateFuzzerServerConfig.getOutputDir());
     }
 
     @Test
     public void parseInvalidCommand() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
+        CommandLineParser commandLineParser = new CommandLineParser(new StateFuzzerConfigBuilderSimple(), null, null, null);
 
         CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                "invalidCommand"
+            "invalidCommand"
         });
 
         Assert.assertNull(parseResult);
@@ -595,83 +91,121 @@ public class CommandLineParserTest {
 
     @Test
     public void parseInvalidOption() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
-        CommandLineParser.ParseResult parseResult;
+        String[] partialArgs = new String[] {
+            "-invalidOption"
+        };
 
-        parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_CLIENT,
-                "-invalidOption",
-                // SulClientConfig required options not asserted here
-                "-port", "0",
-        });
+        CommandLineParser commandLineParser = new CommandLineParser(new StateFuzzerConfigBuilderSimple(), null, null, null);
 
-        Assert.assertNull(parseResult);
-
-        parseResult = commandLineParser.parseCommand(new String[]{
-                CommandLineParser.CMD_STATE_FUZZER_SERVER,
-                "-invalidOption",
-                // SulServerConfig required options not asserted here
-                "-connect", "host:1234",
-        });
-
-        Assert.assertNull(parseResult);
+        assertInvalidClientParse(commandLineParser, partialArgs);
+        assertInvalidServerParse(commandLineParser, partialArgs);
     }
 
     @Test
     public void parseMissingRequiredOptions() {
-        CommandLineParser commandLineParser = buildCommandLineParser();
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, new SulClientConfigStandard(null, null), null, null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, new SulServerConfigStandard(null, null), null, null);
+                }
+            }, null, null, null);
 
-        String[] commands = new String[] {CommandLineParser.CMD_STATE_FUZZER_CLIENT, CommandLineParser.CMD_STATE_FUZZER_SERVER};
+        // omit required options of SulClientConfigStandard and SulServerConfigStandard
+        assertInvalidClientParse(commandLineParser, new String[0]);
+        assertInvalidServerParse(commandLineParser, new String[0]);
+    }
 
-        for (String command : commands) {
-            CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-                    command
-                    // omit required options of SulClientConfig and SulServerConfig respectively
-            });
-            Assert.assertNull(parseResult);
+    @Test
+    public void buildNullStateFuzzerClientConfig() {
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return null;
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null);
+                }
+            }, null, null, null);
+
+        assertInvalidClientParse(commandLineParser, new String[0]);
+    }
+
+    @Test
+    public void buildNullStateFuzzerServerConfig() {
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return null;
+                }
+            }, null, null, null);
+
+        assertInvalidServerParse(commandLineParser, new String[0]);
+    }
+
+    private static class StateFuzzerConfigBuilderSimple implements StateFuzzerConfigBuilder {
+        @Override
+        public StateFuzzerClientConfig buildClientConfig() {
+            return new StateFuzzerClientConfigStandard(null);
+        }
+        @Override
+        public StateFuzzerServerConfig buildServerConfig() {
+            return new StateFuzzerServerConfigStandard(null);
         }
     }
 
-    private StateFuzzerClientConfig assertParseResultOfClient(CommandLineParser.ParseResult parseResult) {
+    /* Static methods available to other test files too */
+
+    public static String[] concatArgs(String[] args1, String[] args2) {
+        String[] args = Arrays.copyOf(args1, args1.length + args2.length);
+        System.arraycopy(args2, 0, args, args1.length, args2.length);
+        return args;
+    }
+
+    public static StateFuzzerClientConfig parseClientArgs(CommandLineParser commandLineParser, String[] partialArgs) {
+        String[] args = concatArgs(new String[] {CommandLineParser.CMD_STATE_FUZZER_CLIENT}, partialArgs);
+        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(args);
+
         Assert.assertNotNull(parseResult);
         Assert.assertTrue(parseResult.isValid());
         Assert.assertEquals(CommandLineParser.CMD_STATE_FUZZER_CLIENT, parseResult.getCommander().getParsedCommand());
         Assert.assertTrue(parseResult.getObjectFromParsedCommand() instanceof StateFuzzerClientConfig);
+
         return (StateFuzzerClientConfig) parseResult.getObjectFromParsedCommand();
     }
 
-    private StateFuzzerServerConfig assertParseResultOfServer(CommandLineParser.ParseResult parseResult) {
+    public static StateFuzzerServerConfig parseServerArgs(CommandLineParser commandLineParser, String[] partialArgs) {
+        String[] args = concatArgs(new String[] {CommandLineParser.CMD_STATE_FUZZER_SERVER}, partialArgs);
+        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(args);
+
         Assert.assertNotNull(parseResult);
         Assert.assertTrue(parseResult.isValid());
         Assert.assertEquals(CommandLineParser.CMD_STATE_FUZZER_SERVER, parseResult.getCommander().getParsedCommand());
         Assert.assertTrue(parseResult.getObjectFromParsedCommand() instanceof StateFuzzerServerConfig);
+
         return (StateFuzzerServerConfig) parseResult.getObjectFromParsedCommand();
     }
 
-    private CommandLineParser buildCommandLineParser() {
-        return new CommandLineParser(new StateFuzzerConfigBuilderImpl(), null, null, null);
+    public static void assertInvalidClientParse(CommandLineParser commandLineParser, String[] partialArgs) {
+        String[] args = concatArgs(new String[] {CommandLineParser.CMD_STATE_FUZZER_CLIENT}, partialArgs);
+        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(args);
+        Assert.assertNull(parseResult);
     }
 
-    private static class StateFuzzerConfigBuilderImpl implements StateFuzzerConfigBuilder {
-
-        @Override
-        public StateFuzzerClientConfig buildClientConfig() {
-            return new StateFuzzerClientConfigStandard(
-                new LearnerConfigStandard(),
-                new SulClientConfigStandard(new MapperConfigStandard(), new SulAdapterConfigStandard()),
-                new TestRunnerConfigStandard(),
-                new TimingProbeConfigStandard()
-            );
-        }
-
-        @Override
-        public StateFuzzerServerConfig buildServerConfig() {
-            return new StateFuzzerServerConfigStandard(
-                new LearnerConfigStandard(),
-                new SulServerConfigStandard(new MapperConfigStandard(), new SulAdapterConfigStandard()),
-                new TestRunnerConfigStandard(),
-                new TimingProbeConfigStandard()
-            );
-        }
+    public static void assertInvalidServerParse(CommandLineParser commandLineParser, String[] partialArgs) {
+        String[] args = concatArgs(new String[] {CommandLineParser.CMD_STATE_FUZZER_SERVER}, partialArgs);
+        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(args);
+        Assert.assertNull(parseResult);
     }
 }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigTest.java
@@ -1,0 +1,65 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfigEmpty;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StateFuzzerClientConfigTest extends StateFuzzerConfigTest {
+    @Test
+    public void parseAllOptions() {
+        StateFuzzerConfig stateFuzzerConfig = super.parseAllOptionsWithStandard();
+
+        Assert.assertTrue(stateFuzzerConfig instanceof StateFuzzerClientConfigStandard);
+        StateFuzzerClientConfigStandard stateFuzzerClientConfigStandard = (StateFuzzerClientConfigStandard) stateFuzzerConfig;
+
+        Assert.assertTrue(stateFuzzerClientConfigStandard.isFuzzingClient());
+
+        // The implementation of StateFuzzerConfigBuilder does not specify any
+        // other config, so the defaults are used, which are the Empty ones
+        Assert.assertTrue(stateFuzzerClientConfigStandard.getLearnerConfig() instanceof LearnerConfigEmpty);
+        Assert.assertTrue(stateFuzzerClientConfigStandard.getSulConfig() instanceof SulConfigEmpty);
+        Assert.assertTrue(stateFuzzerClientConfigStandard.getTestRunnerConfig() instanceof TestRunnerConfigEmpty);
+        Assert.assertTrue(stateFuzzerClientConfigStandard.getTimingProbeConfig() instanceof TimingProbeConfigEmpty);
+    }
+
+    @Override
+    protected StateFuzzerClientConfig parseWithStandard(String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null);
+                }
+            },
+            null, null, null);
+
+        return CommandLineParserTest.parseClientArgs(commandLineParser, partialArgs);
+    }
+
+    @Override
+    protected void assertInvalidParseWithEmpty(String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null);
+                }
+            },
+            null, null, null);
+
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigTest.java
@@ -1,0 +1,86 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.time.format.DateTimeFormatter;
+
+public abstract class StateFuzzerConfigTest {
+    @Test
+    public void parseDefaultOutput() {
+        String prefix = "output" + File.separator + "o_";
+        String dateFormat = "yyyy-MM-dd_HH-mm-ss";
+
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[0]);
+
+        String outputDir = stateFuzzerConfig.getOutputDir();
+        Assert.assertTrue(outputDir.startsWith(prefix));
+        DateTimeFormatter.ofPattern(dateFormat).parse(outputDir.substring(prefix.length()));
+    }
+
+    @Test
+    public void parseDefaultTimestampFormat() {
+        String prefix = "pre_";
+        String output = prefix + "${timestamp}";
+        String dateFormat = "yyyy-MM-dd_HH-mm-ss";
+
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[]{
+            "-output", output
+        });
+
+        String outputDir = stateFuzzerConfig.getOutputDir();
+        Assert.assertTrue(outputDir.startsWith(prefix));
+        DateTimeFormatter.ofPattern(dateFormat).parse(outputDir.substring(prefix.length()));
+    }
+
+    @Test
+    public void parseDynamicTimestampFormat() {
+        String prefix = "pre_";
+        String output = prefix + "${timestamp}";
+        String dateFormat = "yyyy-MM-dd";
+
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[]{
+            "-Dtimestamp.format=" + dateFormat,
+            "-output", output
+        });
+
+        String outputDir = stateFuzzerConfig.getOutputDir();
+        Assert.assertTrue(outputDir.startsWith(prefix));
+        DateTimeFormatter.ofPattern(dateFormat).parse(outputDir.substring(prefix.length()));
+    }
+
+    protected StateFuzzerConfig parseAllOptionsWithStandard() {
+        String output = "output";
+
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[]{
+            "-help",
+            "-debug",
+            "-quiet",
+            "-output", output
+        });
+
+        Assert.assertTrue(stateFuzzerConfig.isHelp());
+        Assert.assertTrue(stateFuzzerConfig.isDebug());
+        Assert.assertTrue(stateFuzzerConfig.isQuiet());
+        Assert.assertEquals(output, stateFuzzerConfig.getOutputDir());
+
+        // StateFuzzerConfig constructor does not allow null configs and instantiates them
+        Assert.assertNotNull(stateFuzzerConfig.getLearnerConfig());
+        Assert.assertNotNull(stateFuzzerConfig.getSulConfig());
+        Assert.assertNotNull(stateFuzzerConfig.getTestRunnerConfig());
+        Assert.assertNotNull(stateFuzzerConfig.getTimingProbeConfig());
+
+        return stateFuzzerConfig;
+    }
+
+    @Test
+    public void invalidParseWithEmpty() {
+        assertInvalidParseWithEmpty(new String[] {
+            "-help",
+        });
+    }
+
+    protected abstract StateFuzzerConfig parseWithStandard(String[] partialArgs);
+    protected abstract void assertInvalidParseWithEmpty(String[] partialArgs);
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigTest.java
@@ -1,0 +1,65 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfigEmpty;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StateFuzzerServerConfigTest extends StateFuzzerConfigTest {
+    @Test
+    public void parseAllOptions() {
+        StateFuzzerConfig stateFuzzerConfig = super.parseAllOptionsWithStandard();
+
+        Assert.assertTrue(stateFuzzerConfig instanceof StateFuzzerServerConfigStandard);
+
+        StateFuzzerServerConfigStandard stateFuzzerServerConfigStandard = (StateFuzzerServerConfigStandard) stateFuzzerConfig;
+        Assert.assertFalse(stateFuzzerServerConfigStandard.isFuzzingClient());
+
+        // The implementation of StateFuzzerConfigBuilder does not specify any
+        // other config, so the defaults are used, which are the Empty ones
+        Assert.assertTrue(stateFuzzerServerConfigStandard.getLearnerConfig() instanceof LearnerConfigEmpty);
+        Assert.assertTrue(stateFuzzerServerConfigStandard.getSulConfig() instanceof SulConfigEmpty);
+        Assert.assertTrue(stateFuzzerServerConfigStandard.getTestRunnerConfig() instanceof TestRunnerConfigEmpty);
+        Assert.assertTrue(stateFuzzerServerConfigStandard.getTimingProbeConfig() instanceof TimingProbeConfigEmpty);
+    }
+
+    @Override
+    protected StateFuzzerServerConfig parseWithStandard(String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null);
+                }
+            },
+            null, null, null);
+
+        return CommandLineParserTest.parseServerArgs(commandLineParser, partialArgs);
+    }
+
+    @Override
+    protected void assertInvalidParseWithEmpty(String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null);
+                }
+            },
+            null, null, null);
+
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigTest.java
@@ -1,0 +1,191 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRunnerConfigTest {
+    @Test
+    public void parseAllOptions_SFCstd_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfigStandard(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfigStandard(), null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfigStandard(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, new TestRunnerConfigStandard(), null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, new TestRunnerConfigStandard(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfigStandard(), null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, new TestRunnerConfigStandard(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, new TestRunnerConfigStandard(), null);
+                }
+            }
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        String test = "testFile";
+        Integer times = 2;
+        String testSpecification = "testSpecificationModel";
+
+        TestRunnerConfig[] testRunnerConfigs = parseWithStandard(stateFuzzerConfigBuilder, new String[]{
+            "-test", test,
+            "-times", String.valueOf(times),
+            "-testSpecification", testSpecification,
+            "-showTransitionSequence",
+        });
+
+        for (TestRunnerConfig testRunnerConfig : testRunnerConfigs) {
+            Assert.assertNotNull(testRunnerConfig);
+            Assert.assertEquals(test, testRunnerConfig.getTest());
+            Assert.assertEquals(times, testRunnerConfig.getTimes());
+            Assert.assertEquals(testSpecification, testRunnerConfig.getTestSpecification());
+            Assert.assertTrue(testRunnerConfig.isShowTransitionSequence());
+        }
+    }
+
+    private TestRunnerConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        TestRunnerConfig[] testRunnerConfigs = new TestRunnerConfig[2];
+
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, partialArgs);
+        Assert.assertNotNull(clientConfig);
+        testRunnerConfigs[0] = clientConfig.getTestRunnerConfig();
+
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, partialArgs);
+        Assert.assertNotNull(serverConfig);
+        testRunnerConfigs[1] = serverConfig.getTestRunnerConfig();
+
+        return testRunnerConfigs;
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SFSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfigEmpty(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfigEmpty(), null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SFSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfigEmpty(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, new TestRunnerConfigEmpty(), null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SFSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, new TestRunnerConfigEmpty(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfigEmpty(), null);
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SFSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, new TestRunnerConfigEmpty(), null);
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, new TestRunnerConfigEmpty(), null);
+                }
+            }
+        );
+    }
+
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        String[] partialArgs = new String[] {
+            "-test", "testPath",
+        };
+
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);
+    }
+}

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigTest.java
@@ -1,0 +1,195 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
+import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParserTest;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerClientConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerConfigBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimingProbeConfigTest {
+    @Test
+    public void parseAllOptions_SFCstd_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfigStandard());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfigStandard());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCstd_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfigStandard());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, null, new TimingProbeConfigStandard());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SFSstd() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, null, new TimingProbeConfigStandard());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfigStandard());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void parseAllOptions_SFCemp_SFSemp() {
+        parseAllOptions(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, null, new TimingProbeConfigStandard());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, null, new TimingProbeConfigStandard());
+                }
+            }
+        );
+    }
+
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        String timingProbe = "probeCommand";
+        Integer probeMin = 1;
+        Integer probeLow = 2;
+        Integer probeHigh = 3;
+        String probeExport = "probeExportFile";
+
+        TimingProbeConfig[] timingProbeConfigs = parseWithStandard(stateFuzzerConfigBuilder, new String[]{
+            "-timingProbe", timingProbe,
+            "-probeMin", String.valueOf(probeMin),
+            "-probeLow", String.valueOf(probeLow),
+            "-probeHigh", String.valueOf(probeHigh),
+            "-probeExport", probeExport,
+        });
+
+        for (TimingProbeConfig timingProbeConfig : timingProbeConfigs) {
+            Assert.assertNotNull(timingProbeConfig);
+            Assert.assertEquals(timingProbe, timingProbeConfig.getProbeCmd());
+            Assert.assertEquals(probeMin, timingProbeConfig.getProbeMin());
+            Assert.assertEquals(probeLow, timingProbeConfig.getProbeLo());
+            Assert.assertEquals(probeHigh, timingProbeConfig.getProbeHi());
+            Assert.assertEquals(probeExport, timingProbeConfig.getProbeExport());
+        }
+    }
+
+    private TimingProbeConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        TimingProbeConfig[] timingProbeConfigs = new TimingProbeConfig[2];
+
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, partialArgs);
+        Assert.assertNotNull(clientConfig);
+        timingProbeConfigs[0] = clientConfig.getTimingProbeConfig();
+
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, partialArgs);
+        Assert.assertNotNull(serverConfig);
+        timingProbeConfigs[1] = serverConfig.getTimingProbeConfig();
+
+        return timingProbeConfigs;
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SFSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfigEmpty());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfigEmpty());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCstd_SFSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfigEmpty());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, null, new TimingProbeConfigEmpty());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SFSstd() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, null, new TimingProbeConfigEmpty());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfigEmpty());
+                }
+            }
+        );
+    }
+
+    @Test
+    public void invalidParseWithEmpty_SFCemp_SFSemp() {
+        invalidParseWithEmpty(
+            new StateFuzzerConfigBuilder() {
+                @Override
+                public StateFuzzerClientConfig buildClientConfig() {
+                    return new StateFuzzerClientConfigEmpty(null, null, null, new TimingProbeConfigEmpty());
+                }
+                @Override
+                public StateFuzzerServerConfig buildServerConfig() {
+                    return new StateFuzzerServerConfigEmpty(null, null, null, new TimingProbeConfigEmpty());
+                }
+            }
+        );
+    }
+
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
+        CommandLineParser commandLineParser = new CommandLineParser(stateFuzzerConfigBuilder, null, null, null);
+
+        String[] partialArgs = new String[] {
+            "-timingProbe", "timingProbeCommand"
+        };
+
+        CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
+        CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);
+    }
+}


### PR DESCRIPTION
I refactored the tests directory. Specifically, I added one test file per configuration, except for the `XConfigStandard.java` and `XConfigEmpty.java` configurations. These are tested in `XConfigTest.java` files, because the testing of the `Empty` variant is minimal.

Essentially, I tried to test for a given configuration, *every sensible* config combination that can alter the observed behavior of the configuration under test. For example a `LearnerConfigStandard` can reside in both `Empty` and `Standard` variants of `StateFuzzerClientConfig` and of `StateFuzzerServerConfig`.

Additionally, the first commit introduces some enhancements to the source code, for which I added some tests and assertions.

I think this PR can be focused on the refactoring, after which we can add more targeted tests.