### PR TITLE
Fix SocketClosedAsTimeout

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SulWrapperStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SulWrapperStandard.java
@@ -62,19 +62,13 @@ public class SulWrapperStandard<I, O, E> implements SulWrapper<I, O, E> {
             abstractSul.setDynamicPortProvider((DynamicPortProvider) wrappedSul);
         }
 
-        O socketClosed;
-        if (abstractSul.getMapper().getMapperConfig().isSocketClosedAsTimeout()) {
-            socketClosed = abstractSul.getMapper().getOutputBuilder().buildTimeout();
-        } else {
-            socketClosed = abstractSul.getMapper().getOutputBuilder().buildSocketClosed();
-        }
-
-        wrappedSul = new SulLivenessWrapper<>(wrappedSul, sulLivenessTracker, socketClosed);
+        O terminatedOutput = abstractSul.getMapper().getOutputBuilder().buildSocketClosed();
+        wrappedSul = new SulLivenessWrapper<>(wrappedSul, sulLivenessTracker, terminatedOutput);
 
         wrappedSul = new CounterSUL<>(wrappedSul);
-
         inputCounter = CounterSUL.class.cast(wrappedSul).getSymbolCounter();
         testCounter = CounterSUL.class.cast(wrappedSul).getResetCounter();
+
         return this;
     }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/OutputBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/OutputBuilder.java
@@ -1,30 +1,52 @@
 package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
- * Interface for building output symbols.
+ * Abstract class for building output symbols.
  *
  * @param <O>  the type of outputs
  */
