### PR TITLE
Bump learnlib from 0.17.0 to 0.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <automatalib.version>0.12.1</automatalib.version>
         <checker-qual.version>3.49.1</checker-qual.version>
         <error-prone.version>2.37.0</error-prone.version>
-        <learnlib.version>0.17.0</learnlib.version>
+        <learnlib.version>0.18.0</learnlib.version>
         <log4j.version>2.24.3</log4j.version>
         <biz-aQute.version>7.1.0</biz-aQute.version>
         <jakarta-xml.version>4.0.2</jakarta-xml.version>
@@ -198,12 +198,6 @@
         <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-core</artifactId>
-        </dependency>
-
-       <!-- https://mvnrepository.com/artifact/net.automatalib/automata-serialization -->
-        <dependency>
-           <groupId>net.automatalib</groupId>
-           <artifactId>automata-serialization-core</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.automatalib/automata-serialization-dot -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <checker-qual.version>3.49.1</checker-qual.version>
         <error-prone.version>2.37.0</error-prone.version>
         <learnlib.version>0.18.0</learnlib.version>
+        <learnlib-tooling.version>0.1.1</learnlib-tooling.version>
         <log4j.version>2.24.3</log4j.version>
         <biz-aQute.version>7.1.0</biz-aQute.version>
         <jakarta-xml.version>4.0.2</jakarta-xml.version>
