### PR TITLE
Add parallelization capability to RandomWpMethodEQOracle

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
@@ -19,7 +19,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return the associated SulConfig
+     * @return  the associated SulConfig
      */
     default SulConfig getSulConfig() {
         return null;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
@@ -3,6 +3,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningAlgorithmName;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.RunDescriptionPrinter;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 
 import java.io.PrintWriter;
 import java.time.Duration;
@@ -12,6 +13,17 @@ import java.util.List;
  * Interface regarding the learning configuration.
  */
 public interface LearnerConfig extends RunDescriptionPrinter {
+
+    /**
+     * Returns the associated SulConfig.
+     * <p>
+     * Default value: null.
+     *
+     * @return the associated SulConfig
+     */
+    default SulConfig getSulConfig() {
+        return null;
+    }
 
     /**
      * Returns the filename of the alphabet to be used for learning.

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
@@ -3,7 +3,6 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningAlgorithmName;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.RunDescriptionPrinter;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 
 import java.io.PrintWriter;
 import java.time.Duration;
@@ -13,17 +12,6 @@ import java.util.List;
  * Interface regarding the learning configuration.
  */
 public interface LearnerConfig extends RunDescriptionPrinter {
-
-    /**
-     * Returns the associated SulConfig.
-     * <p>
-     * Default value: null.
-     *
-     * @return  the associated SulConfig
-     */
-    default SulConfig getSulConfig() {
-        return null;
-    }
 
     /**
      * Returns the filename of the alphabet to be used for learning.
@@ -335,6 +323,17 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      */
     default Boolean getDrawSymbolsUniformly() {
         return true;
+    }
+
+    /**
+     * Returns the number of threads to be used for the SULs.
+     * <p>
+     * Default value: 1.
+     *
+     * @return  the number of threads to be used for the SULs
+     */
+    default int getEquivalenceThreadCount() {
+        return 1;
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
@@ -285,7 +285,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Sets the SulConfig.
      *
-     * @param sulConfig the SulConfig to be set
+     * @param sulConfig  the SulConfig to be set
      */
     public void setSulConfig(SulConfig sulConfig) {
         this.sulConfig = sulConfig;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
@@ -3,7 +3,6 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config
 import com.beust.jcommander.Parameter;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningAlgorithmName;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 
 import java.time.Duration;
 import java.util.List;
@@ -279,22 +278,15 @@ public class LearnerConfigStandard implements LearnerConfig {
             + "statistics for the incomplete learning run are published.")
     protected Integer roundLimit = null;
 
-    /** Stores the SulConfig. */
-    protected SulConfig sulConfig;
-
     /**
-     * Sets the SulConfig.
-     *
-     * @param sulConfig  the SulConfig to be set
+     * Stores the JCommander Parameter -threadCount.
+     * <p>
+     * The number of threads to be used for the SULs.
+     * <p>
+     * Default value: 1.
      */
-    public void setSulConfig(SulConfig sulConfig) {
-        this.sulConfig = sulConfig;
-    }
-
-    @Override
-    public SulConfig getSulConfig() {
-        return sulConfig;
-    }
+    @Parameter(names = {"-equivalenceThreadCount"}, description = "The number of threads to parallel RandomWpMethodEQOracle (we only support this method right now)")
+    protected Integer equivalenceThreadCount = 1;
 
     @Override
     public String getAlphabetFilename() {
@@ -510,4 +502,15 @@ public class LearnerConfigStandard implements LearnerConfig {
     public Integer getRoundLimit() {
         return roundLimit;
     }
+
+    /**
+     * Returns the stored value of {@link #equivalenceThreadCount}.
+     *
+     * @return  the stored value of {@link #equivalenceThreadCount}
+     */
+    @Override
+    public int getEquivalenceThreadCount() {
+        return equivalenceThreadCount;
+    }
+
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
@@ -279,13 +279,13 @@ public class LearnerConfigStandard implements LearnerConfig {
     protected Integer roundLimit = null;
 
     /**
-     * Stores the JCommander Parameter -threadCount.
+     * Stores the JCommander Parameter -equivalenceThreadCount, -eqvThreads.
      * <p>
      * The number of threads to be used for the SULs.
      * <p>
      * Default value: 1.
      */
-    @Parameter(names = {"-equivalenceThreadCount"}, description = "The number of threads to parallel RandomWpMethodEQOracle (we only support this method right now)")
+    @Parameter(names = {"-equivalenceThreadCount", "-eqvThreads"}, description = "The number of threads to parallel RandomWpMethodEQOracle (we only support this method right now)")
     protected Integer equivalenceThreadCount = 1;
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
@@ -3,6 +3,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config
 import com.beust.jcommander.Parameter;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningAlgorithmName;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 
 import java.time.Duration;
 import java.util.List;
@@ -277,6 +278,23 @@ public class LearnerConfigStandard implements LearnerConfig {
             + "and with that, the number of hypotheses generated. Once the limit is reached, learning is stopped and "
             + "statistics for the incomplete learning run are published.")
     protected Integer roundLimit = null;
+
+    /** Stores the SulConfig. */
+    protected SulConfig sulConfig;
+
+    /**
+     * Sets the SulConfig.
+     *
+     * @param sulConfig the SulConfig to be set
+     */
+    public void setSulConfig(SulConfig sulConfig) {
+        this.sulConfig = sulConfig;
+    }
+
+    @Override
+    public SulConfig getSulConfig() {
+        return sulConfig;
+    }
 
     @Override
     public String getAlphabetFilename() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -250,7 +250,7 @@ public class LearningSetupFactory {
             case RANDOM_WP_METHOD ->
                 new RandomWpMethodEQOracle<>(
                         sulOracles, config.getMinLength(), config.getRandLength(),
-                        config.getEquivQueryBound(), config.getSeed(), config.getSulConfig().getThreadCount());
+                        config.getEquivQueryBound(), config.getSeed(), config.getEquivalenceThreadCount());
 
             case SAMPLED_TESTS ->
                 new SampledTestsEQOracle<I, O>(readTests(config, alphabet), sulOracles.get(0));

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -154,8 +154,8 @@ public class LearningSetupFactory {
      * @param <I>         the type of inputs
      * @param <O>         the type of outputs
      * @param config      the learner configuration to be used
-     * @param suls        the set of suls that are contained inside the sulOracles
-     * @param sulOracles  the set of sul oracles to be used that contains the suls
+     * @param suls        the list of suls that are contained inside the sulOracles
+     * @param sulOracles  the list of sul oracles to be used that contains the suls
      * @param alphabet    the alphabet to be used
      * @return            the created Equivalence Oracle
      */
@@ -222,8 +222,8 @@ public class LearningSetupFactory {
      * @param <O>         the type of outputs
      * @param algorithm   the Equivalence algorithm name
      * @param config      the learner configuration to be used
-     * @param suls        the set of suls that are contained inside the sulOracles
-     * @param sulOracles  the set of sul oracles to be used that contains the suls
+     * @param suls        the list of suls that are contained inside the sulOracles
+     * @param sulOracles  the list of sul oracles to be used that contains the suls
      * @param alphabet    the alphabet to be used
      * @return            the created Equivalence Oracle
      */

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -250,7 +250,7 @@ public class LearningSetupFactory {
             case RANDOM_WP_METHOD ->
                 new RandomWpMethodEQOracle<>(
                         sulOracles, config.getMinLength(), config.getRandLength(),
-                        config.getEquivQueryBound(), config.getSeed());
+                        config.getEquivQueryBound(), config.getSeed(), config.getSulConfig().getThreadCount());
 
             case SAMPLED_TESTS ->
                 new SampledTestsEQOracle<I, O>(readTests(config, alphabet), sulOracles.get(0));

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -151,13 +151,13 @@ public class LearningSetupFactory {
     /**
      * Create a new Equivalence Oracle from the given parameters.
      *
-     * @param <I>        the type of inputs
-     * @param <O>        the type of outputs
-     * @param config     the learner configuration to be used
-     * @param suls        the sul that is contained inside the sulOracle
-     * @param sulOracles  the sul oracle to be used that contains the sul
-     * @param alphabet   the alphabet to be used
-     * @return           the created Equivalence Oracle
+     * @param <I>         the type of inputs
+     * @param <O>         the type of outputs
+     * @param config      the learner configuration to be used
+     * @param suls        the suls that are contained inside the sulOracles
+     * @param sulOracles  the sul oracles to be used that contains the suls
+     * @param alphabet    the alphabet to be used
+     * @return            the created Equivalence Oracle
      */
     public static <I, O> EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>> createEquivalenceOracle(
             LearnerConfig config,
@@ -215,17 +215,17 @@ public class LearningSetupFactory {
      * Create a new Equivalence Oracle for the Equivalence algorithm specified
      * and the given parameters.
      * <p>
-     * The sul parameter is needed, because it cannot be extracted from the
-     * sulOracle parameter.
+     * The suls parameter is needed, because it cannot be extracted from the
+     * sulOracles parameter.
      *
-     * @param <I>        the type of inputs
-     * @param <O>        the type of outputs
-     * @param algorithm  the Equivalence algorithm name
-     * @param config     the learner configuration to be used
-     * @param suls        the sul that is contained inside the sulOracle
-     * @param sulOracles  the sul oracle to be used that contains the sul
-     * @param alphabet   the alphabet to be used
-     * @return           the created Equivalence Oracle
+     * @param <I>         the type of inputs
+     * @param <O>         the type of outputs
+     * @param algorithm   the Equivalence algorithm name
+     * @param config      the learner configuration to be used
+     * @param suls        the suls that are contained inside the sulOracles
+     * @param sulOracles  the sul oracles to be used that contains the suls
+     * @param alphabet    the alphabet to be used
+     * @return            the created Equivalence Oracle
      */
     protected static <I, O> EquivalenceOracle.MealyEquivalenceOracle<I, O> createEquivalenceOracleForAlgorithm(
         EquivalenceAlgorithmName algorithm,

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -250,7 +250,7 @@ public class LearningSetupFactory {
             case RANDOM_WP_METHOD ->
                 new RandomWpMethodEQOracle<>(
                         sulOracles, config.getMinLength(), config.getRandLength(),
-                        config.getEquivQueryBound(), config.getSeed(), config.getEquivalenceThreadCount());
+                        config.getEquivQueryBound(), config.getSeed());
 
             case SAMPLED_TESTS ->
                 new SampledTestsEQOracle<I, O>(readTests(config, alphabet), sulOracles.get(0));

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -154,8 +154,8 @@ public class LearningSetupFactory {
      * @param <I>         the type of inputs
      * @param <O>         the type of outputs
      * @param config      the learner configuration to be used
-     * @param suls        the suls that are contained inside the sulOracles
-     * @param sulOracles  the sul oracles to be used that contains the suls
+     * @param suls        the set of suls that are contained inside the sulOracles
+     * @param sulOracles  the set of sul oracles to be used that contains the suls
      * @param alphabet    the alphabet to be used
      * @return            the created Equivalence Oracle
      */
@@ -222,8 +222,8 @@ public class LearningSetupFactory {
      * @param <O>         the type of outputs
      * @param algorithm   the Equivalence algorithm name
      * @param config      the learner configuration to be used
-     * @param suls        the suls that are contained inside the sulOracles
-     * @param sulOracles  the sul oracles to be used that contains the suls
+     * @param suls        the set of suls that are contained inside the sulOracles
+     * @param sulOracles  the set of sul oracles to be used that contains the suls
      * @param alphabet    the alphabet to be used
      * @return            the created Equivalence Oracle
      */

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -46,7 +46,7 @@ import java.util.Random;
 public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
 
     /** Stores the constructor parameter. */
-    protected MealyMembershipOracle<I, O>  sulOracle;
+    protected List<MealyMembershipOracle<I, O>>  sulOracles;
 
     /** Stores the constructor parameter. */
     protected int minimalSize;
@@ -63,15 +63,15 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Constructs a new instance from the given parameters, which represents an unbounded testing oracle.
      *
-     * @param sulOracle    the oracle which answers tests
+     * @param sulOracles    the oracle which answers tests
      * @param minimalSize  the minimal size of the random word
      * @param rndLength    the expected length (in addition to minimalSize) of random word
      * @param seed         the seed to be used for randomness
      */
-    public RandomWpMethodEQOracle(MealyMembershipOracle<I, O> sulOracle,
+    public RandomWpMethodEQOracle(List<MealyMembershipOracle<I, O>> sulOracles,
         int minimalSize, int rndLength, long seed) {
 
-        this.sulOracle = sulOracle;
+        this.sulOracles = sulOracles;
         this.minimalSize = minimalSize;
         this.rndLength = rndLength;
         this.seed = seed;
@@ -81,16 +81,16 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Constructs a new instance from the given parameters, which represents a bounded testing oracle.
      *
-     * @param sulOracle    the oracle which answers tests
+     * @param sulOracles    the oracle which answers tests
      * @param minimalSize  the minimal size of the random word
      * @param rndLength    the expected length (in addition to minimalSize) of random word
      * @param bound        the bound (set to 0 for unbounded).
      * @param seed         the seed to be used for randomness
      */
-    public RandomWpMethodEQOracle(MealyMembershipOracle<I, O> sulOracle,
+    public RandomWpMethodEQOracle(List<MealyMembershipOracle<I, O>> sulOracles,
         int minimalSize, int rndLength, int bound, long seed) {
 
-        this.sulOracle = sulOracle;
+        this.sulOracles = sulOracles;
         this.minimalSize = minimalSize;
         this.rndLength = rndLength;
         this.bound = bound;
@@ -144,7 +144,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
             Word<O> hypOutput = hypothesis.computeOutput(queryWord);
             DefaultQuery<I, Word<O>> query = new DefaultQuery<>(queryWord);
 
-            sulOracle.processQueries(Collections.singleton(query));
+            sulOracles.get(0).processQueries(Collections.singleton(query));
 
             if (!Objects.equals(hypOutput, query.getOutput())) {
                 return query;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -138,7 +138,8 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
         try{
-            while (bound == 0 || currentBound-- > 0) {
+            while (bound == 0 || currentBound > 0) {
+                currentBound -= threadCount;
                 List<DefaultQuery<I, Word<O>>> queries = new ArrayList<>(threadCount);
                 for (int i = 0; i < threadCount; i++) {
                     WordBuilder<I> wb = new WordBuilder<>(minimalSize + rndLength + 1);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -61,8 +61,6 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /** Stores the constructor parameter. */
     protected long seed;
 
-    /** Stores the thread count for parallel execution. */
-    protected int threadCount = 1;
 
     /**
      * Constructs a new instance from the given parameters, which represents an unbounded testing oracle.
@@ -90,17 +88,15 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
      * @param rndLength    the expected length (in addition to minimalSize) of random word
      * @param bound        the bound (set to 0 for unbounded).
      * @param seed         the seed to be used for randomness
-     * @param threadCount  the number of threads
      */
     public RandomWpMethodEQOracle(List<MealyMembershipOracle<I, O>> sulOracles,
-        int minimalSize, int rndLength, int bound, long seed, int threadCount) {
+        int minimalSize, int rndLength, int bound, long seed) {
 
         this.sulOracles = sulOracles;
         this.minimalSize = minimalSize;
         this.rndLength = rndLength;
         this.bound = bound;
         this.seed = seed;
-        this.threadCount = threadCount;
     }
 
     /**
@@ -133,7 +129,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
         List<S> states = new ArrayList<>(hypothesis.getStates());
         int queriesLeft = bound;
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(sulOracles.size());
         final int BATCH_SIZE = 100;
         BlockingQueue<MealyMembershipOracle<I, O>> oraclePool = new LinkedBlockingQueue<>(sulOracles);
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -6,6 +6,8 @@ import de.learnlib.query.DefaultQuery;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -61,6 +63,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /** Stores the constructor parameter. */
     protected long seed;
 
+    private static final Logger LOGGER = LogManager.getLogger();
 
     /**
      * Constructs a new instance from the given parameters, which represents an unbounded testing oracle.
@@ -170,12 +173,12 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
                                 return query;  // Find counterexample
                             }
                         } catch (Exception e) {
-                            System.err.println("[ERROR] process query: " + e.getMessage());
+                            LOGGER.error("[ERROR] process query: " + e.getMessage());
                         } finally {
                             if (oracle != null){
                                 boolean result = oraclePool.offer(oracle);
                                 if (!result) {
-                                    System.err.println("[ERROR] Failed to return oracle to pool - this should not happen");
+                                    LOGGER.error("[ERROR] Failed to return oracle to pool - this should not happen");
                                 }
                             }
                         }
@@ -194,7 +197,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
                             return counterExample;
                         }
                     } catch (Exception e) {
-                        System.err.println("[ERROR] try to find counterexample: " + e.getMessage());
+                        LOGGER.error("[ERROR] try to find counterexample: " + e.getMessage());
                     }
                 }
             }
@@ -203,7 +206,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
             try {
                 executor.awaitTermination(600, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
-                System.err.println("[Error] Executor did not terminate within 600 seconds!");
+                LOGGER.error("[Error] Executor did not terminate within 600 seconds!");
             }
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -179,7 +179,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
                             if (oracle != null){
                                 boolean result = oraclePool.offer(oracle);
                                 if (!result) {
-                                    throw new RuntimeException("This exception should not happen");
+                                    System.err.println("[ERROR] Failed to return oracle to pool - this should not happen");
                                 }
                             }
                         }
@@ -207,7 +207,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
             try {
                 executor.awaitTermination(600, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
-                throw new RuntimeException("This exception should not happen");
+                System.err.println("[Error] Executor did not terminate within 600 seconds!");
             }
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -69,7 +69,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Constructs a new instance from the given parameters, which represents an unbounded testing oracle.
      *
-     * @param sulOracles    the oracle which answers tests
+     * @param sulOracles   the oracles which answer tests
      * @param minimalSize  the minimal size of the random word
      * @param rndLength    the expected length (in addition to minimalSize) of random word
      * @param seed         the seed to be used for randomness
@@ -87,7 +87,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Constructs a new instance from the given parameters, which represents a bounded testing oracle.
      *
-     * @param sulOracles    the oracle which answers tests
+     * @param sulOracles   the oracles which answer tests
      * @param minimalSize  the minimal size of the random word
      * @param rndLength    the expected length (in addition to minimalSize) of random word
      * @param bound        the bound (set to 0 for unbounded).
@@ -187,8 +187,6 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
                         System.err.println("[ERROR] try to find counterexample: " + e.getMessage());
                     }
                 }
-
-                System.out.print(threadCount + " ");    // so we can know this function is working
             }
         } finally {
             executor.shutdown();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -6,8 +6,6 @@ import de.learnlib.query.DefaultQuery;
 import net.automatalib.automaton.transducer.MealyMachine;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -63,8 +61,6 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
 
     /** Stores the constructor parameter. */
     protected long seed;
-
-    private static final Logger LOGGER = LogManager.getLogger();
 
     /**
      * Constructs a new instance from the given parameters, which represents an unbounded testing oracle.

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -137,7 +137,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
 
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
-        try{
+        try {
             while (bound == 0 || currentBound > 0) {
                 currentBound -= threadCount;
                 List<DefaultQuery<I, Word<O>>> queries = new ArrayList<>(threadCount);
@@ -190,7 +190,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
 
                 System.out.print(threadCount + " ");    // so we can know this function is working
             }
-        }finally {
+        } finally {
             executor.shutdown();
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
@@ -1,0 +1,31 @@
+package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics;
+
+import de.learnlib.filter.statistic.Counter;
+
+import java.util.List;
+
+public class AggregatedCounter extends Counter {
+
+    private final List<Counter> counters;
+
+    public AggregatedCounter(List<Counter> counters) {
+        super("AggregatedCounter", "#");
+        this.counters = counters;
+    }
+
+    @Override
+    public long getCount() {
+        long total = 0;
+        for (Counter counter : counters) {
+            total += counter.getCount();
+        }
+        return total;
+    }
+
+    @Override
+    public void increment() {
+        throw new UnsupportedOperationException(
+                "Increment should be called on individual counters, not on the aggregated counter"
+        );
+    }
+}

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
@@ -4,10 +4,28 @@ import de.learnlib.filter.statistic.Counter;
 
 import java.util.List;
 
+/**
+ * Aggregates multiple counters for parallel execution scenarios.
+ * <p>
+ * The aggregated counter only supports read operations ({@link #getCount()}).
+ * Write operations ({@link #increment()}) should be performed on the individual
+ * counters that make up this aggregation.
+ * </p>
+ */
 public class AggregatedCounter extends Counter {
 
+    /** The list of individual counters to aggregate. */
     private final List<Counter> counters;
 
+    /**
+     * Constructs a new AggregatedCounter with the specified list of counters.
+     * <p>
+     * The aggregated counter will sum the counts from all provided counters
+     * when {@link #getCount()} is called.
+     * </p>
+     *
+     * @param counters a list of {@link Counter} instances to aggregate.
+     */
     public AggregatedCounter(List<Counter> counters) {
         super("AggregatedCounter", "#");
         this.counters = counters;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
@@ -24,7 +24,7 @@ public class AggregatedCounter extends Counter {
      * when {@link #getCount()} is called.
      * </p>
      *
-     * @param counters a list of {@link Counter} instances to aggregate.
+     * @param counters  a list of {@link Counter} instances to aggregate.
      */
     public AggregatedCounter(List<Counter> counters) {
         super("AggregatedCounter", "#");

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulAdapterConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulAdapterConfigStandard.java
@@ -40,8 +40,8 @@ public class SulAdapterConfigStandard implements SulAdapterConfig {
 
     /**
      *
-     * @param adapterPort the adapterPort to set
-     * @param adapterAddress the adapterAddress to set
+     * @param adapterPort     the adapterPort to set
+     * @param adapterAddress  the adapterAddress to set
      */
     public SulAdapterConfigStandard(int adapterPort, String adapterAddress) {
         this.adapterPort = adapterPort;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulAdapterConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulAdapterConfigStandard.java
@@ -37,4 +37,11 @@ public class SulAdapterConfigStandard implements SulAdapterConfig {
     public String getAdapterAddress() {
         return adapterAddress;
     }
+
+    public SulAdapterConfigStandard(int adapterPort, String adapterAddress) {
+        this.adapterPort = adapterPort;
+        this.adapterAddress = adapterAddress;
+    }
+
+    public SulAdapterConfigStandard() {   }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulAdapterConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulAdapterConfigStandard.java
@@ -38,10 +38,18 @@ public class SulAdapterConfigStandard implements SulAdapterConfig {
         return adapterAddress;
     }
 
+    /**
+     *
+     * @param adapterPort the adapterPort to set
+     * @param adapterAddress the adapterAddress to set
+     */
     public SulAdapterConfigStandard(int adapterPort, String adapterAddress) {
         this.adapterPort = adapterPort;
         this.adapterAddress = adapterAddress;
     }
 
+    /**
+     * Constructor
+     */
     public SulAdapterConfigStandard() {   }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfig.java
@@ -19,14 +19,14 @@ public interface SulConfig extends RunDescriptionPrinter {
      *
      * @return  the number of threads to be used for the SULs
      */
-    default Integer getThreadCount() {
+    default int getThreadCount() {
         return 1;
     }
 
     /**
      * Return a new instance of SulConfig with the given threadId.
-     * @param threadId used to change the port number
-     * @return a new instance of SulConfig
+     * @param threadId  used to change the port number
+     * @return          a new instance of SulConfig
      */
     default SulConfig cloneWithThreadId(int threadId){
         throw new UnsupportedOperationException("Not implemented yet! Your need to override this method.");

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfig.java
@@ -13,17 +13,6 @@ import java.util.Map;
 public interface SulConfig extends RunDescriptionPrinter {
 
     /**
-     * Returns the number of threads to be used for the SULs.
-     * <p>
-     * Default value: 1.
-     *
-     * @return  the number of threads to be used for the SULs
-     */
-    default int getThreadCount() {
-        return 1;
-    }
-
-    /**
      * Return a new instance of SulConfig with the given threadId.
      * @param threadId  used to change the port number
      * @return          a new instance of SulConfig

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfig.java
@@ -13,6 +13,26 @@ import java.util.Map;
 public interface SulConfig extends RunDescriptionPrinter {
 
     /**
+     * Returns the number of threads to be used for the SULs.
+     * <p>
+     * Default value: 1.
+     *
+     * @return  the number of threads to be used for the SULs
+     */
+    default Integer getThreadCount() {
+        return 1;
+    }
+
+    /**
+     * Return a new instance of SulConfig with the given threadId.
+     * @param threadId used to change the port number
+     * @return a new instance of SulConfig
+     */
+    default SulConfig cloneWithThreadId(int threadId){
+        throw new UnsupportedOperationException("Not implemented yet! Your need to override this method.");
+    }
+
+    /**
      * Returns the role of the SUL under fuzzing that could be either "client" or "server".
      * <p>
      * Default value: {@code "client"}.

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigStandard.java
@@ -14,6 +14,16 @@ import java.util.Map;
 public abstract class SulConfigStandard implements SulConfig {
 
     /**
+     * Stores the JCommander Parameter -threadCount.
+     * <p>
+     * The number of threads to be used for the SULs.
+     * <p>
+     * Default value: 1.
+     */
+    @Parameter(names = {"-threadCount", "-tc"}, description = "The number of threads to parallel RandomWpMethodEQOracle (we only support this method right now)")
+    protected Integer threadCount = 1;
+
+    /**
      * Stores the JCommander Parameter -responseWait, -respWait.
      * <p>
      * Time (ms) the SUL spends waiting for a response.
@@ -131,6 +141,16 @@ public abstract class SulConfigStandard implements SulConfig {
     public SulConfigStandard(MapperConfig mapperConfig, SulAdapterConfig sulAdapterConfig) {
         this.mapperConfig = mapperConfig == null ? new MapperConfig(){} : mapperConfig;
         this.sulAdapterConfig = sulAdapterConfig == null ? new SulAdapterConfig(){} : sulAdapterConfig;
+    }
+
+    /**
+     * Returns the stored value of {@link #threadCount}.
+     *
+     * @return  the stored value of {@link #threadCount}
+     */
+    @Override
+    public Integer getThreadCount() {
+        return threadCount;
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigStandard.java
@@ -149,7 +149,7 @@ public abstract class SulConfigStandard implements SulConfig {
      * @return  the stored value of {@link #threadCount}
      */
     @Override
-    public Integer getThreadCount() {
+    public int getThreadCount() {
         return threadCount;
     }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SulConfigStandard.java
@@ -14,16 +14,6 @@ import java.util.Map;
 public abstract class SulConfigStandard implements SulConfig {
 
     /**
-     * Stores the JCommander Parameter -threadCount.
-     * <p>
-     * The number of threads to be used for the SULs.
-     * <p>
-     * Default value: 1.
-     */
-    @Parameter(names = {"-threadCount", "-tc"}, description = "The number of threads to parallel RandomWpMethodEQOracle (we only support this method right now)")
-    protected Integer threadCount = 1;
-
-    /**
      * Stores the JCommander Parameter -responseWait, -respWait.
      * <p>
      * Time (ms) the SUL spends waiting for a response.
@@ -141,16 +131,6 @@ public abstract class SulConfigStandard implements SulConfig {
     public SulConfigStandard(MapperConfig mapperConfig, SulAdapterConfig sulAdapterConfig) {
         this.mapperConfig = mapperConfig == null ? new MapperConfig(){} : mapperConfig;
         this.sulAdapterConfig = sulAdapterConfig == null ? new SulAdapterConfig(){} : sulAdapterConfig;
-    }
-
-    /**
-     * Returns the stored value of {@link #threadCount}.
-     *
-     * @return  the stored value of {@link #threadCount}
-     */
-    @Override
-    public int getThreadCount() {
-        return threadCount;
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -14,6 +14,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statist
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.AbstractSul;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapper;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerEnabler;
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
@@ -64,7 +65,7 @@ implements StateFuzzerComposer<I,
      * The sul that is built using the SulBuilder constructor parameter and
      * wrapped using the SulWrapper constructor parameter.
      */
-    protected SUL<I, O> sul;
+    protected List<SUL<I, O>> suls;
 
     /** The cache used by the learning oracles. */
     protected ObservationTree<I, O> cache;
@@ -123,17 +124,24 @@ implements StateFuzzerComposer<I,
         // initialize cleanup tasks
         this.cleanupTasks = new CleanupTasks();
 
+        this.suls = new ArrayList<>();
+
         // set up wrapped SUL (System Under Learning)
-        AbstractSul<I, O, E> abstractSul = sulBuilder.build(stateFuzzerEnabler.getSulConfig(), cleanupTasks);
-        this.sul = sulWrapper
-                .wrap(abstractSul)
-                .setTimeLimit(learnerConfig.getTimeLimit())
-                .setTestLimit(learnerConfig.getTestLimit())
-                .setLoggingWrapper("")
-                .getWrappedSul();
+        SulConfig sulConfig = stateFuzzerEnabler.getSulConfig();
+        for (Integer i = 0; i < sulConfig.getThreadCount(); i++) {
+            SulConfig config = (i==0) ? sulConfig : sulConfig.cloneWithThreadId(i);
+            AbstractSul<I, O, E> abstractSul = sulBuilder.build(config, cleanupTasks);
+            var sul = sulWrapper
+                    .wrap(abstractSul)
+                    .setTimeLimit(learnerConfig.getTimeLimit())
+                    .setTestLimit(learnerConfig.getTestLimit())
+                    .setLoggingWrapper("")
+                    .getWrappedSul();
+            this.suls.add(sul);
+        }
 
         // initialize the output for the socket closed
-        this.socketClosedOutput = abstractSul.getMapper().getOutputBuilder().buildOutputExact(OutputBuilder.SOCKET_CLOSED);
+        this.socketClosedOutput = sulBuilder.build(sulConfig, cleanupTasks).getMapper().getOutputBuilder().buildOutputExact(OutputBuilder.SOCKET_CLOSED);
 
         // initialize cache as observation tree
         this.cache = new ObservationTree<>();
@@ -236,7 +244,7 @@ implements StateFuzzerComposer<I,
      */
     protected void composeLearner(List<O> terminatingOutputs) {
 
-        MembershipOracle.MealyMembershipOracle<I, O> learningSulOracle = new SULOracle<>(sul);
+        MembershipOracle.MealyMembershipOracle<I, O> learningSulOracle = new SULOracle<>(suls.get(0));
 
         if (learnerConfig.getRunsPerMembershipQuery() > 1) {
             learningSulOracle = new MultipleRunsSULOracle<>(learnerConfig.getRunsPerMembershipQuery(),
@@ -270,21 +278,25 @@ implements StateFuzzerComposer<I,
      * @param terminatingOutputs  the terminating outputs used by the {@link CachingSULOracle}
      */
     protected void composeEquivalenceOracle(List<O> terminatingOutputs) {
+        List<MembershipOracle.MealyMembershipOracle<I, O>> equivalenceSulOracles = new ArrayList<>();
+        for (SUL<I, O> sul : suls) {
+            MembershipOracle.MealyMembershipOracle<I, O> equivalenceSulOracle = new SULOracle<>(sul);
 
-        MembershipOracle.MealyMembershipOracle<I, O> equivalenceSulOracle = new SULOracle<>(sul);
+            // in case sanitization is enabled, we apply a CE verification wrapper
+            // to check counterexamples before they are returned to the EQ oracle
+            if (learnerConfig.isCeSanitization()) {
+                equivalenceSulOracle = new CESanitizingSULOracle<MealyMachine<?, I, ?, O>, I, O>(
+                        learnerConfig.getCeReruns(), equivalenceSulOracle, learnerConfig.isProbabilisticSanitization(),
+                        nonDetWriter, learner::getHypothesisModel, cache, learnerConfig.isSkipNonDetTests());
+            }
 
-        // in case sanitization is enabled, we apply a CE verification wrapper
-        // to check counterexamples before they are returned to the EQ oracle
-        if (learnerConfig.isCeSanitization()) {
-            equivalenceSulOracle = new CESanitizingSULOracle<MealyMachine<?, I, ?, O>, I, O>(
-                learnerConfig.getCeReruns(), equivalenceSulOracle, learnerConfig.isProbabilisticSanitization(),
-                nonDetWriter, learner::getHypothesisModel, cache, learnerConfig.isSkipNonDetTests());
+            // we are adding a cache and a logging oracle
+            equivalenceSulOracle = new CachingSULOracle<>(equivalenceSulOracle, cache, !learnerConfig.isCacheTests(), terminatingOutputs);
+            equivalenceSulOracle = new LoggingSULOracle<>(equivalenceSulOracle);
+            equivalenceSulOracles.add(equivalenceSulOracle);
         }
 
-        // we are adding a cache and a logging oracle
-        equivalenceSulOracle = new CachingSULOracle<>(equivalenceSulOracle, cache, !learnerConfig.isCacheTests(), terminatingOutputs);
-        equivalenceSulOracle = new LoggingSULOracle<>(equivalenceSulOracle);
 
-        this.equivalenceOracle = LearningSetupFactory.createEquivalenceOracle(learnerConfig, sul, equivalenceSulOracle, alphabet);
+        this.equivalenceOracle = LearningSetupFactory.createEquivalenceOracle(learnerConfig, suls, equivalenceSulOracles, alphabet);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -121,10 +121,6 @@ implements StateFuzzerComposer<I,
         this.stateFuzzerEnabler = stateFuzzerEnabler;
         this.learnerConfig = stateFuzzerEnabler.getLearnerConfig();
 
-        if (this.learnerConfig instanceof LearnerConfigStandard) {
-            ((LearnerConfigStandard) this.learnerConfig).setSulConfig(stateFuzzerEnabler.getSulConfig());
-        }
-
         // de-serialize and build alphabet
         this.alphabetBuilder = alphabetBuilder;
         this.alphabet = alphabetBuilder.build(stateFuzzerEnabler.getLearnerConfig());
@@ -139,7 +135,7 @@ implements StateFuzzerComposer<I,
 
         // set up wrapped SUL (System Under Learning)
         SulConfig sulConfig = stateFuzzerEnabler.getSulConfig();
-        for (int i = 0; i < sulConfig.getThreadCount(); i++) {
+        for (int i = 0; i < learnerConfig.getEquivalenceThreadCount(); i++) {
             SulConfig config = (i==0) ? sulConfig : sulConfig.cloneWithThreadId(i);
             AbstractSul<I, O, E> abstractSul = sulBuilder.build(config, cleanupTasks);
 
@@ -150,7 +146,7 @@ implements StateFuzzerComposer<I,
                 currentSulWrapper = new SulWrapperStandard<>();
             }
 
-            var sul = currentSulWrapper
+            SUL<I, O> sul = currentSulWrapper
                     .wrap(abstractSul)
                     .setTimeLimit(learnerConfig.getTimeLimit())
                     .setTestLimit(learnerConfig.getTestLimit())

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -118,7 +118,7 @@ implements StateFuzzerComposer<I,
         this.stateFuzzerEnabler = stateFuzzerEnabler;
         this.learnerConfig = stateFuzzerEnabler.getLearnerConfig();
 
-        if(this.learnerConfig instanceof LearnerConfigStandard){
+        if (this.learnerConfig instanceof LearnerConfigStandard) {
             ((LearnerConfigStandard) this.learnerConfig).setSulConfig(stateFuzzerEnabler.getSulConfig());
         }
 
@@ -300,7 +300,6 @@ implements StateFuzzerComposer<I,
             equivalenceSulOracle = new LoggingSULOracle<>(equivalenceSulOracle);
             equivalenceSulOracles.add(equivalenceSulOracle);
         }
-
 
         this.equivalenceOracle = LearningSetupFactory.createEquivalenceOracle(learnerConfig, suls, equivalenceSulOracles, alphabet);
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -66,7 +66,7 @@ implements StateFuzzerComposer<I,
     protected Alphabet<I> alphabet;
 
     /**
-     * The sul that is built using the SulBuilder constructor parameter and
+     * The suls that are built using the SulBuilder constructor parameter and
      * wrapped using the SulWrapper constructor parameter.
      */
     protected List<SUL<I, O>> suls;
@@ -139,7 +139,7 @@ implements StateFuzzerComposer<I,
 
         // set up wrapped SUL (System Under Learning)
         SulConfig sulConfig = stateFuzzerEnabler.getSulConfig();
-        for (Integer i = 0; i < sulConfig.getThreadCount(); i++) {
+        for (int i = 0; i < sulConfig.getThreadCount(); i++) {
             SulConfig config = (i==0) ? sulConfig : sulConfig.cloneWithThreadId(i);
             AbstractSul<I, O, E> abstractSul = sulBuilder.build(config, cleanupTasks);
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -2,6 +2,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningSetupFactory;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.CESanitizingSULOracle;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.CachingSULOracle;
@@ -116,6 +117,10 @@ implements StateFuzzerComposer<I,
     ){
         this.stateFuzzerEnabler = stateFuzzerEnabler;
         this.learnerConfig = stateFuzzerEnabler.getLearnerConfig();
+
+        if(this.learnerConfig instanceof LearnerConfigStandard){
+            ((LearnerConfigStandard) this.learnerConfig).setSulConfig(stateFuzzerEnabler.getSulConfig());
+        }
 
         // de-serialize and build alphabet
         this.alphabetBuilder = alphabetBuilder;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -2,7 +2,6 @@ package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.LearningSetupFactory;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.CESanitizingSULOracle;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.CachingSULOracle;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
@@ -131,6 +131,7 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
 
         try {
             LOGGER.info("Input alphabet: {}", alphabet);
+            LOGGER.info("Thread Count: {}", stateFuzzerEnabler.getSulConfig().getThreadCount());
             LOGGER.info("Starting Learning" + System.lineSeparator());
             statisticsTracker.startLearning(stateFuzzerEnabler, alphabet);
             learner.startLearning();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
@@ -186,8 +186,6 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
         } catch (Exception e) {
             notFinishedReason = e.getMessage();
             LOGGER.error("Exception generated during learning\n" + e);
-            System.out.println(e.getMessage());
-            e.printStackTrace();
             // useful to log what actually went wrong
             try (PrintWriter pw = new PrintWriter(new FileWriter(new File(outputDir, ERROR_FILENAME), StandardCharsets.UTF_8))) {
                 pw.println(e.getMessage());

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
@@ -131,7 +131,7 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
 
         try {
             LOGGER.info("Input alphabet: {}", alphabet);
-            LOGGER.info("Thread Count: {}", stateFuzzerEnabler.getSulConfig().getThreadCount());
+            LOGGER.info("Equivalence Thread Count: {}", stateFuzzerEnabler.getLearnerConfig().getEquivalenceThreadCount());
             LOGGER.info("Starting Learning" + System.lineSeparator());
             statisticsTracker.startLearning(stateFuzzerEnabler, alphabet);
             learner.startLearning();
@@ -186,6 +186,8 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
         } catch (Exception e) {
             notFinishedReason = e.getMessage();
             LOGGER.error("Exception generated during learning\n" + e);
+            System.out.println(e.getMessage());
+            e.printStackTrace();
             // useful to log what actually went wrong
             try (PrintWriter pw = new PrintWriter(new FileWriter(new File(outputDir, ERROR_FILENAME), StandardCharsets.UTF_8))) {
                 pw.println(e.getMessage());


### PR DESCRIPTION
With this PR, we can specify how many threads we want to parallelize the **find counter example** phase in `RandomWpMethodEQOracle`.

Every XX-Fuzzer wants to use this parallelization need to override `SulConfig.java` interface  `cloneWithThreadId` method, which should return an independent sulConfig object that different threads will use. For example, for DTLS-Fuzzer, different threads should listen to different UDP ports, otherwise will have conflict, and that's why I added this method into the `SulConfig.java` interface.

I also provide a default implementation (just throw exception) for the  `cloneWithThreadId` method, so it should not break compilation for other projects.

Added new parameter:
`-threadCount` or `-tc`

This is not ready for merge yet, I didn't check how statistics works and I will look at it later this week.

I updated DTLS-Fuzzer with this branch, and you can see results in DTLS-Fuzzer PR: https://github.com/assist-project/dtls-fuzzer/pull/190