-public interface OutputBuilder<O> {
+public abstract class OutputBuilder<O> {
     /** Special output symbol to show that no response was received during the waiting time. */
-    static final String TIMEOUT = "TIMEOUT";
+    public static final String TIMEOUT = "TIMEOUT";
 
     /** Special output symbol to show that the response could not be identified. */
-    static final String UNKNOWN = "UNKNOWN";
+    public static final String UNKNOWN = "UNKNOWN";
 
     /** Special output symbol to show that the SUL process has terminated. */
-    static final String SOCKET_CLOSED = "SOCKET_CLOSED";
+    public static final String SOCKET_CLOSED = "SOCKET_CLOSED";
 
     /** Special output symbol to show that the output is disabled. */
-    static final String DISABLED = "DISABLED";
+    public static final String DISABLED = "DISABLED";
+
+    /** Stores the map containing user specific replacements of symbols. */
+    protected Map<String, String> userSpecificMap = new LinkedHashMap<>();
 
     /**
-     * Builds an output symbol given its name.
+     * Builds the exact output symbol corresponding to the provided name.
      *
      * @param name  the name of the output symbol
      * @return      the output symbol
      */
-    O buildOutput(String name);
+    public abstract O buildOutputExact(String name);
+
+    /**
+     * Builds an output symbol given its name respecting the {@link #userSpecificMap}.
+     * <p>
+     * If there is a replacement in the {@link #userSpecificMap} for the provided
+     * name, then the replacement is used instead.
+     * <p>
+     * The {@link #userSpecificMap} is mostly used for special symbol replacements,
+     * stemming from the user-specified mapper configuration.
+     *
+     * @param name  the name of the output symbol
+     * @return      the output symbol
+     */
+    public O buildOutput(String name) {
+        return buildOutputExact(userSpecificMap.getOrDefault(name, name));
+    }
 
     /**
      * Builds the special output symbol for timeout.
@@ -33,7 +55,7 @@ public interface OutputBuilder<O> {
      *
      * @return  the special output symbol for timeout
      */
-    default O buildTimeout() {
+    public O buildTimeout() {
         return buildOutput(TIMEOUT);
     }
 
@@ -44,7 +66,7 @@ public interface OutputBuilder<O> {
      *
      * @return  the special output symbol for unknown
      */
-    default O buildUnknown() {
+    public O buildUnknown() {
         return buildOutput(UNKNOWN);
     }
 
@@ -55,7 +77,7 @@ public interface OutputBuilder<O> {
      *
      * @return  the special output symbol for socket closed
      */
-    default O buildSocketClosed() {
+    public O buildSocketClosed() {
         return buildOutput(SOCKET_CLOSED);
     }
 
@@ -66,7 +88,16 @@ public interface OutputBuilder<O> {
      *
      * @return  the special output symbol for disabled
      */
-    default O buildDisabled() {
+    public O buildDisabled() {
         return buildOutput(DISABLED);
+    }
+
+    /**
+     * Returns the stored {@link #userSpecificMap}.
+     *
+     * @return the stored {@link #userSpecificMap}.
+     */
+    public Map<String, String> getUserSpecificMap() {
+        return this.userSpecificMap;
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposer.java
@@ -66,9 +66,9 @@ implements Mapper<I, O, E> {
     }
 
     /**
-     * Returns the OutputChecker contained in the {@link #outputMapper}.
+     * Returns the OutputBuilder contained in the {@link #outputMapper}.
      *
-     * @return  the OutputChecker contained in the {@link #outputMapper}
+     * @return  the OutputBuilder contained in the {@link #outputMapper}
      */
     @Override
     public OutputBuilder<O> getOutputBuilder() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposerRA.java
@@ -64,9 +64,9 @@ public class MapperComposerRA<D, P, E extends ExecutionContext<D, D, S>, S>
     }
 
     /**
-     * Returns the OutputChecker contained in the {@link #outputMapper}.
+     * Returns the OutputBuilder contained in the {@link #outputMapper}.
      *
-     * @return the OutputChecker contained in the {@link #outputMapper}
+     * @return the OutputBuilder contained in the {@link #outputMapper}
      */
     @Override
     public OutputBuilder<D> getOutputBuilder() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapper.java
@@ -44,6 +44,10 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
 
     /**
      * Constructs a new instance from the given parameter.
+     * <p>
+     * It also updates the userSpecificMap of the OutputBuilder
+     * according to the mapperConfig's special symbol replacement preferences
+     * {@link MapperConfig#isSocketClosedAsTimeout()}, {@link MapperConfig#isDisabledAsTimeout()}.
      *
      * @param mapperConfig   the configuration of the Mapper
      * @param outputBuilder  the builder of the output symbols
@@ -53,6 +57,14 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
         this.mapperConfig = mapperConfig;
         this.outputBuilder = outputBuilder;
         this.outputChecker = outputChecker;
+
+        if (mapperConfig.isSocketClosedAsTimeout()) {
+            outputBuilder.getUserSpecificMap().put(OutputBuilder.SOCKET_CLOSED, OutputBuilder.TIMEOUT);
+        }
+
+        if (mapperConfig.isDisabledAsTimeout()) {
+            outputBuilder.getUserSpecificMap().put(OutputBuilder.DISABLED, OutputBuilder.TIMEOUT);
+        }
     }
 
     /**
@@ -97,9 +109,6 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      *
      * @return  the timeout symbol or the socket closed symbol */
     public O socketClosed() {
-        if (mapperConfig.isSocketClosedAsTimeout()) {
-            return outputBuilder.buildTimeout();
-        }
         return outputBuilder.buildSocketClosed();
     }
 
@@ -110,9 +119,6 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      * @return  the timeout symbol or the disabled symbol
      */
     public O disabled() {
-        if (mapperConfig.isDisabledAsTimeout()) {
-            return outputBuilder.buildTimeout();
-        }
         return outputBuilder.buildDisabled();
     }
 

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/MockMapper.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/MockMapper.java
@@ -14,7 +14,7 @@ public class MockMapper  implements Mapper<PSymbolInstance, PSymbolInstance, Obj
     public MockMapper() {
         outputBuilder = new OutputBuilder<PSymbolInstance>() {
             @Override
-            public PSymbolInstance buildOutput(String name) {
+            public PSymbolInstance buildOutputExact(String name) {
                 return null;
             }
         };

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASul.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASul.java
@@ -81,7 +81,7 @@ public class RASul implements AbstractSul<PSymbolInstance, PSymbolInstance, Obje
         RAMockMapper() {
             this.outputBuilder = new OutputBuilder<PSymbolInstance>() {
                 @Override
-                public PSymbolInstance buildOutput(String name) {
+                public PSymbolInstance buildOutputExact(String name) {
                     return null;
                 }
             };


### PR DESCRIPTION
Regarding #91, I think I found a less invasive way that keeps the current structure of the Mapper and requires two slight changes on the user code.

Specifically, I converted the `OutputBuilder` to an abstract class and added a `userSpecificMap` which holds the symbol replacements according to the `MapperConfig`. The `userSpecificMap` is filled during the initialization of the `OutputMapper`.

The required changes to users of `ProtocolStateFuzzer` are on the implementation of the `OutputBuilder`, since it changed from an interface to an abstract class and on one of its methods. In other words:

- **extend** the `OutputBuilder` 
- implement **`buildOutputExact`** instead of `buildOutput`


Here is an example of a modified `OutputBuilderImpl`:
```java
public class OutputBuilderImpl extends OutputBuilder<OutputImpl> {
     @Override
     public OutputImpl buildOutputExact(String name) {
         return new OutputImpl(name);
     }
 }

```