@@ -35,6 +36,15 @@
                 <groupId>de.learnlib</groupId>
                 <artifactId>learnlib-parent</artifactId>
                 <version>${learnlib.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- learnlib-tooling -->
+            <dependency>
+                <groupId>de.learnlib.tooling</groupId>
+                <artifactId>build-tools-parent</artifactId>
+                <version>${learnlib-tooling.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -120,8 +130,6 @@
                 <groupId>de.learnlib</groupId>
                 <artifactId>ralib</artifactId>
                 <version>${ralib.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <!-- spotbugs annotations -->
@@ -180,6 +188,12 @@
         <dependency>
             <groupId>de.learnlib</groupId>
             <artifactId>learnlib-ttt</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/de.learnlib.tooling/annotations -->
+        <dependency>
+            <groupId>de.learnlib.tooling</groupId>
+            <artifactId>annotations</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.automatalib/automata-api -->
@@ -271,7 +285,6 @@
         <dependency>
             <groupId>de.learnlib</groupId>
             <artifactId>ralib</artifactId>
-            <version>${ralib.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations -->
@@ -300,6 +313,9 @@
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>
                                     biz.aQute.bnd:biz.aQute.bnd.annotation:jar:*
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    de.learnlib.tooling:annotations:jar:*
                                 </ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderTransformer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderTransformer.java
@@ -2,7 +2,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphab
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
 import net.automatalib.alphabet.Alphabet;
-import net.automatalib.alphabet.ListAlphabet;
+import net.automatalib.alphabet.impl.ListAlphabet;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/EnumAlphabet.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/EnumAlphabet.java
@@ -2,7 +2,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphab
 
 import de.learnlib.ralib.data.DataType;
 import de.learnlib.ralib.words.*;
-import net.automatalib.alphabet.ListAlphabet;
+import net.automatalib.alphabet.impl.ListAlphabet;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetSerializerXml.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetSerializerXml.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import net.automatalib.alphabet.Alphabet;
-import net.automatalib.alphabet.ListAlphabet;
+import net.automatalib.alphabet.impl.ListAlphabet;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/MealyMachineWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/MealyMachineWrapper.java
@@ -1,9 +1,9 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics;
 
 import net.automatalib.alphabet.Alphabet;
-import net.automatalib.alphabet.ListAlphabet;
-import net.automatalib.automaton.transducer.CompactMealy;
+import net.automatalib.alphabet.impl.ListAlphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.automaton.transducer.impl.CompactMealy;
 import net.automatalib.serialization.dot.GraphDOT;
 import net.automatalib.util.automaton.copy.AutomatonCopyMethod;
 import net.automatalib.util.automaton.copy.AutomatonLowLevelCopy;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SulWrapperStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SulWrapperStandard.java
@@ -10,8 +10,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwra
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwrappers.TestLimitWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwrappers.TimeoutWrapper;
 import de.learnlib.filter.statistic.Counter;
-import de.learnlib.filter.statistic.sul.ResetCounterSUL;
-import de.learnlib.filter.statistic.sul.SymbolCounterSUL;
+import de.learnlib.filter.statistic.sul.CounterSUL;
 import de.learnlib.sul.SUL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -72,11 +71,10 @@ public class SulWrapperStandard<I, O, E> implements SulWrapper<I, O, E> {
 
         wrappedSul = new SulLivenessWrapper<>(wrappedSul, sulLivenessTracker, socketClosed);
 
-        wrappedSul = new SymbolCounterSUL<>("input counter", wrappedSul);
-        inputCounter = SymbolCounterSUL.class.cast(wrappedSul).getStatisticalData();
+        wrappedSul = new CounterSUL<>(wrappedSul);
 
-        wrappedSul = new ResetCounterSUL<>("test counter", wrappedSul);
-        testCounter = ResetCounterSUL.class.cast(wrappedSul).getStatisticalData();
+        inputCounter = CounterSUL.class.cast(wrappedSul).getSymbolCounter();
+        testCounter = CounterSUL.class.cast(wrappedSul).getResetCounter();
         return this;
     }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
@@ -15,6 +15,7 @@ import de.learnlib.oracle.MembershipOracle.MealyMembershipOracle;
 import de.learnlib.oracle.membership.SULOracle;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.exception.FormatException;
 import net.automatalib.word.Word;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -100,7 +101,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
                     new MealyIOProcessor<>(alphabet, mapper.getOutputBuilder())
                 );
 
-            } catch (IOException e) {
+            } catch (IOException | FormatException e) {
                 throw new RuntimeException("Could not build protocol model from test specification: " + e.getMessage());
             }
         }
@@ -139,7 +140,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
                     LOGGER.info("Displaying Transition Sequence\n{}", getTransitionSequenceString(result));
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | FormatException e) {
             LOGGER.error(e.getMessage());
             e.printStackTrace();
         } finally {
@@ -163,7 +164,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      *
      * @throws IOException  if an error during reading occurs
      */
-    protected List<TestRunnerResult<Word<I>, Word<O>>> runTests() throws IOException {
+    protected List<TestRunnerResult<Word<I>, Word<O>>> runTests() throws IOException, FormatException {
         TestParser<I> testParser = new TestParser<>();
         List<Word<I>> tests;
         String testFileOrTestString = testRunnerEnabler.getTestRunnerConfig().getTest();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
@@ -162,7 +162,8 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      *
      * @return  a list with the test results
      *
-     * @throws IOException  if an error during reading occurs
+     * @throws IOException      if an error during reading occurs
+     * @throws FormatException  if an invalid format was encountered
      */
     protected List<TestRunnerResult<Word<I>, Word<O>>> runTests() throws IOException, FormatException {
         TestParser<I> testParser = new TestParser<>();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
@@ -7,6 +7,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abst
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerResult;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerEnabler;
+import net.automatalib.exception.FormatException;
 import net.automatalib.word.Word;
 
 import java.io.IOException;
@@ -56,7 +57,7 @@ public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends Test
      *
      * @throws IOException       if an error occurs during {@link #runTests()}
      */
-    public boolean isNonDeterministic(boolean cacheFoundResults) throws IOException {
+    public boolean isNonDeterministic(boolean cacheFoundResults) throws IOException, FormatException {
         List<TestRunnerResult<Word<I>, Word<O>>> results = super.runTests();
         Iterator<TestRunnerResult<Word<I>, Word<O>>> iterator = null;
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
@@ -55,7 +55,8 @@ public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends Test
      * @return                   {@code true} if any result is found to be
      *                           non-deterministic
      *
-     * @throws IOException       if an error occurs during {@link #runTests()}
+     * @throws IOException      if an error occurs during {@link #runTests()}
+     * @throws FormatException  if an invalid format was encountered
      */
     public boolean isNonDeterministic(boolean cacheFoundResults) throws IOException, FormatException {
         List<TestRunnerResult<Word<I>, Word<O>>> results = super.runTests();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
@@ -8,6 +8,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abst
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.MapperOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeEnabler;
+import net.automatalib.exception.FormatException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -91,7 +92,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
             LOGGER.info(TimingProbe.present(bestTimes));
             alphabetBuilder.exportAlphabetToFile(timingProbeConfig.getProbeExport(), probeTestRunner.getAlphabet());
 
-        } catch (ProbeException | IOException | AlphabetSerializerException e) {
+        } catch (ProbeException | IOException | FormatException | AlphabetSerializerException e) {
             LOGGER.error(e.getMessage());
             e.printStackTrace();
 
@@ -113,7 +114,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      *                         from {@link #findProbeLimitRange(String)}
      * @throws ProbeException  if non-determinism is found at max timing values
      */
-    public Map<String, Integer> findDeterministicTimesValues() throws IOException, ProbeException {
+    public Map<String, Integer> findDeterministicTimesValues() throws IOException, FormatException, ProbeException {
         Map<String, Integer> map = new HashMap<>();
         String[] cmds = timingProbeConfig.getProbeCmd().split(",", -1);
 
@@ -209,7 +210,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      *
      * @throws IOException  from {@link ProbeTestRunner#isNonDeterministic(boolean)}
      */
-    protected ProbeLimitRange findProbeLimitRange(String cmd) throws IOException {
+    protected ProbeLimitRange findProbeLimitRange(String cmd) throws IOException, FormatException {
         Integer probeLo = timingProbeConfig.getProbeLo();
         Integer probeHi = timingProbeConfig.getProbeHi();
         Integer probeMin = timingProbeConfig.getProbeMin();
@@ -260,7 +261,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      *
      * @throws IOException  from {@link ProbeTestRunner#isNonDeterministic(boolean)}
      */
-    protected Integer binarySearch(String cmd, ProbeLimitRange probeLimitRange) throws IOException {
+    protected Integer binarySearch(String cmd, ProbeLimitRange probeLimitRange) throws IOException, FormatException {
         Integer hi = probeLimitRange.getHi();
         Integer lo = probeLimitRange.getLo();
         Integer probeMin = timingProbeConfig.getProbeMin();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
@@ -110,9 +110,10 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      *
      * @return  the map from commands to lowest timing probe values
      *
-     * @throws IOException     from {@link ProbeTestRunner#isNonDeterministic(boolean)} or
-     *                         from {@link #findProbeLimitRange(String)}
-     * @throws ProbeException  if non-determinism is found at max timing values
+     * @throws IOException      from {@link ProbeTestRunner#isNonDeterministic(boolean)} or
+     *                          from {@link #findProbeLimitRange(String)}
+     * @throws FormatException  if an invalid format was encountered
+     * @throws ProbeException   if non-determinism is found at max timing values
      */
     public Map<String, Integer> findDeterministicTimesValues() throws IOException, FormatException, ProbeException {
         Map<String, Integer> map = new HashMap<>();
@@ -208,7 +209,8 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      *             value for hi is found on the first try then this is reflected in
      *             the in the hiDeterministic variable of ProbeLimitRange
      *
-     * @throws IOException  from {@link ProbeTestRunner#isNonDeterministic(boolean)}
+     * @throws IOException      from {@link ProbeTestRunner#isNonDeterministic(boolean)}
+     * @throws FormatException  if an invalid format was encountered
      */
     protected ProbeLimitRange findProbeLimitRange(String cmd) throws IOException, FormatException {
         Integer probeLo = timingProbeConfig.getProbeLo();
@@ -259,7 +261,8 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * @param probeLimitRange  the  ProbeLimitRange holding the search interval
      * @return                 the found deterministic timing probe value
      *
-     * @throws IOException  from {@link ProbeTestRunner#isNonDeterministic(boolean)}
+     * @throws IOException      from {@link ProbeTestRunner#isNonDeterministic(boolean)}
+     * @throws FormatException  if an invalid format was encountered
      */
     protected Integer binarySearch(String cmd, ProbeLimitRange probeLimitRange) throws IOException, FormatException {
         Integer hi = probeLimitRange.getHi();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DFAUtils.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DFAUtils.java
@@ -1,10 +1,10 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.utils;
 
-import net.automatalib.alphabet.ListAlphabet;
+import net.automatalib.alphabet.impl.ListAlphabet;
 import net.automatalib.automaton.fsa.DFA;
-import net.automatalib.automaton.fsa.FastDFA;
-import net.automatalib.automaton.fsa.FastDFAState;
 import net.automatalib.automaton.fsa.MutableDFA;
+import net.automatalib.automaton.fsa.impl.FastDFA;
+import net.automatalib.automaton.fsa.impl.FastDFAState;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.common.util.Pair;
 import net.automatalib.common.util.mapping.Mapping;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyDotParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyDotParser.java
@@ -3,6 +3,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.utils;
 import net.automatalib.automaton.AutomatonCreator;
 import net.automatalib.automaton.transducer.MutableMealyMachine;
 import net.automatalib.common.util.Pair;
+import net.automatalib.exception.FormatException;
 import net.automatalib.serialization.InputModelData;
 import net.automatalib.serialization.dot.DOTInputModelDeserializer;
 import net.automatalib.serialization.dot.DOTParsers;
@@ -30,7 +31,7 @@ public class MealyDotParser {
      * @throws IOException  in case of an error reading from the inputStream
      */
     public static <S, I, O, A extends MutableMealyMachine<S, I, ?, O>> InputModelData<I, A>
-    parse(AutomatonCreator<A, I> creator, InputStream inputStream, MealyInputOutputProcessor<I, O> processor) throws IOException {
+    parse(AutomatonCreator<A, I> creator, InputStream inputStream, MealyInputOutputProcessor<I, O> processor) throws IOException, FormatException {
 
         DOTInputModelDeserializer<S, I, A> parser = DOTParsers.mealy(creator, (map) -> {
             Pair<String, String> ioStringPair = DOTParsers.DEFAULT_MEALY_EDGE_PARSER.apply(map);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyDotParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyDotParser.java
@@ -28,7 +28,8 @@ public class MealyDotParser {
      * @param processor    the input output processor
      * @return             the parsed model instance
      *
-     * @throws IOException  in case of an error reading from the inputStream
+     * @throws IOException      in case of an error reading from the inputStream
+     * @throws FormatException  if an invalid format was encountered
      */
     public static <S, I, O, A extends MutableMealyMachine<S, I, ?, O>> InputModelData<I, A>
     parse(AutomatonCreator<A, I> creator, InputStream inputStream, MealyInputOutputProcessor<I, O> processor) throws IOException, FormatException {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ModelFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ModelFactory.java
@@ -1,8 +1,9 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.utils;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.MealyDotParser.MealyInputOutputProcessor;
-import net.automatalib.automaton.transducer.CompactMealy;
 import net.automatalib.automaton.transducer.MealyMachine;
+import net.automatalib.automaton.transducer.impl.CompactMealy;
+import net.automatalib.exception.FormatException;
 import net.automatalib.serialization.InputModelData;
 
 import java.io.FileInputStream;
@@ -27,7 +28,7 @@ public class ModelFactory {
     public static <I, O> MealyMachine<?, I, ?, O> buildProtocolModel(
         String dotFilename,
         MealyInputOutputProcessor<I, O> processor
-    ) throws IOException {
+    ) throws IOException, FormatException {
 
         InputModelData<I, CompactMealy<I, O>> result = MealyDotParser.parse(
             new CompactMealy.Creator<I, O>(),

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ModelFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ModelFactory.java
@@ -23,7 +23,8 @@ public class ModelFactory {
      * @param processor    the processor for the inputs and outputs
      * @return             the built model after parsing
      *
-     * @throws IOException  if an error parsing the DOT file occurs
+     * @throws IOException      if an error parsing the DOT file occurs
+     * @throws FormatException  if an invalid format was encountered
      */
     public static <I, O> MealyMachine<?, I, ?, O> buildProtocolModel(
         String dotFilename,

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RAAlphabetBuilder.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RAAlphabetBuilder.java
@@ -5,7 +5,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabe
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
 import de.learnlib.ralib.words.ParameterizedSymbol;
 import net.automatalib.alphabet.Alphabet;
-import net.automatalib.alphabet.ListAlphabet;
+import net.automatalib.alphabet.impl.ListAlphabet;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
This is WIP towards upgrading to the recently released learnlib 0.18.0. 

AFAIK, there are two kinds of issues still remaining:
1. Adjust the `SulWrapperStandard` class to use `CounterSUL` instead of `ResetCounterSUL` and `SymbolCounterSUL` as discussed [here](https://github.com/LearnLib/learnlib/issues/147).
2. Fix the `de.learnlib.tooling` issues.  As mentioned in [the release notes of learnlib 0.18.0](https://github.com/LearnLib/learnlib/releases/tag/learnlib-0.18.0), the `de.learnlib.tooling:learnlib-annotation-processor` artifact has been dropped and its functionality has been moved to another artifact.

Help is needed.  @actyp ?