### PR TITLE
Bump spotbugs-maven-plugin to 4.8.1.0 and fix some warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,18 @@ public class MultiBuilder implements
     @Override
     public StateFuzzer build(StateFuzzerEnabler stateFuzzerEnabler) {
         return new StateFuzzerStandard(
-            new StateFuzzerComposerStandard(stateFuzzerEnabler, alphabetBuilder, sulBuilder, sulWrapper)
+            new StateFuzzerComposerStandard(stateFuzzerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize()
         );
     }
 
     @Override
     public TestRunner build(TestRunnerEnabler testRunnerEnabler) {
-        return new TestRunner(testRunnerEnabler, alphabetBuilder, sulBuilder, sulWrapper);
+        return new TestRunner(testRunnerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
     }
 
     @Override
     public TimingProbe build(TimingProbeEnabler timingProbeEnabler) {
-        return new TimingProbe(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper);
+        return new TimingProbe(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
     }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.7.3.6</version>
+                <version>4.8.1.0</version>
                 <configuration>
                     <includeFilterFile>spotbugs-include.xml</includeFilterFile>
                 </configuration>

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunner.java
@@ -75,9 +75,8 @@ public class TestRunner {
     /**
      * Constructs a new instance from the given parameters.
      * <p>
-     * It also checks if the TestRunnerConfig from the TestRunnerEnabler contains
-     * any test specification that needs to be built and used.
      * The {@link #sulOracle} contains the wrapped (and built) sul.
+     * Invoke {@link #initialize()} afterwards.
      *
      * @param testRunnerEnabler  the configuration that enables the testing
      * @param alphabetBuilder    the builder of the alphabet
@@ -96,7 +95,19 @@ public class TestRunner {
         this.sulOracle = new SULOracle<>(sulWrapper.wrap(abstractSul).getWrappedSul());
 
         this.testSpecification = null;
-        if (testRunnerEnabler.getTestRunnerConfig().getTestSpecification() != null) {
+    }
+
+    /**
+     * Initializes the instance; to be run after the constructor.
+     * <p>
+     * It checks if the TestRunnerConfig from the TestRunnerEnabler contains
+     * any test specification that needs to be built and used.
+     *
+     * @return  the same instance
+     */
+    public TestRunner initialize() {
+        if (this.testSpecification == null &&
+            this.testRunnerEnabler.getTestRunnerConfig().getTestSpecification() != null) {
             try {
                 this.testSpecification = ModelFactory.buildProtocolModel(
                         alphabet, testRunnerEnabler.getTestRunnerConfig().getTestSpecification());
@@ -104,7 +115,7 @@ public class TestRunner {
                 throw new RuntimeException("Could not build protocol model from test specification: " + e.getMessage());
             }
         }
-
+        return this;
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
@@ -46,6 +46,9 @@ public class TimingProbe {
     /**
      * Constructs a new instance from the given parameters.
      *
+     * <p>
+     * Invoke {@link #initialize()} afterwards.
+     *
      * @param timingProbeEnabler  the configuration that enables testing with the timing probe
      * @param alphabetBuilder     the builder of the alphabet
      * @param sulBuilder          the builder of the sul
@@ -58,8 +61,22 @@ public class TimingProbe {
         this.alphabetBuilder = alphabetBuilder;
 
         if(isActive()) {
-            probeTestRunner = new ProbeTestRunner(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper);
+            this.probeTestRunner = new ProbeTestRunner(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper);
         }
+    }
+
+    /**
+     * Initializes the instance; to be run after the constructor.
+     * <p>
+     * It initializes the {@link #probeTestRunner} if the probe is active.
+     *
+     * @return  the same instance
+     */
+    public TimingProbe initialize() {
+        if (isActive() && this.probeTestRunner != null) {
+            this.probeTestRunner.initialize();
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/Flow.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/Flow.java
@@ -45,26 +45,22 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
      * @param inputWord   the word containing the input symbols
      * @param outputWord  the word containing the output symbols
      * @param fromStart   indicates if the flow starts from the initial state
-     *
-     * @throws NullPointerException  if inputWord or outputWord are null
-     *                               or if they have different lengths
      */
     public Flow(Word<I> inputWord, Word<O> outputWord, boolean fromStart) {
-        if (inputWord == null) {
-            throw new NullPointerException("The provided inputWord is null");
-        }
-
-        if (outputWord == null) {
-            throw new NullPointerException("The provided outputWord is null");
-        }
-
-        if (inputWord.length() != outputWord.length()) {
-            throw new NullPointerException("The provided inputWord and outputWord have different lengths");
-        }
-
         this.inputWord = inputWord;
         this.outputWord = outputWord;
         this.fromStart = fromStart;
+    }
+
+    /**
+     * Returns {@code true} if the current instance is a valid flow.
+     *
+     * @return  {@code true} if the current instance is a valid flow
+     */
+    public boolean isValid() {
+        return inputWord != null
+            && outputWord != null
+            && inputWord.length() == outputWord.length();
     }
 
     /**


### PR DESCRIPTION
After bumping the plugin's version, some necessary changes were required. These were related to exception throwing in the constructor of a class. I removed all those instances and placed them inside `initialize` methods after some simplifications. I also updated the `README`.