### PR TITLE
Refactor SulWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ public class MultiBuilder implements
 
     // ExecutionContextImpl, SulBuilderImpl need to be implemented
     protected SulBuilder<InputImpl, OutputImpl, ExecutionContextImpl> sulBuilder = new SulBuilderImpl();
-    protected SulWrapper<InputImpl, OutputImpl, ExecutionContextImpl> sulWrapper = new SulWrapperStandard<>();
 
     @Override
     public StateFuzzerClientConfig buildClientConfig() {
@@ -145,18 +144,18 @@ public class MultiBuilder implements
     @Override
     public StateFuzzer<MealyMachineWrapper<InputImpl, OutputImpl>> build(StateFuzzerEnabler stateFuzzerEnabler) {
         return new StateFuzzerStandard<>(
-            new StateFuzzerComposerStandard<>(stateFuzzerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize()
+            new StateFuzzerComposerStandard<>(stateFuzzerEnabler, alphabetBuilder, sulBuilder).initialize()
         );
     }
 
     @Override
     public TestRunner build(TestRunnerEnabler testRunnerEnabler) {
-        return new TestRunnerStandard<>(testRunnerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
+        return new TestRunnerStandard<>(testRunnerEnabler, alphabetBuilder, sulBuilder).initialize();
     }
 
     @Override
     public TimingProbe build(TimingProbeEnabler timingProbeEnabler) {
-        return new TimingProbeStandard<>(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
+        return new TimingProbeStandard<>(timingProbeEnabler, alphabetBuilder, sulBuilder).initialize();
     }
 }
 ```

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SulBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SulBuilder.java
@@ -19,5 +19,12 @@ public interface SulBuilder<I, O, E> {
      * @param cleanupTasks  the cleanup tasks to run in the end
      * @return              a new AbstractSul instance
      */
-    AbstractSul<I, O, E> build(SulConfig sulConfig, CleanupTasks cleanupTasks);
+    AbstractSul<I, O, E> buildSul(SulConfig sulConfig, CleanupTasks cleanupTasks);
+
+    /**
+     * Builds a new instance of the {@link AbstractSul} wrapper.
+     *
+     * @return  a new SulWrapper instance
+     */
+    SulWrapper<I, O, E> buildWrapper();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerRA.java
@@ -56,9 +56,8 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
     protected Alphabet<B> alphabet;
 
     /**
-     * The sulOracle that is built using the SulBuilder constructor parameter,
-     * wrapped using the SulWrapper constructor parameter and then wrapped
-     * using DataWordSULWrapper.
+     * The sulOracle that is built and wrapped using the SulBuilder constructor
+     * parameter and then wrapped using DataWordSULWrapper.
      */
     protected MultiQuerySULOracle sulOracle;
 
@@ -95,8 +94,7 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
      * Specifically:
      * <ul>
      * <li>the alphabet is built using the AlphabetBuilder parameter
-     * <li>the sul is built using the SulBuilder parameter and the SulWrapper
-     * parameter
+     * <li>the sul is built and wrapped using the SulBuilder parameter
      * <li>the StatisticsTracker is created
      * </ul>
      * <p>
@@ -105,14 +103,12 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
      * @param stateFuzzerEnabler the configuration that enables the state fuzzing
      * @param alphabetBuilder    the builder of the alphabet
      * @param sulBuilder         the builder of the sul
-     * @param sulWrapper         the wrapper of the sul
      * @param teachers           the teachers to be used
      */
     public StateFuzzerComposerRA(
             StateFuzzerEnabler stateFuzzerEnabler,
             AlphabetBuilder<B> alphabetBuilder,
             SulBuilder<PSymbolInstance, PSymbolInstance, E> sulBuilder,
-            SulWrapper<PSymbolInstance, PSymbolInstance, E> sulWrapper,
             @SuppressWarnings("rawtypes") Map<DataType, Theory> teachers) {
 
         this.stateFuzzerEnabler = stateFuzzerEnabler;
@@ -131,7 +127,9 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
 
         // set up wrapped SUL (System Under Learning)
         AbstractSul<PSymbolInstance, PSymbolInstance, E> abstractSul = sulBuilder
-                .build(stateFuzzerEnabler.getSulConfig(), cleanupTasks);
+                .buildSul(stateFuzzerEnabler.getSulConfig(), cleanupTasks);
+
+        SulWrapper<PSymbolInstance, PSymbolInstance, E> sulWrapper = sulBuilder.buildWrapper();
 
         SUL<PSymbolInstance, PSymbolInstance> sul = sulWrapper
                 .wrap(abstractSul)

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
@@ -3,7 +3,6 @@ package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.co
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.AbstractSul;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.Mapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.MapperOutput;
@@ -46,7 +45,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
     /** The Mapper provided from the built {@link #sulOracle}. */
     protected Mapper<I, O, E> mapper;
 
-    /** The Oracle that contains the sul built via SulBuilder and wrapped via SulWrapper constructor parameters. */
+    /** The Oracle that contains the sul built and wrapped via SulBuilder constructor parameter. */
     protected MealyMembershipOracle<I, O> sulOracle;
 
     /** Stores the Mealy Machine specification built if provided in the TestRunnerConfig. */
@@ -64,21 +63,19 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      * @param testRunnerEnabler        the configuration that enables the testing
      * @param alphabetBuilder          the builder of the alphabet
      * @param sulBuilder               the builder of the sul
-     * @param sulWrapper               the wrapper of the sul
      */
     public TestRunnerStandard(
         TestRunnerEnabler testRunnerEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SulBuilder<I, O, E> sulBuilder,
-        SulWrapper<I, O, E> sulWrapper
+        SulBuilder<I, O, E> sulBuilder
     ) {
         this.testRunnerEnabler = testRunnerEnabler;
         this.alphabet = alphabetBuilder.build(testRunnerEnabler.getLearnerConfig());
         this.cleanupTasks = new CleanupTasks();
 
-        AbstractSul<I, O, E> abstractSul = sulBuilder.build(testRunnerEnabler.getSulConfig(), cleanupTasks);
+        AbstractSul<I, O, E> abstractSul = sulBuilder.buildSul(testRunnerEnabler.getSulConfig(), cleanupTasks);
         this.mapper = abstractSul.getMapper();
-        this.sulOracle = new SULOracle<>(sulWrapper.wrap(abstractSul).getWrappedSul());
+        this.sulOracle = new SULOracle<>(sulBuilder.buildWrapper().wrap(abstractSul).getWrappedSul());
 
         this.testSpec = null;
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
@@ -2,7 +2,6 @@ package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.ti
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.MapperOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerResult;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerStandard;
@@ -34,15 +33,13 @@ public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends Test
      * @param testRunnerEnabler  the configuration that enables the testing
      * @param alphabetBuilder    the builder of the alphabet
      * @param sulBuilder         the builder of the sul
-     * @param sulWrapper         the wrapper of the sul
      */
     public ProbeTestRunner(
         TestRunnerEnabler testRunnerEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SulBuilder<I, O, E> sulBuilder,
-        SulWrapper<I, O, E> sulWrapper
+        SulBuilder<I, O, E> sulBuilder
     ) {
-        super(testRunnerEnabler, alphabetBuilder, sulBuilder, sulWrapper);
+        super(testRunnerEnabler, alphabetBuilder, sulBuilder);
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
@@ -3,7 +3,6 @@ package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.ti
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetSerializerException;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.MapperInput;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.MapperOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfig;
@@ -45,20 +44,18 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * @param timingProbeEnabler  the configuration that enables testing with the timing probe
      * @param alphabetBuilder     the builder of the alphabet
      * @param sulBuilder          the builder of the sul
-     * @param sulWrapper          the wrapper of the sul
      */
     public TimingProbeStandard(
         TimingProbeEnabler timingProbeEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SulBuilder<I, O, E> sulBuilder,
-        SulWrapper<I, O, E> sulWrapper
+        SulBuilder<I, O, E> sulBuilder
     ) {
         this.timingProbeConfig = timingProbeEnabler.getTimingProbeConfig();
         this.alphabetBuilder = alphabetBuilder;
 
         if(isActive()) {
             this.probeTestRunner = new ProbeTestRunner<>(
-                timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper
+                timingProbeEnabler, alphabetBuilder, sulBuilder
             );
         }
     }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASulBuilder.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASulBuilder.java
@@ -2,6 +2,8 @@ package com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core;
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.AbstractSul;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapper;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapperStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 import de.learnlib.ralib.automata.RegisterAutomaton;
@@ -28,7 +30,12 @@ public class RASulBuilder implements SulBuilder<PSymbolInstance, PSymbolInstance
     }
 
     @Override
-    public AbstractSul<PSymbolInstance, PSymbolInstance, Object> build(SulConfig sulConfig, CleanupTasks cleanupTasks) {
+    public AbstractSul<PSymbolInstance, PSymbolInstance, Object> buildSul(SulConfig sulConfig, CleanupTasks cleanupTasks) {
         return new RASul(ra, teachers, consts);
+    }
+
+    @Override
+    public SulWrapper<PSymbolInstance, PSymbolInstance, Object> buildWrapper() {
+        return new SulWrapperStandard<>();
     }
 }


### PR DESCRIPTION
As I mentioned in some comments of #96, the line `currentSulWrapper = new SulWrapperStandard<>();` in `StateFuzzerComposerStandard` seemed to not be the ideal one.

The main reason is that the user provided `SulWrapper` should be used in all the suls that are running in parallel (and not only in the first one). Thus I tried to find a clean way to do this.

The solution I came up with is to provide a builder for the `SulWrapper` instances, which I paired up with the `SulBuilder`, since the `SulWrapper` 'wraps' only `AbstractSul` instances.
This cleaned up things a bit and also achieved my initial goal.

I tested these changes in [edhoc-fuzzer](https://github.com/protocol-fuzzing/edhoc-fuzzer/actions/runs/15836668735) and I would like to test these also in dtls-fuzzer. The changes needed are minimal like in the [edhoc-fuzzer's case](https://github.com/protocol-fuzzing/edhoc-fuzzer/compare/main...refactor-sulwrapper).