### PR TITLE
Enforce formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "[git] Starting pre-commit hook"
+
+if ! mvn spotless:check; then
+    echo "[git] Spotless found problems, running spotless:apply"
+    mvn spotless:apply
+    echo "[git] Ran spotless:apply, inspect the changes and re-commit"
+    exit 1
+fi
+
+echo "[git] Ending pre-commit hook successfully"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "[git] Starting pre-push hook"
+
+if ! mvn verify; then
+    echo "[git] The pre-push hook failed"
+    exit 1
+fi
+
+echo "[git] Ending pre-push hook successfully"

--- a/.spotless/eclipse-style.xml
+++ b/.spotless/eclipse-style.xml
@@ -1,0 +1,405 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="23">
+    <profile kind="CodeFormatterProfile" name="ProjectStyle" version="23">
+        <setting id="org.eclipse.jdt.core.formatter.align_arrows_in_switch_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_selector_in_method_invocation_on_expression_first_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_arrow" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_colon" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="32"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_permitted_types_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_switch_case_with_arrow" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_annotations" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case_after_arrow" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_markdown_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.javadoc_do_not_separate_block_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_record_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_permitted_types" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_record_components" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_permitted_types" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_record_components" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_constructor" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_case_with_arrow_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+    </profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <assembly-plugin.version>3.8.0</assembly-plugin.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <dependency-plugin.version>3.10.0</dependency-plugin.version>
+        <gitbuildhook-plugin.version>3.6.0</gitbuildhook-plugin.version>
         <javadoc-plugin.version>3.12.0</javadoc-plugin.version>
         <source-plugin.version>3.4.0</source-plugin.version>
         <spotbugs-plugin.version>4.9.8.3</spotbugs-plugin.version>
@@ -470,6 +471,25 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Use the project's custom git hooks -->
+            <plugin>
+                <groupId>com.rudikershaw.gitbuildhook</groupId>
+                <artifactId>git-build-hook-maven-plugin</artifactId>
+                <version>${gitbuildhook-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>configure</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <gitConfig>
+                        <core.hooksPath>.githooks</core.hooksPath>
+                    </gitConfig>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,16 +19,25 @@
         <biz-aQute.version>7.2.3</biz-aQute.version>
         <checker-qual.version>3.54.1</checker-qual.version>
         <error-prone.version>2.48.0</error-prone.version>
-        <learnlib.version>0.18.0</learnlib.version>
-        <learnlib-tooling.version>0.1.1</learnlib-tooling.version>
-        <log4j.version>2.25.4</log4j.version>
         <jakarta-xml.version>4.0.5</jakarta-xml.version>
         <jaxb-runtime.version>4.0.7</jaxb-runtime.version>
         <jcommander.version>1.82</jcommander.version>
+        <jconstraints.version>0.9.9</jconstraints.version>
         <junit.version>4.13.2</junit.version>
+        <learnlib-tooling.version>0.1.1</learnlib-tooling.version>
+        <learnlib.version>0.18.0</learnlib.version>
+        <log4j.version>2.25.4</log4j.version>
         <ralib.version>0.1</ralib.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>
-        <jconstraints.version>0.9.9</jconstraints.version>
+
+        <!-- Plugin versions alphabetically sorted -->
+        <assembly-plugin.version>3.8.0</assembly-plugin.version>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <dependency-plugin.version>3.10.0</dependency-plugin.version>
+        <javadoc-plugin.version>3.12.0</javadoc-plugin.version>
+        <source-plugin.version>3.4.0</source-plugin.version>
+        <spotbugs-plugin.version>4.9.8.3</spotbugs-plugin.version>
+        <spotless-plugin.version>3.4.0</spotless-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -316,7 +325,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>${dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>analyze-only</id>
@@ -344,7 +353,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${spotless-plugin.version}</version>
                 <configuration>
                     <formats>
                         <format>
@@ -390,7 +399,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <version>3.15.0</version>
+               <version>${compiler-plugin.version}</version>
                <configuration>
                    <showWarnings>true</showWarnings>
                    <compilerArgs>
@@ -415,7 +424,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.9.8.3</version>
+                <version>${spotbugs-plugin.version}</version>
                 <configuration>
                     <threshold>Medium</threshold>
                     <includeFilterFile>.spotbugs/include.xml</includeFilterFile>
@@ -434,7 +443,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>${javadoc-plugin.version}</version>
                 <configuration>
                     <failOnWarnings>true</failOnWarnings>
                 </configuration>
@@ -452,7 +461,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -364,18 +364,17 @@
                         </format>
                     </formats>
                     <java>
+                        <eclipse>
+                            <file>${project.basedir}/.spotless/eclipse-style.xml</file>
+                        </eclipse>
+                        <removeUnusedImports />
                         <importOrder>
                             <!-- the empty string is for all imports not specified explicitly, '|' joins groups without blank line -->
                             <order>,javax|java</order>
                         </importOrder>
-                        <removeUnusedImports />
                         <formatAnnotations />
-                        <endWithNewline />
                         <trimTrailingWhitespace />
-                        <indent>
-                            <spaces>true</spaces>
-                            <spacesPerTab>4</spacesPerTab>
-                        </indent>
+                        <endWithNewline />
                     </java>
                 </configuration>
                 <executions>

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/LearnerResult.java
@@ -16,7 +16,7 @@ import java.util.List;
  * for emptiness using {@link #isEmpty()}. An empty LearnerResult can be
  * converted back to normal using {@link #toNormal()}.
  *
- * @param <M>  the type of machine model
+ * @param <M> the type of machine model
  */
 public class LearnerResult<M> {
 
@@ -56,7 +56,7 @@ public class LearnerResult<M> {
      * <p>
      * The {@code get} methods will return null after this.
      *
-     * @return  a reference to the same instance
+     * @return a reference to the same instance
      */
     public LearnerResult<M> toEmpty() {
         hypotheses = null;
@@ -71,7 +71,7 @@ public class LearnerResult<M> {
     /**
      * Checks if this instance is empty.
      *
-     * @return  {@code true} if this instance is empty
+     * @return {@code true} if this instance is empty
      */
     public boolean isEmpty() {
         return hypotheses == null
@@ -84,7 +84,7 @@ public class LearnerResult<M> {
     /**
      * Returns {@code true} if the instance comes from testing instead of learning.
      *
-     * @return  {@code true} if the instance comes from testing instead of learning
+     * @return {@code true} if the instance comes from testing instead of learning
      */
     public boolean isFromTest() {
         return fromTest;
@@ -93,7 +93,7 @@ public class LearnerResult<M> {
     /**
      * Sets the value of fromTest.
      *
-     * @param fromTest  {@code true} if the instance comes from testing instead of learning
+     * @param fromTest {@code true} if the instance comes from testing instead of learning
      */
     public void setFromTest(boolean fromTest) {
         this.fromTest = fromTest;
@@ -105,7 +105,7 @@ public class LearnerResult<M> {
      * <p>
      * An already normal LearnerResult remains unaffected.
      *
-     * @return  a reference to the same instance
+     * @return a reference to the same instance
      */
     public LearnerResult<M> toNormal() {
         if (isEmpty()) {
@@ -117,7 +117,7 @@ public class LearnerResult<M> {
     /**
      * Adds a hypothesis to {@link #hypotheses} if this instance is not empty.
      *
-     * @param hypothesis  the hypothesis to be added
+     * @param hypothesis the hypothesis to be added
      */
     public void addHypothesis(M hypothesis) {
         if (!isEmpty()) {
@@ -128,7 +128,7 @@ public class LearnerResult<M> {
     /**
      * Returns an unmodifiable list of non-null {@link #hypotheses} or null.
      *
-     * @return  an unmodifiable list of non-null {@link #hypotheses} or null
+     * @return an unmodifiable list of non-null {@link #hypotheses} or null
      */
     public List<M> getHypotheses() {
         return hypotheses == null ? null : Collections.unmodifiableList(hypotheses);
@@ -137,7 +137,7 @@ public class LearnerResult<M> {
     /**
      * Returns the stored value of {@link #learnedModel}.
      *
-     * @return  the stored value of {@link #learnedModel}
+     * @return the stored value of {@link #learnedModel}
      */
     public M getLearnedModel() {
         return learnedModel;
@@ -146,7 +146,7 @@ public class LearnerResult<M> {
     /**
      * Sets the value of {@link #learnedModel}, if this instance is not empty.
      *
-     * @param learnedModel  the learned model to be set
+     * @param learnedModel the learned model to be set
      */
     public void setLearnedModel(M learnedModel) {
         if (!isEmpty()) {
@@ -157,7 +157,7 @@ public class LearnerResult<M> {
     /**
      * Returns the stored value of {@link #learnedModelFile}.
      *
-     * @return  the stored value of {@link #learnedModelFile}
+     * @return the stored value of {@link #learnedModelFile}
      */
     public File getLearnedModelFile() {
         return learnedModelFile;
@@ -166,7 +166,7 @@ public class LearnerResult<M> {
     /**
      * Sets the value of {@link #learnedModelFile}, if this instance is not empty.
      *
-     * @param learnedModelFile  the file of the learned model to be set
+     * @param learnedModelFile the file of the learned model to be set
      */
     public void setLearnedModelFile(File learnedModelFile) {
         if (!isEmpty()) {
@@ -177,7 +177,7 @@ public class LearnerResult<M> {
     /**
      * Returns the stored value of {@link #statistics}.
      *
-     * @return  the stored value of {@link #statistics}
+     * @return the stored value of {@link #statistics}
      */
     public Statistics<?, ?, ?, ?> getStatistics() {
         return statistics;
@@ -186,7 +186,7 @@ public class LearnerResult<M> {
     /**
      * Sets the value of {@link #statistics}, if this instance is not empty.
      *
-     * @param statistics  the statistics to be set
+     * @param statistics the statistics to be set
      */
     public void setStatistics(Statistics<?, ?, ?, ?> statistics) {
         if (!isEmpty()) {
@@ -197,7 +197,7 @@ public class LearnerResult<M> {
     /**
      * Returns the stored value of {@link #stateFuzzerEnabler}.
      *
-     * @return  the stored value of {@link #stateFuzzerEnabler}
+     * @return the stored value of {@link #stateFuzzerEnabler}
      */
     public StateFuzzerEnabler getStateFuzzerEnabler() {
         return stateFuzzerEnabler;
@@ -206,7 +206,7 @@ public class LearnerResult<M> {
     /**
      * Sets the value of {@link #stateFuzzerEnabler}, if this instance is not empty.
      *
-     * @param stateFuzzerEnabler  the StateFuzzerEnabler to be set
+     * @param stateFuzzerEnabler the StateFuzzerEnabler to be set
      */
     public void setStateFuzzerEnabler(StateFuzzerEnabler stateFuzzerEnabler) {
         if (!isEmpty()) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilder.java
@@ -9,7 +9,7 @@ import java.io.InputStream;
 /**
  * Interface for alphabet operations on different file types.
  *
- * @param <I>  the type of inputs
+ * @param <I> the type of inputs
  */
 public interface AlphabetBuilder<I> {
 
@@ -19,7 +19,8 @@ public interface AlphabetBuilder<I> {
     /**
      * Builds the (input) alphabet from the given provider.
      *
-     * @param learnerConfig  the LearnerConfig containing the alphabet filename
+     * @param  learnerConfig the LearnerConfig containing the alphabet filename
+     *
      * @return               the built input alphabet
      */
     Alphabet<I> build(LearnerConfig learnerConfig);
@@ -29,7 +30,8 @@ public interface AlphabetBuilder<I> {
      * or a new input stream of the default alphabet file located in the resources
      * if a null provider or a provider with null alphabet file is provided.
      *
-     * @param learnerConfig  the LearnerConfig containing the alphabet filename
+     * @param  learnerConfig the LearnerConfig containing the alphabet filename
+     *
      * @return               the file's input stream
      */
     InputStream getAlphabetFileInputStream(LearnerConfig learnerConfig);
@@ -37,18 +39,18 @@ public interface AlphabetBuilder<I> {
     /**
      * Returns the alphabet file extension that the builder handles.
      *
-     * @return  the alphabet file extension that the builder handles
+     * @return the alphabet file extension that the builder handles
      */
     String getAlphabetFileExtension();
 
     /**
      * Exports the given alphabet to the specified file.
      *
-     * @param outputFileName  the name of the destination file
-     * @param alphabet        the alphabet to be exported
+     * @param  outputFileName              the name of the destination file
+     * @param  alphabet                    the alphabet to be exported
      *
-     * @throws IOException                  if an error occurs regarding the destination file
-     * @throws AlphabetSerializerException  if an error occurs regarding the alphabet serialization
+     * @throws IOException                 if an error occurs regarding the destination file
+     * @throws AlphabetSerializerException if an error occurs regarding the alphabet serialization
      */
     void exportAlphabetToFile(String outputFileName, Alphabet<I> alphabet)
         throws IOException, AlphabetSerializerException;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderEnum.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderEnum.java
@@ -43,7 +43,7 @@ public class AlphabetBuilderEnum<I> implements AlphabetBuilder<I> {
 
     @Override
     public void exportAlphabetToFile(String outputFileName, Alphabet<I> alphabet)
-            throws IOException, AlphabetSerializerException {
+        throws IOException, AlphabetSerializerException {
         // Do nothing.
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderStandard.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * The standard implementation of the AlphabetBuilder that requires a
  * file specific AlphabetSerializer.
  *
- * @param <I>  the type of inputs
+ * @param <I> the type of inputs
  */
 public class AlphabetBuilderStandard<I> implements AlphabetBuilder<I> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -37,7 +37,7 @@ public class AlphabetBuilderStandard<I> implements AlphabetBuilder<I> {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param alphabetSerializer  the AlphabetSerializer to be used
+     * @param alphabetSerializer the AlphabetSerializer to be used
      */
     public AlphabetBuilderStandard(AlphabetSerializer<I> alphabetSerializer) {
         this.alphabetSerializer = alphabetSerializer;
@@ -58,10 +58,12 @@ public class AlphabetBuilderStandard<I> implements AlphabetBuilder<I> {
 
         try (InputStream inputStream = getAlphabetFileInputStream(learnerConfig)) {
             alphabet = alphabetSerializer.read(inputStream);
-        } catch (AlphabetSerializerException e) {
+        }
+        catch (AlphabetSerializerException e) {
             LOGGER.fatal("Failed to instantiate " + kind + " alphabet");
             throw new RuntimeException(e);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.debug("Failed to close input stream of " + kind + " alphabet");
         }
 
@@ -85,7 +87,8 @@ public class AlphabetBuilderStandard<I> implements AlphabetBuilder<I> {
 
         try {
             return new FileInputStream(learnerConfig.getAlphabetFilename());
-        } catch (FileNotFoundException e) {
+        }
+        catch (FileNotFoundException e) {
             LOGGER.fatal("Failed to find the provided alphabet file: {}", learnerConfig.getAlphabetFilename());
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderTransformer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetBuilderTransformer.java
@@ -14,8 +14,8 @@ import java.util.stream.Collectors;
  * <p>
  * An {@code AlphabetBuilderStandard<RI>} is used for the {@code Alphabet<RI>}
  *
- * @param <RI>  the type of read inputs
- * @param <TI>  the type of transformed inputs
+ * @param <RI> the type of read inputs
+ * @param <TI> the type of transformed inputs
  */
 public abstract class AlphabetBuilderTransformer<RI, TI> implements AlphabetBuilder<TI> {
 
@@ -25,7 +25,7 @@ public abstract class AlphabetBuilderTransformer<RI, TI> implements AlphabetBuil
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param alphabetBuilderStandard  the AlphabetBuilderStandard to be used for the read inputs
+     * @param alphabetBuilderStandard the AlphabetBuilderStandard to be used for the read inputs
      */
     public AlphabetBuilderTransformer(AlphabetBuilderStandard<RI> alphabetBuilderStandard) {
         this.alphabetBuilderStandard = alphabetBuilderStandard;
@@ -35,8 +35,7 @@ public abstract class AlphabetBuilderTransformer<RI, TI> implements AlphabetBuil
     public Alphabet<TI> build(LearnerConfig learnerConfig) {
         Alphabet<RI> rAlphabet = alphabetBuilderStandard.build(learnerConfig);
         Alphabet<TI> tAlphabet = new ListAlphabet<>(
-            rAlphabet.stream().map(ri -> toTransformedInput(ri)).collect(Collectors.toList())
-        );
+            rAlphabet.stream().map(ri -> toTransformedInput(ri)).collect(Collectors.toList()));
         return tAlphabet;
     }
 
@@ -54,15 +53,15 @@ public abstract class AlphabetBuilderTransformer<RI, TI> implements AlphabetBuil
     public void exportAlphabetToFile(String outputFileName, Alphabet<TI> tAlphabet)
         throws IOException, AlphabetSerializerException {
         Alphabet<RI> rAlphabet = new ListAlphabet<>(
-            tAlphabet.stream().map(ti -> fromTransformedInput(ti)).collect(Collectors.toList())
-        );
+            tAlphabet.stream().map(ti -> fromTransformedInput(ti)).collect(Collectors.toList()));
         alphabetBuilderStandard.exportAlphabetToFile(outputFileName, rAlphabet);
     }
 
     /**
      * Converts the read input to transformed input.
      *
-     * @param ri  the read input to be converted
+     * @param  ri the read input to be converted
+     *
      * @return    the converted transformed input
      */
     public abstract TI toTransformedInput(RI ri);
@@ -70,7 +69,8 @@ public abstract class AlphabetBuilderTransformer<RI, TI> implements AlphabetBuil
     /**
      * Converts the transformed input to read input.
      *
-     * @param ti  the transformed input to be converted
+     * @param  ti the transformed input to be converted
+     *
      * @return    the converted read input
      */
     public abstract RI fromTransformedInput(TI ti);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetSerializer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetSerializer.java
@@ -9,34 +9,35 @@ import java.io.OutputStream;
  * Interface for reading and writing operations for a specific file type of
  * alphabets.
  *
- * @param <I>  the type of inputs
+ * @param <I> the type of inputs
  */
 public interface AlphabetSerializer<I> {
 
     /**
      * Reads the alphabet from the given input stream.
      *
-     * @param alphabetStream  the source input stream
-     * @return                the alphabet read
+     * @param  alphabetStream              the source input stream
      *
-     * @throws AlphabetSerializerException  if an error occurs
+     * @return                             the alphabet read
+     *
+     * @throws AlphabetSerializerException if an error occurs
      */
     Alphabet<I> read(InputStream alphabetStream) throws AlphabetSerializerException;
 
     /**
      * Writes the given alphabet to the specified output stream.
      *
-     * @param alphabetStream  the destination output stream
-     * @param alphabet        the alphabet to be written
+     * @param  alphabetStream              the destination output stream
+     * @param  alphabet                    the alphabet to be written
      *
-     * @throws AlphabetSerializerException  if an error occurs
+     * @throws AlphabetSerializerException if an error occurs
      */
     void write(OutputStream alphabetStream, Alphabet<I> alphabet) throws AlphabetSerializerException;
 
     /**
      * Returns the file extension that this serializer handles prepended by a . (dot).
      *
-     * @return  the file extension that this serializer handles prepended by a . (dot)
+     * @return the file extension that this serializer handles prepended by a . (dot)
      */
     String getAlphabetFileExtension();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetSerializerException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/AlphabetSerializerException.java
@@ -13,7 +13,7 @@ public class AlphabetSerializerException extends Exception {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param msg  the message related to the exception
+     * @param msg the message related to the exception
      */
     public AlphabetSerializerException(String msg) {
         super(msg);
@@ -22,8 +22,8 @@ public class AlphabetSerializerException extends Exception {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param msg    the message related to the exception
-     * @param cause  the cause related to the exception
+     * @param msg   the message related to the exception
+     * @param cause the cause related to the exception
      */
     public AlphabetSerializerException(String msg, Throwable cause) {
         super(msg, cause);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/DataTypeMap.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/DataTypeMap.java
@@ -26,9 +26,10 @@ public class DataTypeMap<T extends Enum<T>> extends EnumMap<T, DataType> {
     /**
      * Create a datavalue from an enumMember and a value
      *
-     * @param enumName the name of the DataType
-     * @param value    the value
-     * @return a new {@link DataValue} with value value
+     * @param  enumName the name of the DataType
+     * @param  value    the value
+     *
+     * @return          a new {@link DataValue} with value value
      */
     public DataValue newDataValue(T enumName, BigDecimal value) {
         return new DataValue(this.get(enumName), value);
@@ -55,13 +56,14 @@ public class DataTypeMap<T extends Enum<T>> extends EnumMap<T, DataType> {
         /**
          * Creates an {@link DataType} with a predefined base class
          *
-         * @param <C>       the type of the base class
-         * @param nameEnums the enum values for which to create a DataType
-         * @param baseClass the base class for the data type
-         * @return the builder
+         * @param  <C>       the type of the base class
+         * @param  nameEnums the enum values for which to create a DataType
+         * @param  baseClass the base class for the data type
+         *
+         * @return           the builder
          */
         public <C> Builder<TT> newDataTypes(TT[] nameEnums, Class<C> baseClass) {
-            for (TT nameEnum : nameEnums) {
+            for (TT nameEnum: nameEnums) {
                 DataType dataType = new DataType(nameEnum.name());
                 map.put(nameEnum, dataType);
             }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/EnumAlphabet.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/EnumAlphabet.java
@@ -47,16 +47,17 @@ public class EnumAlphabet extends ListAlphabet<ParameterizedSymbol> {
      * Retrieve the ParameterizedSymbol associated with a particular
      * enum member.
      *
-     * @param <T>         enum type
-     * @param enum_member the member to be used in retrieval
-     * @return the associated symbol
+     * @param  <T>         enum type
+     * @param  enum_member the member to be used in retrieval
+     *
+     * @return             the associated symbol
      */
     public <T extends Enum<T>> ParameterizedSymbol getPSymbol(T enum_member) {
 
         ParameterizedSymbol symbol = symbolMap.get(enum_member.name());
         if (symbol == null) {
             throw new RuntimeException("The symbol " + enum_member.name()
-                    + " is not present in the alphabet map, the map may have not been initialised properly.");
+                + " is not present in the alphabet map, the map may have not been initialised properly.");
         }
         return symbol;
     }
@@ -66,7 +67,6 @@ public class EnumAlphabet extends ListAlphabet<ParameterizedSymbol> {
      * <p>
      * The current design allows for updating previously built members,
      * by changing multiple
-     *
      * with one or more
      * withInput or
      * withOutput.
@@ -101,10 +101,11 @@ public class EnumAlphabet extends ListAlphabet<ParameterizedSymbol> {
          * Constructs an InputSymbol from an enum member,
          * with or without DataType s
          *
-         * @param <T>        any enum type
-         * @param enumMember the name of the symbol to add, as an enum
-         * @param dataTypes  zero or more DataTypes associated with this symbol
-         * @return the builder
+         * @param  <T>        any enum type
+         * @param  enumMember the name of the symbol to add, as an enum
+         * @param  dataTypes  zero or more DataTypes associated with this symbol
+         *
+         * @return            the builder
          */
         public <T extends Enum<T>> Builder withInput(T enumMember, DataType... dataTypes) {
             String name = enumMember.name();
@@ -118,10 +119,11 @@ public class EnumAlphabet extends ListAlphabet<ParameterizedSymbol> {
          * member,
          * with or without DataType s
          *
-         * @param <T>        any enum type
-         * @param enumMember the name of the symbol to add, as an enum
-         * @param dataTypes  zero or more DataTypes associated with this symbol
-         * @return the builder
+         * @param  <T>        any enum type
+         * @param  enumMember the name of the symbol to add, as an enum
+         * @param  dataTypes  zero or more DataTypes associated with this symbol
+         *
+         * @return            the builder
          */
         public <T extends Enum<T>> Builder withOutput(T enumMember, DataType... dataTypes) {
             String name = enumMember.name();
@@ -134,13 +136,14 @@ public class EnumAlphabet extends ListAlphabet<ParameterizedSymbol> {
          * Constructs InputSymbol from one or more enum members,
          * without DataType
          *
-         * @param <T>         any enum type
-         * @param enumMembers the names of the symbols to add, as enum members.
-         *                    Meant to be used with enum.values()
-         * @return the builder
+         * @param  <T>         any enum type
+         * @param  enumMembers the names of the symbols to add, as enum members.
+         *                         Meant to be used with enum.values()
+         *
+         * @return             the builder
          */
         public <T extends Enum<T>> Builder withInputs(T[] enumMembers) {
-            for (T e : enumMembers) {
+            for (T e: enumMembers) {
                 symbolMap.put(e.name(), new InputSymbol(e.name()));
             }
             return this;
@@ -150,13 +153,14 @@ public class EnumAlphabet extends ListAlphabet<ParameterizedSymbol> {
          * Constructs OutputSymbol s from one or more enum members,
          * without DataType s
          *
-         * @param <T>         any enum type
-         * @param enumMembers the names of the symbols to add, as enum members.
-         *                    Meant to be used with enum#values()
-         * @return the builder
+         * @param  <T>         any enum type
+         * @param  enumMembers the names of the symbols to add, as enum members.
+         *                         Meant to be used with enum#values()
+         *
+         * @return             the builder
          */
         public <T extends Enum<T>> Builder withOutputs(T[] enumMembers) {
-            for (T e : enumMembers) {
+            for (T e: enumMembers) {
                 symbolMap.put(e.name(), new OutputSymbol(e.name()));
             }
             return this;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetPojoXml.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetPojoXml.java
@@ -6,6 +6,7 @@ import java.util.List;
  * POJO class used for XML (de)serialization by {@link AlphabetSerializerXml}.
  * <p>
  * Example of a subclass with an annotated List member inputs:
+ *
  * <pre>
  *  {@code @XmlRootElement}(name = "alphabet")}
  *  {@code @XmlAccessorType}(XmlAccessType.FIELD)}
@@ -29,7 +30,7 @@ import java.util.List;
  *   }
  * </pre>
  *
- * @param <I>  the type of inputs
+ * @param <I> the type of inputs
  */
 public abstract class AlphabetPojoXml<I> {
 
@@ -43,7 +44,7 @@ public abstract class AlphabetPojoXml<I> {
      * <p>
      * It should be overridden to store the parameter into a list of inputs.
      *
-     * @param inputs  the list of inputs
+     * @param inputs the list of inputs
      */
     public AlphabetPojoXml(List<I> inputs) {}
 
@@ -52,7 +53,7 @@ public abstract class AlphabetPojoXml<I> {
      * <p>
      * It should be overridden, because this always returns null.
      *
-     * @return  the stored list of inputs.
+     * @return the stored list of inputs.
      */
     public List<I> getInputs() {
         return List.of();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetSerializerXml.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/alphabet/xml/AlphabetSerializerXml.java
@@ -23,8 +23,8 @@ import java.util.List;
 /**
  * Implementation of the AlphabetSerializer for alphabet in XML format.
  *
- * @param <I>   the type of inputs
- * @param <AP>  the type of alphabet pojo
+ * @param <I>  the type of inputs
+ * @param <AP> the type of alphabet pojo
  */
 public class AlphabetSerializerXml<I, AP extends AlphabetPojoXml<I>> implements AlphabetSerializer<I> {
 
@@ -41,9 +41,9 @@ public class AlphabetSerializerXml<I, AP extends AlphabetPojoXml<I>> implements 
      * Returns the {@link #context} or creates and returns a new JAXBContext
      * if {@link #context} is null.
      *
-     * @return  the JAXBContext instance stored in {@link #context}
+     * @return               the JAXBContext instance stored in {@link #context}
      *
-     * @throws JAXBException  if the instance cannot be created
+     * @throws JAXBException if the instance cannot be created
      */
     protected synchronized JAXBContext getJAXBContext() throws JAXBException {
         if (context == null) {
@@ -55,8 +55,8 @@ public class AlphabetSerializerXml<I, AP extends AlphabetPojoXml<I>> implements 
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param inputClass                 the class of the alphabet inputs
-     * @param alphabetPojoXmlChildClass  the class that specifies the alphabet's XML POJO
+     * @param inputClass                the class of the alphabet inputs
+     * @param alphabetPojoXmlChildClass the class that specifies the alphabet's XML POJO
      */
     public AlphabetSerializerXml(Class<I> inputClass, Class<AP> alphabetPojoXmlChildClass) {
         this.inputClass = inputClass;
@@ -70,7 +70,8 @@ public class AlphabetSerializerXml<I, AP extends AlphabetPojoXml<I>> implements 
             XMLInputFactory xif = XMLInputFactory.newFactory();
             xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-            XMLStreamReader xsr = xif.createXMLStreamReader(new InputStreamReader(alphabetStream, StandardCharsets.UTF_8));
+            XMLStreamReader xsr = xif
+                .createXMLStreamReader(new InputStreamReader(alphabetStream, StandardCharsets.UTF_8));
             Object unmarshalled = unmarshaller.unmarshal(xsr);
 
             List<I> inputList = List.of();
@@ -79,7 +80,8 @@ public class AlphabetSerializerXml<I, AP extends AlphabetPojoXml<I>> implements 
             }
             return new ListAlphabet<I>(inputList);
 
-        } catch (JAXBException | XMLStreamException e) {
+        }
+        catch (JAXBException | XMLStreamException e) {
             throw new AlphabetSerializerException("Cannot read the alphabet", e);
         }
     }
@@ -90,11 +92,13 @@ public class AlphabetSerializerXml<I, AP extends AlphabetPojoXml<I>> implements 
             Marshaller m = getJAXBContext().createMarshaller();
             m.setProperty(Marshaller.JAXB_FRAGMENT, true);
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            AP alphabetPojo = alphabetPojoXmlChildClass.getConstructor(List.class).newInstance(new ArrayList<>(alphabet));
+            AP alphabetPojo = alphabetPojoXmlChildClass.getConstructor(List.class)
+                .newInstance(new ArrayList<>(alphabet));
             m.marshal(alphabetPojo, alphabetStream);
 
-        } catch (JAXBException | NoSuchMethodException | InvocationTargetException | IllegalAccessException |
-                 InstantiationException e) {
+        }
+        catch (JAXBException | NoSuchMethodException | InvocationTargetException | IllegalAccessException
+            | InstantiationException e) {
             throw new AlphabetSerializerException("Cannot write the alphabet", e);
         }
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/DurationConverter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/DurationConverter.java
@@ -13,13 +13,14 @@ public class DurationConverter implements IStringConverter<Duration> {
     /**
      * Constructor
      */
-    public DurationConverter() { }
+    public DurationConverter() {}
 
     /**
      * Converts a String to Duration and uses {@link PropertyResolver#resolve(String)}.
      *
-     * @param value   the value to be converted
-     * @return        the converted value
+     * @param  value the value to be converted
+     *
+     * @return       the converted value
      */
     @Override
     public Duration convert(String value) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfig.java
@@ -18,7 +18,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the filename of the alphabet to be used for learning
+     * @return the filename of the alphabet to be used for learning
      */
     default String getAlphabetFilename() {
         return null;
@@ -29,7 +29,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the algorithm that should be used for learning
+     * @return the algorithm that should be used for learning
      */
     default LearningAlgorithmName getLearningAlgorithm() {
         return null;
@@ -40,7 +40,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: [RANDOM_WP_METHOD].
      *
-     * @return  the algorithms that should be used for equivalence testing
+     * @return the algorithms that should be used for equivalence testing
      */
     default List<EquivalenceAlgorithmName> getEquivalenceAlgorithms() {
         return List.of(EquivalenceAlgorithmName.RANDOM_WP_METHOD);
@@ -51,7 +51,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 1.
      *
-     * @return  the maximal depth (W/WP Method)
+     * @return the maximal depth (W/WP Method)
      */
     default int getMaxDepth() {
         return 1;
@@ -62,7 +62,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 5.
      *
-     * @return  the minimum length (random words, Random WP Method)
+     * @return the minimum length (random words, Random WP Method)
      */
     default int getMinLength() {
         return 5;
@@ -73,7 +73,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 15.
      *
-     * @return  the maximum length (random words)
+     * @return the maximum length (random words)
      */
     default int getMaxLength() {
         return 15;
@@ -84,7 +84,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 5.
      *
-     * @return  the size of the random part (Random WP Method)
+     * @return the size of the random part (Random WP Method)
      */
     default int getRandLength() {
         return 5;
@@ -97,7 +97,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 1000.
      *
-     * @return  the maximum number of queries used by some equivalence algorithms
+     * @return the maximum number of queries used by some equivalence algorithms
      */
     default int getEquivQueryBound() {
         return 1000;
@@ -108,18 +108,20 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 1.
      *
-     * @return  the number of times each membership query is executed before an answer is returned
+     * @return the number of times each membership query is executed before an answer is returned
      */
     default int getRunsPerMembershipQuery() {
         return 1;
     }
 
     /**
-     * Returns the number of times a membership query is executed in case cache inconsistency is detected.
+     * Returns the number of times a membership query is executed in case cache inconsistency is
+     * detected.
      * <p>
      * Default value: 3.
      *
-     * @return  the number of times a membership query is executed in case cache inconsistency is detected
+     * @return the number of times a membership query is executed in case cache inconsistency is
+     *             detected
      */
     default int getMembershipQueryRetries() {
         return 3;
@@ -130,7 +132,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if membership query logging should occur
+     * @return {@code true} if membership query logging should occur
      */
     default boolean isLogQueries() {
         return false;
@@ -141,7 +143,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 0.0.
      *
-     * @return  the probability of stopping the execution of a test after each input
+     * @return the probability of stopping the execution of a test after each input
      */
     default double getProbReset() {
         return 0.0;
@@ -152,7 +154,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  a file with tests (equivalence queries) to be run or null
+     * @return a file with tests (equivalence queries) to be run or null
      */
     default String getTestFile() {
         return null;
@@ -163,7 +165,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 0.
      *
-     * @return  a seed used for random value generation
+     * @return a seed used for random value generation
      */
     default long getSeed() {
         return 0L;
@@ -175,7 +177,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if tests should be cached
+     * @return {@code true} if tests should be cached
      */
     default boolean isCacheTests() {
         return false;
@@ -187,7 +189,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if CE sanitization should be enabled
+     * @return {@code true} if CE sanitization should be enabled
      */
     default boolean isCeSanitization() {
         return false;
@@ -199,7 +201,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if non-deterministic tests should be skipped
+     * @return {@code true} if non-deterministic tests should be skipped
      */
     default boolean isSkipNonDetTests() {
         return false;
@@ -210,7 +212,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 3.
      *
-     * @return  the number of times a CE is re-run in order for it to be confirmed
+     * @return the number of times a CE is re-run in order for it to be confirmed
      */
     default int getCeReruns() {
         return 3;
@@ -222,7 +224,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if probabilistic sanitization should be enabled
+     * @return {@code true} if probabilistic sanitization should be enabled
      */
     default boolean isProbabilisticSanitization() {
         return false;
@@ -233,7 +235,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  null or a time limit on the learning experiment
+     * @return null or a time limit on the learning experiment
      */
     default Duration getTimeLimit() {
         return null;
@@ -244,7 +246,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  null or a test limit on the learning experiment
+     * @return null or a test limit on the learning experiment
      */
     default Long getTestLimit() {
         return null;
@@ -255,7 +257,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  null or a round limit on the learning experiment
+     * @return null or a round limit on the learning experiment
      */
     default Integer getRoundLimit() {
         return null;
@@ -274,7 +276,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * The probability that a new data value is selected during a IO random walk
      * run.
      *
-     * @return  Double precition floating point between 0 and 1.
+     * @return Double precition floating point between 0 and 1.
      */
     default Double getProbNewDataValue() {
         return 0.1;
@@ -292,7 +294,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
     /**
      * Returns the max depth of an IO random walk run.
      *
-     * @return  the max depth of a run
+     * @return the max depth of a run
      */
     default Integer getMaxDepthRA() {
         return 1;
@@ -310,7 +312,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
     /**
      * Returns if seed transitions should be done or not for IO random walks.
      *
-     * @return  true if seed transitions should be done, otherwise false
+     * @return true if seed transitions should be done, otherwise false
      */
     default Boolean getSeedTransitions() {
         return true;
@@ -319,7 +321,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
     /**
      * Returns if symbols should be drawn uniformly or not for IO random walks.
      *
-     * @return  true if symbols should be drawn uniformly, otherwise false.
+     * @return true if symbols should be drawn uniformly, otherwise false.
      */
     default Boolean getDrawSymbolsUniformly() {
         return true;
@@ -330,7 +332,7 @@ public interface LearnerConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 1.
      *
-     * @return  the number of threads to be used for the SULs
+     * @return the number of threads to be used for the SULs
      */
     default int getEquivalenceThreadCount() {
         return 1;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigRA.java
@@ -14,7 +14,6 @@ public class LearnerConfigRA extends LearnerConfigStandard {
 
     /**
      * Constructs new instance with default parameters.
-     *
      */
     public LearnerConfigRA() {
         super();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigStandard.java
@@ -25,10 +25,10 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: null.
      */
     @Parameter(names = "-alphabet", description = "A file defining the input alphabet. "
-            + "If it is not provided then the default alphabet in resources would be used. "
-            + "The alphabet is used to interpret inputs from a given specification, as well as to learn. "
-            + "Each input in the alphabet has a name under which it appears in the specification. "
-            + "In XML format, for example, the name is specified using the 'name' attribute.")
+        + "If it is not provided then the default alphabet in resources would be used. "
+        + "The alphabet is used to interpret inputs from a given specification, as well as to learn. "
+        + "Each input in the alphabet has a name under which it appears in the specification. "
+        + "In XML format, for example, the name is specified using the 'name' attribute.")
     protected String alphabetFilename = null;
 
     /**
@@ -52,9 +52,9 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: [RANDOM_WP_METHOD].
      */
     @Parameter(names = "-equivalenceAlgorithms", description = "Which test algorithms should be used for "
-            + "equivalence testing. Expected comma-separated values of: W_METHOD, MODIFIED_W_METHOD, WP_METHOD, "
-            + "RANDOM_WORDS, RANDOM_WALK, RANDOM_WP_METHOD, SAMPLED_TESTS, WP_SAMPLED_TESTS. "
-            + "Do not leave any whitespace in between or after the final value")
+        + "equivalence testing. Expected comma-separated values of: W_METHOD, MODIFIED_W_METHOD, WP_METHOD, "
+        + "RANDOM_WORDS, RANDOM_WALK, RANDOM_WP_METHOD, SAMPLED_TESTS, WP_SAMPLED_TESTS. "
+        + "Do not leave any whitespace in between or after the final value")
     protected List<EquivalenceAlgorithmName> equivalenceAlgorithms = List.of(EquivalenceAlgorithmName.RANDOM_WP_METHOD);
 
     /**
@@ -106,20 +106,21 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: 1000.
      */
     @Parameter(names = {"-equivalenceQueryBound", "-eqvQueries"}, description = "Max number of queries used by some equivalence algorithms. "
-            + "It is used as the 'bound' parameter in those equivalence algorithms.")
+        + "It is used as the 'bound' parameter in those equivalence algorithms.")
     protected Integer equivQueryBound = 1000;
 
     /**
      * Stores the JCommander Parameter -memQueryRuns.
      * <p>
      * The number of times each membership query is executed before an answer is returned.
-     * Setting it to more than 1 enables a multiple-run oracle which can be used to resolve non-determinism.
+     * Setting it to more than 1 enables a multiple-run oracle which can be used to resolve
+     * non-determinism.
      * <p>
      * Default value: 1.
      */
     @Parameter(names = "-memQueryRuns", description = "The number of times each membership query is executed before "
-            + "an answer is returned. Setting it to more than 1 enables a multiple-run oracle "
-            + "which can be used to resolve non-determinism.")
+        + "an answer is returned. Setting it to more than 1 enables a multiple-run oracle "
+        + "which can be used to resolve non-determinism.")
     protected Integer runsPerMembershipQuery = 1;
 
     /**
@@ -130,7 +131,7 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: 3.
      */
     @Parameter(names = "-memQueryRetries", description = "The number of times a membership query is executed in case "
-            + "cache inconsistency is detected.")
+        + "cache inconsistency is detected.")
     protected Integer membershipQueryRetries = 3;
 
     /**
@@ -141,7 +142,7 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: false.
      */
     @Parameter(names = "-logQueries", description = "If set, logs all membership queries to a specific file in the "
-            + "output directory.")
+        + "output directory.")
     protected boolean logQueries = false;
 
     /**
@@ -184,7 +185,7 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: false.
      */
     @Parameter(names = "-cacheTests", description = "Cache tests, which increases the memory footprint, "
-            + "but improves performance. It also renders useless most forms of non-determinism sanitization")
+        + "but improves performance. It also renders useless most forms of non-determinism sanitization")
     protected boolean cacheTests = false;
 
     /**
@@ -196,18 +197,19 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: false.
      */
     @Parameter(names = "-ceSanitizationDisable", description = "Disables counterexamples (CE) sanitization, "
-            + "which involves re-running potential CE's ensuring they are not spurious")
+        + "which involves re-running potential CE's ensuring they are not spurious")
     protected boolean ceSanitizationDisable = false;
 
     /**
      * Stores the JCommander Parameter -skipNonDetTests.
      * <p>
-     * Rather than throwing an exception, logs and skips tests, whose execution turned out non-deterministic.
+     * Rather than throwing an exception, logs and skips tests, whose execution turned out
+     * non-deterministic.
      * <p>
      * Default value: false.
      */
     @Parameter(names = "-skipNonDetTests", description = "Rather than throw an exception, logs and skips tests, "
-            + "whose execution turned out non-deterministic")
+        + "whose execution turned out non-deterministic")
     protected boolean skipNonDetTests = false;
 
     /**
@@ -218,7 +220,7 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: 3.
      */
     @Parameter(names = "-ceReruns", description = "Represents the number of times a CE is re-run in order for it to "
-            + "be confirmed")
+        + "be confirmed")
     protected Integer ceReruns = 3;
 
     /**
@@ -229,7 +231,7 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: false.
      */
     @Parameter(names = "-probabilisticSanitizationDisable", description = "Disables probabilistic sanitization of "
-            + "CEs resulting in non-determinism")
+        + "CEs resulting in non-determinism")
     protected boolean probabilisticSanitizationDisable = false;
 
     /**
@@ -245,10 +247,9 @@ public class LearnerConfigStandard implements LearnerConfig {
      * @see Duration#parse(CharSequence)
      */
     @Parameter(names = "-timeLimit", description = "If set, imposes a time limit on the learning experiment. "
-            + "Once this time elapses, learning is stopped and statistics for the incomplete learning run are published "
-            + "The formats accepted are based on the ISO-8601 duration format PnDTnHnMn.nS with days considered to be "
-            + "exactly 24 hours. See java.time.Duration#parse(java.lang.CharSequence) for specific details on format.",
-            converter = DurationConverter.class)
+        + "Once this time elapses, learning is stopped and statistics for the incomplete learning run are published "
+        + "The formats accepted are based on the ISO-8601 duration format PnDTnHnMn.nS with days considered to be "
+        + "exactly 24 hours. See java.time.Duration#parse(java.lang.CharSequence) for specific details on format.", converter = DurationConverter.class)
     protected Duration timeLimit = null;
 
     /**
@@ -261,8 +262,8 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: null.
      */
     @Parameter(names = "-testLimit", description = "If set, imposes a test limit on the learning experiment. "
-            + "Once the number of tests has reached this limit, learning is stopped and statistics for the incomplete "
-            + "learning run are published")
+        + "Once the number of tests has reached this limit, learning is stopped and statistics for the incomplete "
+        + "learning run are published")
     protected Long testLimit = null;
 
     /**
@@ -275,8 +276,8 @@ public class LearnerConfigStandard implements LearnerConfig {
      * Default value: null.
      */
     @Parameter(names = "-roundLimit", description = "If set, limits the number of hypothesis construction rounds "
-            + "and with that, the number of hypotheses generated. Once the limit is reached, learning is stopped and "
-            + "statistics for the incomplete learning run are published.")
+        + "and with that, the number of hypotheses generated. Once the limit is reached, learning is stopped and "
+        + "statistics for the incomplete learning run are published.")
     protected Integer roundLimit = null;
 
     /**
@@ -292,7 +293,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Constructor
      */
-    public LearnerConfigStandard() { }
+    public LearnerConfigStandard() {}
 
     @Override
     public String getAlphabetFilename() {
@@ -302,7 +303,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #learningAlgorithm}.
      *
-     * @return  the stored value of {@link #learningAlgorithm}
+     * @return the stored value of {@link #learningAlgorithm}
      */
     @Override
     public LearningAlgorithmName getLearningAlgorithm() {
@@ -312,7 +313,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #equivalenceAlgorithms}.
      *
-     * @return  the stored value of {@link #equivalenceAlgorithms}
+     * @return the stored value of {@link #equivalenceAlgorithms}
      */
     @Override
     public List<EquivalenceAlgorithmName> getEquivalenceAlgorithms() {
@@ -322,7 +323,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #maxDepth}.
      *
-     * @return  the stored value of {@link #maxDepth}
+     * @return the stored value of {@link #maxDepth}
      */
     @Override
     public int getMaxDepth() {
@@ -332,7 +333,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #minLength}.
      *
-     * @return  the stored value of {@link #minLength}
+     * @return the stored value of {@link #minLength}
      */
     @Override
     public int getMinLength() {
@@ -342,7 +343,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #maxLength}.
      *
-     * @return  the stored value of {@link #maxLength}
+     * @return the stored value of {@link #maxLength}
      */
     @Override
     public int getMaxLength() {
@@ -352,7 +353,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #randLength}.
      *
-     * @return  the stored value of {@link #randLength}
+     * @return the stored value of {@link #randLength}
      */
     @Override
     public int getRandLength() {
@@ -362,7 +363,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #equivQueryBound}.
      *
-     * @return  the stored value of {@link #equivQueryBound}
+     * @return the stored value of {@link #equivQueryBound}
      */
     @Override
     public int getEquivQueryBound() {
@@ -372,7 +373,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #runsPerMembershipQuery}.
      *
-     * @return  the stored value of {@link #runsPerMembershipQuery}
+     * @return the stored value of {@link #runsPerMembershipQuery}
      */
     @Override
     public int getRunsPerMembershipQuery() {
@@ -382,7 +383,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #membershipQueryRetries}.
      *
-     * @return  the stored value of {@link #membershipQueryRetries}
+     * @return the stored value of {@link #membershipQueryRetries}
      */
     @Override
     public int getMembershipQueryRetries() {
@@ -392,7 +393,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #logQueries}.
      *
-     * @return  the stored value of {@link #logQueries}
+     * @return the stored value of {@link #logQueries}
      */
     @Override
     public boolean isLogQueries() {
@@ -402,7 +403,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #probReset}.
      *
-     * @return  the stored value of {@link #probReset}
+     * @return the stored value of {@link #probReset}
      */
     @Override
     public double getProbReset() {
@@ -412,7 +413,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #testFile}.
      *
-     * @return  the stored value of {@link #testFile}
+     * @return the stored value of {@link #testFile}
      */
     @Override
     public String getTestFile() {
@@ -422,7 +423,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #seed}.
      *
-     * @return  the stored value of {@link #seed}
+     * @return the stored value of {@link #seed}
      */
     @Override
     public long getSeed() {
@@ -432,7 +433,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #cacheTests}.
      *
-     * @return  the stored value of {@link #cacheTests}
+     * @return the stored value of {@link #cacheTests}
      */
     @Override
     public boolean isCacheTests() {
@@ -442,7 +443,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #ceSanitizationDisable}.
      *
-     * @return  the stored value of {@link #ceSanitizationDisable}
+     * @return the stored value of {@link #ceSanitizationDisable}
      */
     @Override
     public boolean isCeSanitization() {
@@ -452,7 +453,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #skipNonDetTests}.
      *
-     * @return  the stored value of {@link #skipNonDetTests}
+     * @return the stored value of {@link #skipNonDetTests}
      */
     @Override
     public boolean isSkipNonDetTests() {
@@ -462,7 +463,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #ceReruns}.
      *
-     * @return  the stored value of {@link #ceReruns}
+     * @return the stored value of {@link #ceReruns}
      */
     @Override
     public int getCeReruns() {
@@ -472,7 +473,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #probabilisticSanitizationDisable}.
      *
-     * @return  the stored value of {@link #probabilisticSanitizationDisable}
+     * @return the stored value of {@link #probabilisticSanitizationDisable}
      */
     @Override
     public boolean isProbabilisticSanitization() {
@@ -482,7 +483,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #timeLimit}.
      *
-     * @return  the stored value of {@link #timeLimit}
+     * @return the stored value of {@link #timeLimit}
      */
     @Override
     public Duration getTimeLimit() {
@@ -492,7 +493,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #testLimit}.
      *
-     * @return  the stored value of {@link #testLimit}
+     * @return the stored value of {@link #testLimit}
      */
     @Override
     public Long getTestLimit() {
@@ -502,7 +503,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #roundLimit}.
      *
-     * @return  the stored value of {@link #roundLimit}
+     * @return the stored value of {@link #roundLimit}
      */
     @Override
     public Integer getRoundLimit() {
@@ -512,7 +513,7 @@ public class LearnerConfigStandard implements LearnerConfig {
     /**
      * Returns the stored value of {@link #equivalenceThreadCount}.
      *
-     * @return  the stored value of {@link #equivalenceThreadCount}
+     * @return the stored value of {@link #equivalenceThreadCount}
      */
     @Override
     public int getEquivalenceThreadCount() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/RoundLimitReachedException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/RoundLimitReachedException.java
@@ -16,7 +16,7 @@ public class RoundLimitReachedException extends RuntimeException {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param roundLimit  the limit of rounds that has been reached
+     * @param roundLimit the limit of rounds that has been reached
      */
     public RoundLimitReachedException(long roundLimit) {
         super("Experiment has exceeded the round limit given: " + roundLimit);
@@ -26,7 +26,7 @@ public class RoundLimitReachedException extends RuntimeException {
     /**
      * Returns the stored {@link #roundLimit}.
      *
-     * @return  the stored {@link #roundLimit}
+     * @return the stored {@link #roundLimit}
      */
     public long getRoundLimit() {
         return roundLimit;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/TestLimitReachedException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/TestLimitReachedException.java
@@ -16,7 +16,7 @@ public class TestLimitReachedException extends RuntimeException {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param testLimit  the limit of tests that has been reached
+     * @param testLimit the limit of tests that has been reached
      */
     public TestLimitReachedException(long testLimit) {
         super("Experiment has exceeded the test limit given: " + testLimit);
@@ -26,7 +26,7 @@ public class TestLimitReachedException extends RuntimeException {
     /**
      * Returns the stored {@link #testLimit}.
      *
-     * @return  the stored {@link #testLimit}
+     * @return the stored {@link #testLimit}
      */
     public long getTestLimit() {
         return testLimit;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/TimeLimitReachedException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/TimeLimitReachedException.java
@@ -17,7 +17,7 @@ public class TimeLimitReachedException extends RuntimeException {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param duration  the duration that has been exceeded
+     * @param duration the duration that has been exceeded
      */
     public TimeLimitReachedException(Duration duration) {
         super("Experiment has exceeded the duration limit given: " + duration);
@@ -27,7 +27,7 @@ public class TimeLimitReachedException extends RuntimeException {
     /**
      * Returns the stored {@link #duration}.
      *
-     * @return  the stored {@link #duration}
+     * @return the stored {@link #duration}
      */
     public Duration getDuration() {
         return duration;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/EquivalenceAlgorithmName.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/EquivalenceAlgorithmName.java
@@ -16,13 +16,22 @@ public enum EquivalenceAlgorithmName {
     /** Represents the WP Method, which is smarter. */
     WP_METHOD,
 
-    /** Check {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.RandomWpMethodEQOracle}. */
+    /**
+     * Check
+     * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.RandomWpMethodEQOracle}.
+     */
     RANDOM_WP_METHOD,
 
-    /** Check {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.SampledTestsEQOracle}. */
+    /**
+     * Check
+     * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.SampledTestsEQOracle}.
+     */
     SAMPLED_TESTS,
 
-    /** Check {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.WpSampledTestsEQOracle}. */
+    /**
+     * Check
+     * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.oracles.WpSampledTestsEQOracle}.
+     */
     WP_SAMPLED_TESTS,
 
     /** It is currently unsupported. */

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningAlgorithmName.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningAlgorithmName.java
@@ -2,7 +2,8 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factor
 
 /**
  * The learning algorithms.
- * Inspired from <a href="https://gitlab.science.ru.nl/ramonjanssen/basic-learning">basic-learning</a>.
+ * Inspired from
+ * <a href="https://gitlab.science.ru.nl/ramonjanssen/basic-learning">basic-learning</a>.
  */
 public enum LearningAlgorithmName {
     /** It is the basic algorithm. */

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -59,27 +59,27 @@ public class LearningSetupFactory {
     /**
      * Constructor
      */
-    public LearningSetupFactory() { }
+    public LearningSetupFactory() {}
 
     /**
      * Create a new MealyLearner from the given parameters.
      *
-     * @param <I>        the type of inputs
-     * @param <O>        the type of outputs
-     * @param config     the learner configuration to be used
-     * @param sulOracle  the sul oracle to be used for the Learner
-     * @param alphabet   the (input) alphabet to be used
+     * @param  <I>       the type of inputs
+     * @param  <O>       the type of outputs
+     * @param  config    the learner configuration to be used
+     * @param  sulOracle the sul oracle to be used for the Learner
+     * @param  alphabet  the (input) alphabet to be used
+     *
      * @return           the created Learner
      */
     public static <I, O> MealyLearner<I, O> createMealyLearner(
         LearnerConfig config,
         MealyMembershipOracle<I, O> sulOracle,
-        Alphabet<I> alphabet
-    ) {
+        Alphabet<I> alphabet) {
         return switch (config.getLearningAlgorithm()) {
             case LSTAR ->
                 new ExtensibleLStarMealy<>(alphabet, sulOracle, new ArrayList<>(),
-                        ObservationTableCEXHandlers.CLASSIC_LSTAR, ClosingStrategies.CLOSE_SHORTEST);
+                    ObservationTableCEXHandlers.CLASSIC_LSTAR, ClosingStrategies.CLOSE_SHORTEST);
 
             case TTT ->
                 new TTTLearnerMealyBuilder<I, O>()
@@ -90,7 +90,7 @@ public class LearningSetupFactory {
 
             case RS ->
                 new ExtensibleLStarMealy<>(alphabet, sulOracle, new ArrayList<>(),
-                        ObservationTableCEXHandlers.RIVEST_SCHAPIRE, ClosingStrategies.CLOSE_SHORTEST);
+                    ObservationTableCEXHandlers.RIVEST_SCHAPIRE, ClosingStrategies.CLOSE_SHORTEST);
 
             case KV ->
                 new KearnsVaziraniMealy<>(alphabet, sulOracle, false, AcexAnalyzers.LINEAR_FWD);
@@ -103,24 +103,25 @@ public class LearningSetupFactory {
     /**
      * Create a new MealyLearner from the given parameters.
      *
-     * @param config    the learner configuration to be used
-     * @param ioOracle  the sul oracle to be used for the Learner
-     * @param alphabet  the (input) alphabet to be used
-     * @param teachers  the teachers to be used for learning
-     * @param solver    the solver to be used for learning
-     * @param consts    the constants to be used for learning
+     * @param  config   the learner configuration to be used
+     * @param  ioOracle the sul oracle to be used for the Learner
+     * @param  alphabet the (input) alphabet to be used
+     * @param  teachers the teachers to be used for learning
+     * @param  solver   the solver to be used for learning
+     * @param  consts   the constants to be used for learning
+     *
      * @return          the created Learner
      */
     public static RaLearningAlgorithm createRALearner(
-            LearnerConfig config,
-            IOOracle ioOracle,
-            Alphabet<? extends ParameterizedSymbol> alphabet,
-            Map<DataType, Theory> teachers,
-            ConstraintSolver solver,
-            Constants consts) {
+        LearnerConfig config,
+        IOOracle ioOracle,
+        Alphabet<? extends ParameterizedSymbol> alphabet,
+        Map<DataType, Theory> teachers,
+        ConstraintSolver solver,
+        Constants consts) {
 
         ParameterizedSymbol[] inputs = alphabet.stream().filter(p -> p instanceof InputSymbol)
-                .toArray(ParameterizedSymbol[]::new);
+            .toArray(ParameterizedSymbol[]::new);
 
         ParameterizedSymbol[] alphaArray = alphabet.toArray(ParameterizedSymbol[]::new);
 
@@ -128,12 +129,12 @@ public class LearningSetupFactory {
         IOFilter ioFilter = new IOFilter(ioCache, inputs);
 
         MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
-                ioFilter, teachers, consts, solver);
+            ioFilter, teachers, consts, solver);
 
         SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
 
         TreeOracleFactory hypFactory = (RegisterAutomaton hyp) -> new MultiTheoryTreeOracle(new SimulatorOracle(hyp),
-                teachers, consts, solver);
+            teachers, consts, solver);
 
         return switch (config.getLearningAlgorithm()) {
             case SLLAMBDA ->
@@ -144,40 +145,42 @@ public class LearningSetupFactory {
 
             default ->
                 throw new RuntimeException(
-                        "RA Learner algorithm " + config.getLearningAlgorithm() + " is not supported");
+                    "RA Learner algorithm " + config.getLearningAlgorithm() + " is not supported");
         };
     }
 
     /**
      * Create a new Equivalence Oracle from the given parameters.
      *
-     * @param <I>         the type of inputs
-     * @param <O>         the type of outputs
-     * @param config      the learner configuration to be used
-     * @param suls        the list of suls that are contained inside the sulOracles
-     * @param sulOracles  the list of sul oracles to be used that contains the suls
-     * @param alphabet    the alphabet to be used
+     * @param  <I>        the type of inputs
+     * @param  <O>        the type of outputs
+     * @param  config     the learner configuration to be used
+     * @param  suls       the list of suls that are contained inside the sulOracles
+     * @param  sulOracles the list of sul oracles to be used that contains the suls
+     * @param  alphabet   the alphabet to be used
+     *
      * @return            the created Equivalence Oracle
      */
     public static <I, O> EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>> createEquivalenceOracle(
-            LearnerConfig config,
-            List<SUL<I, O>> suls,
-            List<MealyMembershipOracle<I, O>> sulOracles,
-            Alphabet<I> alphabet) {
+        LearnerConfig config,
+        List<SUL<I, O>> suls,
+        List<MealyMembershipOracle<I, O>> sulOracles,
+        Alphabet<I> alphabet) {
         if (config.getEquivalenceAlgorithms().isEmpty()) {
             return (m, i) -> null;
         }
 
         if (config.getEquivalenceAlgorithms().size() == 1) {
-            return createEquivalenceOracleForAlgorithm(config.getEquivalenceAlgorithms().get(0), config, suls, sulOracles,
-                    alphabet);
+            return createEquivalenceOracleForAlgorithm(config.getEquivalenceAlgorithms().get(0), config, suls,
+                sulOracles,
+                alphabet);
         }
 
         List<EquivalenceOracle.MealyEquivalenceOracle<I, O>> eqOracles;
 
         eqOracles = config.getEquivalenceAlgorithms().stream()
-                .map(alg -> createEquivalenceOracleForAlgorithm(alg, config, suls, sulOracles, alphabet))
-                .collect(Collectors.toList());
+            .map(alg -> createEquivalenceOracleForAlgorithm(alg, config, suls, sulOracles, alphabet))
+            .collect(Collectors.toList());
 
         return new MealyEQOracleChain<>(eqOracles);
     }
@@ -185,26 +188,27 @@ public class LearningSetupFactory {
     /**
      * Create one or more new RA Equivalence Oracles from the given parameters.
      *
-     * @param config    the learner configuration to be used
-     * @param sul       the sul that is contained inside the sulOracle
-     * @param alphabet  the alphabet to be used
-     * @param teachers  the teachers to be used
-     * @param consts    the consts to be used
+     * @param  config   the learner configuration to be used
+     * @param  sul      the sul that is contained inside the sulOracle
+     * @param  alphabet the alphabet to be used
+     * @param  teachers the teachers to be used
+     * @param  consts   the consts to be used
+     *
      * @return          the created RA Equivalence Oracle
      */
     public static IOEquivalenceOracle createEquivalenceOracle(
-            LearnerConfig config,
-            DataWordSUL sul,
-            Alphabet<? extends ParameterizedSymbol> alphabet,
-            Map<DataType, Theory> teachers,
-            Constants consts) {
+        LearnerConfig config,
+        DataWordSUL sul,
+        Alphabet<? extends ParameterizedSymbol> alphabet,
+        Map<DataType, Theory> teachers,
+        Constants consts) {
 
         if (config.getEquivalenceAlgorithms().isEmpty()) {
             throw new RuntimeException("No RA Equivalence algorithm has been chosen");
         }
 
         return createEquivalenceOracleForAlgorithm(config.getEquivalenceAlgorithms().get(0), config, sul,
-                alphabet, teachers, consts);
+            alphabet, teachers, consts);
     }
 
     /**
@@ -214,13 +218,14 @@ public class LearningSetupFactory {
      * The suls parameter is needed, because it cannot be extracted from the
      * sulOracles parameter.
      *
-     * @param <I>         the type of inputs
-     * @param <O>         the type of outputs
-     * @param algorithm   the Equivalence algorithm name
-     * @param config      the learner configuration to be used
-     * @param suls        the list of suls that are contained inside the sulOracles
-     * @param sulOracles  the list of sul oracles to be used that contains the suls
-     * @param alphabet    the alphabet to be used
+     * @param  <I>        the type of inputs
+     * @param  <O>        the type of outputs
+     * @param  algorithm  the Equivalence algorithm name
+     * @param  config     the learner configuration to be used
+     * @param  suls       the list of suls that are contained inside the sulOracles
+     * @param  sulOracles the list of sul oracles to be used that contains the suls
+     * @param  alphabet   the alphabet to be used
+     *
      * @return            the created Equivalence Oracle
      */
     protected static <I, O> EquivalenceOracle.MealyEquivalenceOracle<I, O> createEquivalenceOracleForAlgorithm(
@@ -234,7 +239,7 @@ public class LearningSetupFactory {
             // simplest method, but doesn't perform well for large models
             case RANDOM_WALK ->
                 new RandomWalkEQOracle<>(suls.get(0), config.getProbReset(), config.getEquivQueryBound(), true,
-                        new Random(config.getSeed()));
+                    new Random(config.getSeed()));
 
             // Smarter methods: state coverage, trying to distinguish states, etc.
             case W_METHOD ->
@@ -245,8 +250,8 @@ public class LearningSetupFactory {
 
             case RANDOM_WP_METHOD ->
                 new RandomWpMethodEQOracle<>(
-                        sulOracles, config.getMinLength(), config.getRandLength(),
-                        config.getEquivQueryBound(), config.getSeed());
+                    sulOracles, config.getMinLength(), config.getRandLength(),
+                    config.getEquivQueryBound(), config.getSeed());
 
             case SAMPLED_TESTS ->
                 new SampledTestsEQOracle<I, O>(readTests(config, alphabet), sulOracles.get(0));
@@ -268,40 +273,41 @@ public class LearningSetupFactory {
      * The sul parameter is needed, because it cannot be extracted from the
      * sulOracle parameter.
      *
-     * @param algorithm  the Equivalence algorithm name
-     * @param config     the learner configuration to be used
-     * @param sul        the sul that is contained inside the sulOracle
-     * @param alphabet   the alphabet to be used
-     * @param teachers   the teachers to be used
-     * @param consts     the consts to be used
+     * @param  algorithm the Equivalence algorithm name
+     * @param  config    the learner configuration to be used
+     * @param  sul       the sul that is contained inside the sulOracle
+     * @param  alphabet  the alphabet to be used
+     * @param  teachers  the teachers to be used
+     * @param  consts    the consts to be used
+     *
      * @return           the created RA Equivalence Oracle
      */
     protected static IOEquivalenceOracle createEquivalenceOracleForAlgorithm(
-            EquivalenceAlgorithmName algorithm,
-            LearnerConfig config,
-            DataWordSUL sul,
-            Alphabet<? extends ParameterizedSymbol> alphabet,
-            Map<DataType, Theory> teachers,
-            Constants consts) {
+        EquivalenceAlgorithmName algorithm,
+        LearnerConfig config,
+        DataWordSUL sul,
+        Alphabet<? extends ParameterizedSymbol> alphabet,
+        Map<DataType, Theory> teachers,
+        Constants consts) {
 
         ParameterizedSymbol[] inputs = alphabet.stream()
-                .filter(pSymbol -> pSymbol instanceof InputSymbol)
-                .toArray(ParameterizedSymbol[]::new);
+            .filter(pSymbol -> pSymbol instanceof InputSymbol)
+            .toArray(ParameterizedSymbol[]::new);
 
         return switch (algorithm) {
             case IO_RANDOM_WALK ->
                 new IORandomWalk(new Random(config.getSeed()),
-                        sul,
-                        config.getDrawSymbolsUniformly(),
-                        config.getProbReset(),
-                        config.getProbNewDataValue(),
-                        config.getMaxRuns(),
-                        config.getMaxDepthRA(),
-                        consts,
-                        config.getResetRuns(),
-                        config.getSeedTransitions(),
-                        teachers,
-                        inputs);
+                    sul,
+                    config.getDrawSymbolsUniformly(),
+                    config.getProbReset(),
+                    config.getProbNewDataValue(),
+                    config.getMaxRuns(),
+                    config.getMaxDepthRA(),
+                    consts,
+                    config.getResetRuns(),
+                    config.getSeedTransitions(),
+                    teachers,
+                    inputs);
 
             default ->
                 throw new RuntimeException("Equivalence algorithm " + algorithm + " is not supported for RA");
@@ -311,17 +317,19 @@ public class LearningSetupFactory {
     /**
      * Reads tests from the file found in {@link LearnerConfig#getTestFile()}.
      *
-     * @param <I>       the type of inputs
-     * @param config    the learner config to be used
-     * @param alphabet  the alphabet of the tests
+     * @param  <I>      the type of inputs
+     * @param  config   the learner config to be used
+     * @param  alphabet the alphabet of the tests
+     *
      * @return          the list of words of inputs; one word for each test read
      */
     protected static <I> List<Word<I>> readTests(LearnerConfig config, Alphabet<I> alphabet) {
         try {
             return new TestParser<I>().readTests(alphabet, config.getTestFile());
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new RuntimeException(
-                    "Could not read tests from file " + config.getTestFile() + ": " + e.getMessage());
+                "Could not read tests from file " + config.getTestFile() + ": " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/factory/LearningSetupFactory.java
@@ -115,10 +115,6 @@ public class LearningSetupFactory {
             LearnerConfig config,
             IOOracle ioOracle,
             Alphabet<? extends ParameterizedSymbol> alphabet,
-            /*
-             * Theory is used as a rawtype like this in RALib as theories of different types
-             * can be used for the same learner so we don't know how to solve this warning
-             */
             Map<DataType, Theory> teachers,
             ConstraintSolver solver,
             Constants consts) {
@@ -200,10 +196,6 @@ public class LearningSetupFactory {
             LearnerConfig config,
             DataWordSUL sul,
             Alphabet<? extends ParameterizedSymbol> alphabet,
-            /*
-             * Theory is used as a rawtype like this in RALib as theories of different types
-             * can be used for the same learner so we don't know how to solve this warning
-             */
             Map<DataType, Theory> teachers,
             Constants consts) {
 
@@ -289,10 +281,6 @@ public class LearningSetupFactory {
             LearnerConfig config,
             DataWordSUL sul,
             Alphabet<? extends ParameterizedSymbol> alphabet,
-            /*
-             * Theory is used as a rawtype like this in RALib as theories of different types
-             * can be used for the same learner so we don't know how to solve this warning
-             */
             Map<DataType, Theory> teachers,
             Constants consts) {
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/CESanitizingSULOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/CESanitizingSULOracle.java
@@ -14,14 +14,15 @@ import java.util.function.Supplier;
  * Checks and confirms a potential counterexample by re-running it.
  * <p>
  * This allows to avoid restarting the whole testing process due to spurious counterexamples.
- * The output comparison should be done twice, but that cost is insignificant in the context of learning.
+ * The output comparison should be done twice, but that cost is insignificant in the context of
+ * learning.
  *
  * @param <HA> the type of hypothesis automaton
  * @param <I>  the type of inputs
  * @param <O>  the type of outputs
  */
 public class CESanitizingSULOracle<HA extends UniversalDeterministicAutomaton<?, I, ?, ?, ?> & Output<I, Word<O>>, I, O>
-        extends MultipleRunsSULOracle<I, O> {
+    extends MultipleRunsSULOracle<I, O> {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -37,13 +38,15 @@ public class CESanitizingSULOracle<HA extends UniversalDeterministicAutomaton<?,
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param runs                       the number of times that a counterexample should be run, stored in {@link #runs}
-     * @param sulOracle                  the sul Oracle that is being wrapped
-     * @param probabilisticSanitization  {@code true} to enable the probabilistic sanitization
-     * @param writer                     the writer used to log results and information
-     * @param automatonProvider          the provider of the hypothesis automaton
-     * @param cache                      the external cache used for lookup
-     * @param skipNonDetTests            {@code true} to skip non-deterministic tests and not throw an exception
+     * @param runs                      the number of times that a counterexample should be run, stored
+     *                                      in {@link #runs}
+     * @param sulOracle                 the sul Oracle that is being wrapped
+     * @param probabilisticSanitization {@code true} to enable the probabilistic sanitization
+     * @param writer                    the writer used to log results and information
+     * @param automatonProvider         the provider of the hypothesis automaton
+     * @param cache                     the external cache used for lookup
+     * @param skipNonDetTests           {@code true} to skip non-deterministic tests and not throw an
+     *                                      exception
      */
     public CESanitizingSULOracle(int runs,
         MealyMembershipOracle<I, O> sulOracle, boolean probabilisticSanitization,
@@ -59,9 +62,9 @@ public class CESanitizingSULOracle<HA extends UniversalDeterministicAutomaton<?,
     /**
      * Processes the given query using counterexample sanitization.
      *
-     * @param query  the query to be processed
+     * @param  query                   the query to be processed
      *
-     * @throws NonDeterminismException  thrown from {@link #getCheckedOutput(Word, Word, Word)}
+     * @throws NonDeterminismException thrown from {@link #getCheckedOutput(Word, Word, Word)}
      */
     @Override
     public void processQuery(Query<I, Word<O>> query) throws NonDeterminismException {
@@ -101,19 +104,21 @@ public class CESanitizingSULOracle<HA extends UniversalDeterministicAutomaton<?,
      * <p>
      * Specifically:
      * <ul>
-     * <li> If the output does not equal none of originalOutput and hypOutput then it is a CE
-     * <li> If the output does not equal the originalOutput, but equals the hypOutput then it is not a CE
+     * <li>If the output does not equal none of originalOutput and hypOutput then it is a CE
+     * <li>If the output does not equal the originalOutput, but equals the hypOutput then it is not a CE
      * </ul>
      *
-     * @param input           the input to be run multiple times
-     * @param originalOutput  the original output of the sulOracle
-     * @param hypOutput       the hypothesis output obtained from {@link #automatonProvider}
-     * @return                the checked output or the hypOutput if the checked output
-     *                        can be found and {@link #skipNonDetTests} is enabled
+     * @param  input                   the input to be run multiple times
+     * @param  originalOutput          the original output of the sulOracle
+     * @param  hypOutput               the hypothesis output obtained from {@link #automatonProvider}
      *
-     * @throws NonDeterminismException  if the checked output cannot be found after multiple runs
+     * @return                         the checked output or the hypOutput if the checked output
+     *                                     can be found and {@link #skipNonDetTests} is enabled
+     *
+     * @throws NonDeterminismException if the checked output cannot be found after multiple runs
      */
-    protected Word<O> getCheckedOutput(Word<I> input, Word<O> originalOutput, Word<O> hypOutput) throws NonDeterminismException {
+    protected Word<O> getCheckedOutput(Word<I> input, Word<O> originalOutput, Word<O> hypOutput)
+        throws NonDeterminismException {
         try {
             Word<O> checkedOutput = super.getMultipleRunOutput(input);
 
@@ -134,7 +139,8 @@ public class CESanitizingSULOracle<HA extends UniversalDeterministicAutomaton<?,
 
             return checkedOutput;
 
-        } catch (NonDeterminismException e) {
+        }
+        catch (NonDeterminismException e) {
             if (!skipNonDetTests) {
                 throw e;
             }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/CacheInconsistencyException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/CacheInconsistencyException.java
@@ -7,7 +7,8 @@ import java.io.Serial;
 /**
  * Exception used by the {@link CachingSULOracle}.
  * <p>
- * Copied from <a href="https://gitlab.science.ru.nl/ramonjanssen/basic-learning/">basic-learning</a>
+ * Copied from
+ * <a href="https://gitlab.science.ru.nl/ramonjanssen/basic-learning/">basic-learning</a>
  * and split into this one and {@link NonDeterminismException}.
  */
 public class CacheInconsistencyException extends NonDeterminismException {
@@ -18,9 +19,9 @@ public class CacheInconsistencyException extends NonDeterminismException {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param input      the input for which non-determinism was observed
-     * @param oldOutput  the old output corresponding to the input
-     * @param newOutput  the new output corresponding to the input and is different from oldOutput
+     * @param input     the input for which non-determinism was observed
+     * @param oldOutput the old output corresponding to the input
+     * @param newOutput the new output corresponding to the input and is different from oldOutput
      */
     public CacheInconsistencyException(Word<?> input, Word<?> oldOutput, Word<?> newOutput) {
         super(input, oldOutput, newOutput);
@@ -29,10 +30,10 @@ public class CacheInconsistencyException extends NonDeterminismException {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param message    the message related to the exception
-     * @param input      the input for which non-determinism was observed
-     * @param oldOutput  the old output corresponding to the input
-     * @param newOutput  the new output corresponding to the input and is different from oldOutput
+     * @param message   the message related to the exception
+     * @param input     the input for which non-determinism was observed
+     * @param oldOutput the old output corresponding to the input
+     * @param newOutput the new output corresponding to the input and is different from oldOutput
      */
     public CacheInconsistencyException(String message, Word<?> input, Word<?> oldOutput, Word<?> newOutput) {
         super(message, input, oldOutput, newOutput);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/CachingSULOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/CachingSULOracle.java
@@ -15,8 +15,8 @@ import java.util.List;
 /**
  * Caches inputs and outputs and adds functionality for terminating outputs.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class CachingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -36,10 +36,11 @@ public class CachingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sulOracle           the sul oracle to be wrapped
-     * @param cache               the external cache used to lookup and store inputs and outputs
-     * @param onlyLookup          {@code true} if the external cache is used only for lookup, but not for storing
-     * @param terminatingOutputs  the terminating outputs to be used
+     * @param sulOracle          the sul oracle to be wrapped
+     * @param cache              the external cache used to lookup and store inputs and outputs
+     * @param onlyLookup         {@code true} if the external cache is used only for lookup, but not for
+     *                               storing
+     * @param terminatingOutputs the terminating outputs to be used
      */
     public CachingSULOracle(MembershipOracle<I, Word<O>> sulOracle, ObservationTree<I, O> cache,
         boolean onlyLookup, List<O> terminatingOutputs) {
@@ -61,11 +62,11 @@ public class CachingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
      * It also stores each input and output to {@link #cache}, if storing is
      * enabled.
      *
-     * @param queries  the queries to be answered
+     * @param queries the queries to be answered
      */
     @Override
     public void processQueries(Collection<? extends Query<I, Word<O>>> queries) {
-        for (Query<I, Word<O>> q : queries) {
+        for (Query<I, Word<O>> q: queries) {
             Word<I> fullInput = q.getPrefix().concat(q.getSuffix());
             Word<O> fullOutput = cacheAnswer(fullInput);
 
@@ -86,13 +87,14 @@ public class CachingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     /**
      * Adds the input and output words to {@link #cache}.
      *
-     * @param input   the input
-     * @param output  the corresponding output
+     * @param input  the input
+     * @param output the corresponding output
      */
     protected void cacheAdd(Word<I> input, Word<O> output) {
         try {
             cache.addObservation(input, output);
-        } catch (CacheInconsistencyException e) {
+        }
+        catch (CacheInconsistencyException e) {
             LOGGER.warn(e.getMessage());
         }
     }
@@ -100,7 +102,8 @@ public class CachingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     /**
      * Looks up {@link #cache} for an output to the given input.
      *
-     * @param input  the input to be answered if it is cached
+     * @param  input the input to be answered if it is cached
+     *
      * @return       the corresponding output or null
      */
     @Nullable protected Word<O> cacheAnswer(Word<I> input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/LoggingSULOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/LoggingSULOracle.java
@@ -14,8 +14,8 @@ import java.util.Collection;
  * Logs the queries that it processes to the console and optionally using
  * a given Writer.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class LoggingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -29,8 +29,8 @@ public class LoggingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sulOracle  the sul Oracle that is being wrapped
-     * @param writer     the Writer used for logging queries
+     * @param sulOracle the sul Oracle that is being wrapped
+     * @param writer    the Writer used for logging queries
      */
     public LoggingSULOracle(MealyMembershipOracle<I, O> sulOracle, Writer writer) {
         this.sulOracle = sulOracle;
@@ -40,7 +40,7 @@ public class LoggingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
     /**
      * Constructs a new instance from the given parameter without any Writer.
      *
-     * @param sulOracle  the sul Oracle that is being wrapped
+     * @param sulOracle the sul Oracle that is being wrapped
      */
     public LoggingSULOracle(MealyMembershipOracle<I, O> sulOracle) {
         this.sulOracle = sulOracle;
@@ -51,7 +51,7 @@ public class LoggingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
      * Processes the provided query using {@link processQueries} and
      * logs the query.
      *
-     * @param query  the query to be processed
+     * @param query the query to be processed
      */
     @Override
     public void processQuery(Query<I, Word<O>> query) {
@@ -63,11 +63,11 @@ public class LoggingSULOracle<I, O> implements MealyMembershipOracle<I, O> {
      * Processes the provided queries using the stored {@link #sulOracle} and then
      * logs each query (with their answer) using {@link #printWriter}.
      *
-     * @param queries  the queries to be processed
+     * @param queries the queries to be processed
      */
     @Override
     public void processQueries(Collection<? extends Query<I, Word<O>>> queries) {
-        for (Query<I, Word<O>> query : queries) {
+        for (Query<I, Word<O>> query: queries) {
             sulOracle.processQuery(query);
 
             if (printWriter != null) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/MembershipOracleWrapperRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/MembershipOracleWrapperRA.java
@@ -22,7 +22,7 @@ public class MembershipOracleWrapperRA implements MembershipOracle<PSymbolInstan
     /**
      * Constructs a wrapper around the provided instance
      *
-     * @param wrappedOracle    The SULOracle to wrap
+     * @param wrappedOracle The SULOracle to wrap
      */
     public MembershipOracleWrapperRA(SULOracle wrappedOracle) {
         this.wrappedOracle = wrappedOracle;
@@ -39,7 +39,7 @@ public class MembershipOracleWrapperRA implements MembershipOracle<PSymbolInstan
 
         Word<PSymbolInstance> ioTrace = wrappedOracle.trace(ioTraceBuilder.toWord());
         WordBuilder<PSymbolInstance> outputBuilder = new WordBuilder<PSymbolInstance>();
-        for (PSymbolInstance symInstance : ioTrace) {
+        for (PSymbolInstance symInstance: ioTrace) {
             if (symInstance.getBaseSymbol() instanceof OutputSymbol) {
                 outputBuilder.add(symInstance);
             }
@@ -50,7 +50,7 @@ public class MembershipOracleWrapperRA implements MembershipOracle<PSymbolInstan
 
     @Override
     public void processQueries(Collection<? extends Query<PSymbolInstance, Word<PSymbolInstance>>> queries) {
-        for (Query<PSymbolInstance, Word<PSymbolInstance>> query : queries) {
+        for (Query<PSymbolInstance, Word<PSymbolInstance>> query: queries) {
             query.answer(answerQuery(query.getInput()));
         }
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/MultiQuerySULOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/MultiQuerySULOracle.java
@@ -76,36 +76,36 @@ public class MultiQuerySULOracle extends SULOracle {
             if (enoughTestsRun(tries)) {
 
                 Entry<Word<PSymbolInstance>, Integer> mostCommonEntry = wordOccurrenceMap
-                        .entrySet()
-                        .stream()
-                        .max(Entry.comparingByValue())
-                        .orElseThrow();
+                    .entrySet()
+                    .stream()
+                    .max(Entry.comparingByValue())
+                    .orElseThrow();
 
                 double likelihood = (double) mostCommonEntry.getValue() / (tries + 1);
                 LOGGER.info("Most likely answer {} has likelihood {} after {} tests", mostCommonEntry.getKey(),
-                        likelihood, tries);
+                    likelihood, tries);
 
                 if (likelihood >= ACCEPTABLE_PROBABILISTIC_THRESHOLD) {
                     LOGGER.info("Likelihood {} greater or equal to {}, returning answer {}",
-                            likelihood,
-                            ACCEPTABLE_PROBABILISTIC_THRESHOLD,
-                            mostCommonEntry.getKey());
+                        likelihood,
+                        ACCEPTABLE_PROBABILISTIC_THRESHOLD,
+                        mostCommonEntry.getKey());
                     return mostCommonEntry.getKey();
                 } else if (likelihood >= PASSABLE_PROBABILISTIC_THRESHOLD) {
                     LOGGER.info("Likelihood {} greater or equal to {}, continuing execution",
-                            likelihood,
-                            PASSABLE_PROBABILISTIC_THRESHOLD);
+                        likelihood,
+                        PASSABLE_PROBABILISTIC_THRESHOLD);
                 } else {
                     LOGGER.error("Likelihood {} below passable threshold {}",
-                            likelihood,
-                            PASSABLE_PROBABILISTIC_THRESHOLD);
+                        likelihood,
+                        PASSABLE_PROBABILISTIC_THRESHOLD);
                     Iterator<Word<PSymbolInstance>> outputIter = wordOccurrenceMap.keySet().iterator();
                     throw new NonDeterminismException(input, outputIter.next(), outputIter.next()).makeCompact();
                 }
             }
         }
         LOGGER.error("Exhausted {} or more tests without having found an acceptable answer",
-                runs * PROBABILISTIC_MAX_MULTIPLIER);
+            runs * PROBABILISTIC_MAX_MULTIPLIER);
         Iterator<Word<PSymbolInstance>> outputIter = wordOccurrenceMap.keySet().iterator();
         throw new NonDeterminismException(input, outputIter.next(), outputIter.next()).makeCompact();
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/MultipleRunsSULOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/MultipleRunsSULOracle.java
@@ -19,12 +19,13 @@ import java.util.Map.Entry;
  * <p>
  * Probabilistic sanitization entails running the query many times and
  * computing the answer with the highest likelihood. If the likelihood is
- * greater than a threshold the answer is returned otherwise {@link NonDeterminismException} is thrown.
+ * greater than a threshold the answer is returned otherwise {@link NonDeterminismException} is
+ * thrown.
  * <p>
  * This oracle provides a foundation for other oracles that want to re-run queries.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> {
 
@@ -55,12 +56,13 @@ public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> 
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param runs                       the number of times that a query should be run
-     * @param sulOracle                  the sul Oracle that is being wrapped
-     * @param probabilisticSanitization  {@code true} to enable the probabilistic sanitization
-     * @param writer                     the writer used to log results and information
+     * @param runs                      the number of times that a query should be run
+     * @param sulOracle                 the sul Oracle that is being wrapped
+     * @param probabilisticSanitization {@code true} to enable the probabilistic sanitization
+     * @param writer                    the writer used to log results and information
      */
-    public MultipleRunsSULOracle(int runs, MealyMembershipOracle<I, O> sulOracle, boolean probabilisticSanitization, Writer writer) {
+    public MultipleRunsSULOracle(int runs, MealyMembershipOracle<I, O> sulOracle, boolean probabilisticSanitization,
+        Writer writer) {
         this.sulOracle = sulOracle;
         this.runs = runs;
         this.probabilisticSanitization = probabilisticSanitization;
@@ -70,11 +72,11 @@ public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> 
     /**
      * Processes queries using {@link #processQuery}.
      *
-     * @param queries  the queries to be processed
+     * @param queries the queries to be processed
      */
     @Override
     public void processQueries(Collection<? extends Query<I, Word<O>>> queries) {
-        for (Query<I, Word<O>> query : queries) {
+        for (Query<I, Word<O>> query: queries) {
             processQuery(query);
         }
     }
@@ -82,7 +84,7 @@ public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> 
     /**
      * Processes the given query using {@link #getMultipleRunOutput}.
      *
-     * @param query  the query to be processed
+     * @param query the query to be processed
      */
     @Override
     public void processQuery(Query<I, Word<O>> query) {
@@ -94,13 +96,14 @@ public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> 
      * Runs an input {@link #runs} times and also performs probabilistic sanitization if
      * multiple different answers are received and {@link #probabilisticSanitization} enables it.
      *
-     * @param input  the input to be used
-     * @return       the single output that corresponds to the input
+     * @param  input                   the input to be used
      *
-     * @throws NonDeterminismException  if multiple different answers are received
-     *                                  and probabilistic sanitization is disabled
-     *                                  or if probabilistic sanitization is performed
-     *                                  but fails to find an answer
+     * @return                         the single output that corresponds to the input
+     *
+     * @throws NonDeterminismException if multiple different answers are received
+     *                                     and probabilistic sanitization is disabled
+     *                                     or if probabilistic sanitization is performed
+     *                                     but fails to find an answer
      */
     protected Word<O> getMultipleRunOutput(Word<I> input) throws NonDeterminismException {
         TestRunnerResult<Word<I>, Word<O>> result = TestRunner.runTest(input, runs, sulOracle);
@@ -128,18 +131,22 @@ public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> 
      * <p>
      * Specifically:
      * <ul>
-     * <li> Runs the input at most {@link #runs} * {@link #PROBABILISTIC_MAX_MULTIPLIER} times
-     * <li> Checks the likelihood of the most common answer every time after {@link #runs} * {@link #PROBABILISTIC_MIN_MULTIPLIER} times
-     * <li> If the most common answer has likelihood over {@link #ACCEPTABLE_PROBABILISTIC_THRESHOLD} then it is returned
-     * <li> But if the most common answer has likelihood only over {@link #PASSABLE_PROBABILISTIC_THRESHOLD} then the process continues
+     * <li>Runs the input at most {@link #runs} * {@link #PROBABILISTIC_MAX_MULTIPLIER} times
+     * <li>Checks the likelihood of the most common answer every time after {@link #runs} *
+     * {@link #PROBABILISTIC_MIN_MULTIPLIER} times
+     * <li>If the most common answer has likelihood over {@link #ACCEPTABLE_PROBABILISTIC_THRESHOLD}
+     * then it is returned
+     * <li>But if the most common answer has likelihood only over
+     * {@link #PASSABLE_PROBABILISTIC_THRESHOLD} then the process continues
      * </ul>
      *
-     * @param input  the input to be used
-     * @return       the single output that corresponds to the input
+     * @param  input                   the input to be used
      *
-     * @throws NonDeterminismException  if no acceptable answer can be found or
-     *                                  if the most common answer has likelihood (anytime)
-     *                                  below {@link #PASSABLE_PROBABILISTIC_THRESHOLD}
+     * @return                         the single output that corresponds to the input
+     *
+     * @throws NonDeterminismException if no acceptable answer can be found or
+     *                                     if the most common answer has likelihood (anytime)
+     *                                     below {@link #PASSABLE_PROBABILISTIC_THRESHOLD}
      */
     protected Word<O> getProbabilisticOutput(Word<I> input) throws NonDeterminismException {
         printWriter.println("Performing probabilistic sanitization");
@@ -159,7 +166,8 @@ public class MultipleRunsSULOracle<I, O> implements MealyMembershipOracle<I, O> 
 
             // after running enough tests, we can check whether we can return an acceptable answer
             if (i >= runs * PROBABILISTIC_MIN_MULTIPLIER) {
-                Entry<Word<O>, Integer> mostCommonEntry =  frequencyMap.entrySet().stream().max(Entry.comparingByValue()).orElseThrow();
+                Entry<Word<O>, Integer> mostCommonEntry = frequencyMap.entrySet().stream().max(Entry.comparingByValue())
+                    .orElseThrow();
                 double likelihood = (double) mostCommonEntry.getValue() / (i + 1);
                 printWriter.println("Most likely answer has likelihood " + likelihood + " after " + (i + 1) + " runs");
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/NonDeterminismException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/NonDeterminismException.java
@@ -31,9 +31,9 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param input      the input for which non-determinism was observed
-     * @param oldOutput  the old output corresponding to the input
-     * @param newOutput  the new output corresponding to the input and is different from oldOutput
+     * @param input     the input for which non-determinism was observed
+     * @param oldOutput the old output corresponding to the input
+     * @param newOutput the new output corresponding to the input and is different from oldOutput
      */
     public NonDeterminismException(Word<?> input, Word<?> oldOutput, Word<?> newOutput) {
         this.input = input;
@@ -44,10 +44,10 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param message    the message related to the exception
-     * @param input      the input for which non-determinism was observed
-     * @param oldOutput  the old output corresponding to the input
-     * @param newOutput  the new output corresponding to the input and is different from oldOutput
+     * @param message   the message related to the exception
+     * @param input     the input for which non-determinism was observed
+     * @param oldOutput the old output corresponding to the input
+     * @param newOutput the new output corresponding to the input and is different from oldOutput
      */
     public NonDeterminismException(String message, Word<?> input, Word<?> oldOutput, Word<?> newOutput) {
         super(message);
@@ -59,7 +59,7 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Returns the stored {@link #oldOutput}.
      *
-     * @return  the stored {@link #oldOutput}
+     * @return the stored {@link #oldOutput}
      */
     public Word<?> getOldOutput() {
         return this.oldOutput;
@@ -68,7 +68,7 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Returns the stored {@link #newOutput}.
      *
-     * @return  the stored {@link #newOutput}
+     * @return the stored {@link #newOutput}
      */
     public Word<?> getNewOutput() {
         return this.newOutput;
@@ -77,7 +77,7 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Stores the given preceding input in {@link #precedingInput}.
      *
-     * @param precedingInput  the input to be set
+     * @param precedingInput the input to be set
      */
     public void setPrecedingInput(Word<?> precedingInput) {
         this.precedingInput = precedingInput;
@@ -86,7 +86,7 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Returns the shortest sub-word of the input word which causes non-determinism.
      *
-     * @return  the shortest sub-word of the input word which causes non-determinism.
+     * @return the shortest sub-word of the input word which causes non-determinism.
      */
     public Word<?> getShortestInconsistentInput() {
         int indexOfInconsistency = 0;
@@ -102,7 +102,7 @@ public class NonDeterminismException extends RuntimeException {
      * {@link #getShortestInconsistentInput()} and shortening the length of {@link #oldOutput}
      * and {@link #newOutput} to match the length of the new {@link #input}.
      *
-     * @return  this instance with the {@link #input}, {@link #oldOutput} and {@link #newOutput} changed
+     * @return this instance with the {@link #input}, {@link #oldOutput} and {@link #newOutput} changed
      */
     public NonDeterminismException makeCompact() {
         this.input = getShortestInconsistentInput();
@@ -114,7 +114,7 @@ public class NonDeterminismException extends RuntimeException {
     /**
      * Overrides the default method.
      *
-     * @return  the string representation of this instance
+     * @return the string representation of this instance
      */
     @Override
     public String getMessage() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/NonDeterminismRetryingSULOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/NonDeterminismRetryingSULOracle.java
@@ -8,8 +8,8 @@ import java.io.Writer;
 /**
  * Checks and confirms a potential non-deterministic answer by re-running it.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class NonDeterminismRetryingSULOracle<I, O> extends MultipleRunsSULOracle<I, O> {
 
@@ -22,11 +22,11 @@ public class NonDeterminismRetryingSULOracle<I, O> extends MultipleRunsSULOracle
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param runs                       the number of times that a query should be run
-     * @param sulOracle                  the sul Oracle that is being wrapped
-     * @param probabilisticSanitization  {@code true} to enable the probabilistic sanitization
-     * @param writer                     the writer used to log results and information
-     * @param cache                      the external cache used for lookup
+     * @param runs                      the number of times that a query should be run
+     * @param sulOracle                 the sul Oracle that is being wrapped
+     * @param probabilisticSanitization {@code true} to enable the probabilistic sanitization
+     * @param writer                    the writer used to log results and information
+     * @param cache                     the external cache used for lookup
      */
     public NonDeterminismRetryingSULOracle(int runs,
         MealyMembershipOracle<I, O> sulOracle, boolean probabilisticSanitization,
@@ -40,9 +40,9 @@ public class NonDeterminismRetryingSULOracle<I, O> extends MultipleRunsSULOracle
      * Processes the given query by comparing the {@link #sulOracle}'s answer with
      * the cached one and if they differ then {@link #getCheckedOutput(Word, Word)} is used.
      *
-     * @param query  the query to be processed
+     * @param  query                   the query to be processed
      *
-     * @throws NonDeterminismException  thrown from {@link #getCheckedOutput(Word, Word)}
+     * @throws NonDeterminismException thrown from {@link #getCheckedOutput(Word, Word)}
      */
     @Override
     public void processQuery(Query<I, Word<O>> query) throws NonDeterminismException {
@@ -59,7 +59,8 @@ public class NonDeterminismRetryingSULOracle<I, O> extends MultipleRunsSULOracle
 
             try {
                 returnedOutput = getCheckedOutput(query.getInput(), originalOutput);
-            } catch (NonDeterminismException e) {
+            }
+            catch (NonDeterminismException e) {
                 e.setPrecedingInput(precedingInput);
                 throw e;
             }
@@ -73,11 +74,12 @@ public class NonDeterminismRetryingSULOracle<I, O> extends MultipleRunsSULOracle
      * Reruns the input {@link #runs} times and compares the checked output with
      * the given originalOutput.
      *
-     * @param input           the input to be run multiple times
-     * @param originalOutput  the original output of the sulOracle
-     * @return                the checked output
+     * @param  input                   the input to be run multiple times
+     * @param  originalOutput          the original output of the sulOracle
      *
-     * @throws NonDeterminismException  if the checked output cannot be found after multiple runs
+     * @return                         the checked output
+     *
+     * @throws NonDeterminismException if the checked output cannot be found after multiple runs
      */
     protected Word<O> getCheckedOutput(Word<I> input, Word<O> originalOutput) throws NonDeterminismException {
         Word<O> checkedOutput = super.getMultipleRunOutput(input);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
@@ -9,13 +9,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 /**
  * Data Structure used for storing and querying inputs and outputs.
  * <p>
  * An instance of an Observation Tree represents a node of the tree.
  * <p>
- * Adapted from <a href="https://gitlab.science.ru.nl/ramonjanssen/basic-learning/">basic-learning</a>.
+ * Adapted from
+ * <a href="https://gitlab.science.ru.nl/ramonjanssen/basic-learning/">basic-learning</a>.
  *
  * @param <I> the input type of the observations
  * @param <O> the output type of the observations
@@ -48,9 +48,9 @@ public class ObservationTree<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param parent        the parent observation tree of this node
-     * @param parentInput   the parent input
-     * @param parentOutput  the parent output
+     * @param parent       the parent observation tree of this node
+     * @param parentInput  the parent input
+     * @param parentOutput the parent output
      */
     public ObservationTree(ObservationTree<I, O> parent, I parentInput, O parentOutput) {
         this.children = new HashMap<>();
@@ -61,10 +61,11 @@ public class ObservationTree<I, O> {
     }
 
     /**
-     *  Return a word of symbols from a symbols list.
+     * Return a word of symbols from a symbols list.
      *
-     * @param <T>         the type of list elements
-     * @param symbolList  the list to be converted
+     * @param  <T>        the type of list elements
+     * @param  symbolList the list to be converted
+     *
      * @return            the word of symbols
      */
     public static <T> Word<T> toWord(List<T> symbolList) {
@@ -74,7 +75,7 @@ public class ObservationTree<I, O> {
     /**
      * Returns the outputs observed from the root of the tree until this node.
      *
-     * @return  the outputs observed from the root of the tree until this node
+     * @return the outputs observed from the root of the tree until this node
      */
     protected List<O> getOutputChain() {
         if (this.parent == null) {
@@ -89,7 +90,7 @@ public class ObservationTree<I, O> {
     /**
      * Returns the inputs observed from the root of the tree until this node.
      *
-     * @return  the inputs observed from the root of the tree until this node
+     * @return the inputs observed from the root of the tree until this node
      */
     protected List<I> getInputChain() {
         if (this.parent == null) {
@@ -104,11 +105,12 @@ public class ObservationTree<I, O> {
     /**
      * Add one input and output symbol and traverse the tree to the next node.
      *
-     * @param input   the input symbol to be added
-     * @param output  the output symbol to be added
-     * @return        the next node
+     * @param  input                       the input symbol to be added
+     * @param  output                      the output symbol to be added
      *
-     * @throws CacheInconsistencyException  on inconsistency with previous observations input
+     * @return                             the next node
+     *
+     * @throws CacheInconsistencyException on inconsistency with previous observations input
      */
     public ObservationTree<I, O> addObservation(I input, O output) throws CacheInconsistencyException {
         O previousOutput = this.outputs.get(input);
@@ -138,10 +140,10 @@ public class ObservationTree<I, O> {
     /**
      * Add Observation of Words to the tree using {@link #addObservation(List, List)}.
      *
-     * @param inputs   the word of inputs
-     * @param outputs  the word of outputs
+     * @param  inputs                      the word of inputs
+     * @param  outputs                     the word of outputs
      *
-     * @throws CacheInconsistencyException  on inconsistency between new and stored observations
+     * @throws CacheInconsistencyException on inconsistency between new and stored observations
      */
     public void addObservation(Word<I> inputs, Word<O> outputs) throws CacheInconsistencyException {
         addObservation(inputs.asList(), outputs.asList());
@@ -150,10 +152,10 @@ public class ObservationTree<I, O> {
     /**
      * Add Observation of Lists to the tree.
      *
-     * @param inputs   the list of inputs
-     * @param outputs  the list of outputs
+     * @param  inputs                      the list of inputs
+     * @param  outputs                     the list of outputs
      *
-     * @throws CacheInconsistencyException  on inconsistency between new and stored observations
+     * @throws CacheInconsistencyException on inconsistency between new and stored observations
      */
     public void addObservation(List<I> inputs, List<O> outputs) throws CacheInconsistencyException {
         if (inputs.isEmpty() && outputs.isEmpty()) {
@@ -161,7 +163,8 @@ public class ObservationTree<I, O> {
         }
 
         if (inputs.isEmpty() || outputs.isEmpty()) {
-            throw new RuntimeException("Input and output words should have the same length:" + "\n" + inputs + "\n" + outputs);
+            throw new RuntimeException(
+                "Input and output words should have the same length:" + "\n" + inputs + "\n" + outputs);
         }
 
         I firstInput = inputs.get(0);
@@ -169,7 +172,8 @@ public class ObservationTree<I, O> {
         try {
             this.addObservation(firstInput, firstOutput)
                 .addObservation(inputs.subList(1, inputs.size()), outputs.subList(1, outputs.size()));
-        } catch (CacheInconsistencyException e) {
+        }
+        catch (CacheInconsistencyException e) {
             throw new CacheInconsistencyException(toWord(inputs), e.getOldOutput(), toWord(outputs));
         }
     }
@@ -182,7 +186,7 @@ public class ObservationTree<I, O> {
             throw new RuntimeException("Cannot remove root node");
         }
 
-        for (I symbol : this.parent.children.keySet()) {
+        for (I symbol: this.parent.children.keySet()) {
             if (this == this.parent.children.get(symbol)) {
                 this.parent.children.remove(symbol);
                 this.parent.outputs.remove(symbol);
@@ -194,7 +198,7 @@ public class ObservationTree<I, O> {
     /**
      * Removes the given word sequence starting from this node using {@link #remove(List)}.
      *
-     * @param accessSequence  the word sequence to be removed
+     * @param accessSequence the word sequence to be removed
      */
     public void remove(Word<I> accessSequence) {
         remove(accessSequence.asList());
@@ -205,9 +209,9 @@ public class ObservationTree<I, O> {
      * <p>
      * If the accessSequence is empty then this node is removed.
      *
-     * @param accessSequence  the list sequence to be removed
+     * @param  accessSequence   the list sequence to be removed
      *
-     * @throws RemovalException  if the sequence cannot be removed
+     * @throws RemovalException if the sequence cannot be removed
      */
     public void remove(List<I> accessSequence) throws RemovalException {
         if (accessSequence.isEmpty()) {
@@ -223,7 +227,8 @@ public class ObservationTree<I, O> {
 
         try {
             child.remove(accessSequence.subList(1, accessSequence.size()));
-        } catch (RemovalException e) {
+        }
+        catch (RemovalException e) {
             throw new RemovalException("Cannot remove branch which is not present for input\n" + accessSequence);
         }
     }
@@ -231,9 +236,10 @@ public class ObservationTree<I, O> {
     /**
      * Answers the given query only if the whole input word is stored in the tree.
      *
-     * @param word  the input word
+     * @param  word the input word
+     *
      * @return      an answer only if the whole input word is stored in the tree,
-     *              otherwise null
+     *                  otherwise null
      */
     @Nullable public Word<O> answerQuery(Word<I> word) {
         List<I> inputChain = word.asList();
@@ -250,11 +256,12 @@ public class ObservationTree<I, O> {
      * Incomplete resolution captures the case when the input word is not
      * completely stored in the tree.
      *
-     * @param word                   the input word to be answered
-     * @param allowIncompleteAnswer  {@code true} to enable incomplete answers
+     * @param  word                  the input word to be answered
+     * @param  allowIncompleteAnswer {@code true} to enable incomplete answers
+     *
      * @return                       an answer for the longest prefix stored in
-     *                               the cache if allowIncompleteAnswer is
-     *                               {@code true} else null
+     *                                   the cache if allowIncompleteAnswer is
+     *                                   {@code true} else null
      */
     @Nullable public Word<O> answerQuery(Word<I> word, boolean allowIncompleteAnswer) {
         List<I> inputChain = word.asList();
@@ -271,8 +278,9 @@ public class ObservationTree<I, O> {
      * Incomplete resolution captures the case when the input word is not
      * completely stored in the tree.
      *
-     * @param inputs                 the list of inputs to be answered
-     * @param allowIncompleteAnswer  {@code true} to enable incomplete answers
+     * @param  inputs                the list of inputs to be answered
+     * @param  allowIncompleteAnswer {@code true} to enable incomplete answers
+     *
      * @return                       the list of answers or null
      */
     @Nullable public List<O> answerInputChain(List<I> inputs, boolean allowIncompleteAnswer) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RandomWpMethodEQOracle.java
@@ -17,38 +17,41 @@ import java.util.Random;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-
 /**
  * Implements an equivalence test by applying the WP-method test on the given
- * hypothesis automaton as described in "Test Selection Based on Finite State Models" by {@literal S. Fujiwara et al}.
+ * hypothesis automaton as described in "Test Selection Based on Finite State Models" by
+ * {@literal S. Fujiwara et al}.
  * <p>
  * Adapted from an EQ oracle implementation in LearnLib's development branch not
  * available in the version we use, see
- * <a href="https://github.com/mtf90/learnlib/blob/develop/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWpMethodEQOracle.java">RandomWpMethodEQOracle</a>.
+ * <a href=
+ * "https://github.com/mtf90/learnlib/blob/develop/oracles/equivalence-oracles/src/main/java/de/learnlib/oracle/equivalence/RandomWpMethodEQOracle.java">RandomWpMethodEQOracle</a>.
  * Our adaptation is randomizing access sequence generation.
  * <p>
  * Instead of enumerating the test suite in order, this is a sampling implementation:
  * <ol>
- * <li> Sample uniformly from the states for a prefix
- * <li> Sample geometrically a random word
- * <li> Sample a word from the set of suffixes / state identifiers (either local or global).
+ * <li>Sample uniformly from the states for a prefix
+ * <li>Sample geometrically a random word
+ * <li>Sample a word from the set of suffixes / state identifiers (either local or global).
  * </ol>
  * <p>
  * There are two parameters:
  * <ul>
- * <li> minimalSize determines the minimal size of the random word. This is useful when one first performs a
- *      W(p)-method with some depth and continues with this randomized tester from that depth onward
- * <li> rndLength determines the expected length of the random word. The expected length in effect is minimalSize + rndLength.
- *      In the unbounded case it will not terminate for a correct hypothesis.
+ * <li>minimalSize determines the minimal size of the random word. This is useful when one first
+ * performs a
+ * W(p)-method with some depth and continues with this randomized tester from that depth onward
+ * <li>rndLength determines the expected length of the random word. The expected length in effect is
+ * minimalSize + rndLength.
+ * In the unbounded case it will not terminate for a correct hypothesis.
  * </ul>
  *
- * @param <I>  input symbol type
- * @param <O>  output symbol type
+ * @param <I> input symbol type
+ * @param <O> output symbol type
  */
-public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
+public class RandomWpMethodEQOracle<I, O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
 
     /** Stores the constructor parameter. */
-    protected List<MealyMembershipOracle<I, O>>  sulOracles;
+    protected List<MealyMembershipOracle<I, O>> sulOracles;
 
     /** Stores the constructor parameter. */
     protected int minimalSize;
@@ -63,12 +66,13 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     protected long seed;
 
     /**
-     * Constructs a new instance from the given parameters, which represents an unbounded testing oracle.
+     * Constructs a new instance from the given parameters, which represents an unbounded testing
+     * oracle.
      *
-     * @param sulOracles   the oracles which answer tests
-     * @param minimalSize  the minimal size of the random word
-     * @param rndLength    the expected length (in addition to minimalSize) of random word
-     * @param seed         the seed to be used for randomness
+     * @param sulOracles  the oracles which answer tests
+     * @param minimalSize the minimal size of the random word
+     * @param rndLength   the expected length (in addition to minimalSize) of random word
+     * @param seed        the seed to be used for randomness
      */
     public RandomWpMethodEQOracle(List<MealyMembershipOracle<I, O>> sulOracles,
         int minimalSize, int rndLength, long seed) {
@@ -83,11 +87,11 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Constructs a new instance from the given parameters, which represents a bounded testing oracle.
      *
-     * @param sulOracles   the oracles which answer tests
-     * @param minimalSize  the minimal size of the random word
-     * @param rndLength    the expected length (in addition to minimalSize) of random word
-     * @param bound        the bound (set to 0 for unbounded).
-     * @param seed         the seed to be used for randomness
+     * @param sulOracles  the oracles which answer tests
+     * @param minimalSize the minimal size of the random word
+     * @param rndLength   the expected length (in addition to minimalSize) of random word
+     * @param bound       the bound (set to 0 for unbounded).
+     * @param seed        the seed to be used for randomness
      */
     public RandomWpMethodEQOracle(List<MealyMembershipOracle<I, O>> sulOracles,
         int minimalSize, int rndLength, int bound, long seed) {
@@ -102,8 +106,9 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Tries to find a counterexample using {@link #doFindCounterExample(MealyMachine, Collection)}.
      *
-     * @param hypothesis  the hypothesis to be searched
-     * @param inputs      the inputs to be used
+     * @param  hypothesis the hypothesis to be searched
+     * @param  inputs     the inputs to be used
+     *
      * @return            the counterexample or null
      */
     @Override
@@ -116,9 +121,10 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
     /**
      * Implements the search technique.
      *
-     * @param <S>         the type of states
-     * @param hypothesis  the hypothesis to be searched
-     * @param inputs      the inputs to be used
+     * @param  <S>        the type of states
+     * @param  hypothesis the hypothesis to be searched
+     * @param  inputs     the inputs to be used
+     *
      * @return            the counterexample or null
      */
     public <S> @Nullable DefaultQuery<I, Word<O>> doFindCounterExample(MealyMachine<S, I, ?, O> hypothesis,
@@ -134,7 +140,7 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
 
         List<Thread> threads = new ArrayList<>();
 
-        for (MealyMembershipOracle<I, O> oracle : sulOracles) {
+        for (MealyMembershipOracle<I, O> oracle: sulOracles) {
             Thread thread = new Thread(() -> {
                 while (globalCounter.get() < bound) {
                     DefaultQuery<I, Word<O>> query;
@@ -164,15 +170,15 @@ public class RandomWpMethodEQOracle<I,O> implements EquivalenceOracle.MealyEquiv
             thread.start();
         }
 
-        for (Thread thread : threads) {
+        for (Thread thread: threads) {
             try {
                 thread.join();
-            } catch (InterruptedException e) {
+            }
+            catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
         }
 
-        return counterExamples.isEmpty() ? null :
-           counterExamples.get(Collections.min(counterExamples.keySet()));
+        return counterExamples.isEmpty() ? null : counterExamples.get(Collections.min(counterExamples.keySet()));
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RemovalException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/RemovalException.java
@@ -13,7 +13,7 @@ public class RemovalException extends RuntimeException {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param msg  the message related to the exception
+     * @param msg the message related to the exception
      */
     public RemovalException(String msg) {
         super(msg);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/SampledTestsEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/SampledTestsEQOracle.java
@@ -16,10 +16,10 @@ import java.util.Objects;
  * Equivalence Oracle for the
  * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName#SAMPLED_TESTS}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
-public class SampledTestsEQOracle<I,O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
+public class SampledTestsEQOracle<I, O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
 
     /** Stores the constructor parameter. */
     protected List<Word<I>> tests;
@@ -30,8 +30,8 @@ public class SampledTestsEQOracle<I,O> implements EquivalenceOracle.MealyEquival
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param tests      the list of tests to be sampled
-     * @param sulOracle  the sul oracle to be used
+     * @param tests     the list of tests to be sampled
+     * @param sulOracle the sul oracle to be used
      */
     public SampledTestsEQOracle(List<Word<I>> tests, MealyMembershipOracle<I, O> sulOracle) {
         this.tests = tests;
@@ -41,15 +41,16 @@ public class SampledTestsEQOracle<I,O> implements EquivalenceOracle.MealyEquival
     /**
      * Tries to find a counterexample using the sampled tests technique.
      *
-     * @param hypothesis  the hypothesis to be searched
-     * @param inputs      the inputs to be used
+     * @param  hypothesis the hypothesis to be searched
+     * @param  inputs     the inputs to be used
+     *
      * @return            the counterexample or null
      */
     @Override
     public @Nullable DefaultQuery<I, Word<O>> findCounterExample(
         MealyMachine<?, I, ?, O> hypothesis, Collection<? extends I> inputs) {
 
-        for (Word<I> test : tests) {
+        for (Word<I> test: tests) {
             DefaultQuery<I, Word<O>> query = new DefaultQuery<>(test);
             Word<O> hypOutput = hypothesis.computeOutput(test);
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
@@ -145,8 +145,9 @@ public class WpEQSequenceGenerator<I, D, S> {
 
         while ((size > 0) || (rand.nextDouble() > 1 / (rndLength + 1.0))) {
             wb.append(arrayAlphabet.get(rand.nextInt(arrayAlphabet.size())));
-            if (size > 0)
+            if (size > 0) {
                 size--;
+            }
         }
 
         return wb.toWord();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpEQSequenceGenerator.java
@@ -17,18 +17,18 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-
 /**
  * Sequence generation method that randomizes access sequences.
  * <p>
  * Factored out from
- * <a href="https://github.com/mtf90/learnlib/blob/develop/eqtests/basic-eqtests/src/main/java/de/learnlib/eqtests/basic/RandomWpMethodEQOracle.java">RandomWpMethodEQOracle</a>.
+ * <a href=
+ * "https://github.com/mtf90/learnlib/blob/develop/eqtests/basic-eqtests/src/main/java/de/learnlib/eqtests/basic/RandomWpMethodEQOracle.java">RandomWpMethodEQOracle</a>.
  * <p>
  * The key difference is that we randomize access sequences.
  *
- * @param <I>  the type of inputs
- * @param <D>  the type of output domain
- * @param <S>  the type of states
+ * @param <I> the type of inputs
+ * @param <D> the type of output domain
+ * @param <S> the type of states
  */
 public class WpEQSequenceGenerator<I, D, S> {
 
@@ -50,8 +50,8 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs of the automaton
+     * @param automaton the automaton to be used
+     * @param inputs    the inputs of the automaton
      */
     public WpEQSequenceGenerator(
         UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
@@ -67,10 +67,11 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Computes the predecessor map of automaton inputs.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs of the automaton
+     * @param  <S>       the type of states
+     * @param  <I>       the type of inputs
+     * @param  automaton the automaton to be used
+     * @param  inputs    the inputs of the automaton
+     *
      * @return           the predecessor map
      */
     public static <S, I> Map<S, List<PredStruct<S, I>>> computePredecessorMap(
@@ -78,8 +79,8 @@ public class WpEQSequenceGenerator<I, D, S> {
         Collection<? extends I> inputs) {
 
         Map<S, List<PredStruct<S, I>>> predMap = new HashMap<>();
-        for (S s : automaton.getStates()) {
-            for (I input : inputs) {
+        for (S s: automaton.getStates()) {
+            for (I input: inputs) {
                 S succ = automaton.getSuccessor(s, input);
                 if (succ != null) {
                     predMap.putIfAbsent(succ, new ArrayList<>());
@@ -93,8 +94,9 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Computes the global suffixes of the automaton.
      *
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs of the automaton
+     * @param  automaton the automaton to be used
+     * @param  inputs    the inputs of the automaton
+     *
      * @return           the list of global suffixes
      */
     private List<Word<I>> computeGlobalSuffixes(
@@ -109,16 +111,17 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Computes the local suffixes of the automaton.
      *
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs of the automaton
+     * @param  automaton the automaton to be used
+     * @param  inputs    the inputs of the automaton
+     *
      * @return           the list of local suffixes
      */
     private MutableMapping<S, List<Word<I>>> computeLocalSuffixSets(
-        UniversalDeterministicAutomaton<S, I, ?, ?,?> automaton,
+        UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
         Collection<? extends I> inputs) {
 
         MutableMapping<S, List<Word<I>>> localSuffixSets = automaton.createStaticStateMapping();
-        for (S state : automaton.getStates()) {
+        for (S state: automaton.getStates()) {
             List<Word<I>> suffixSet = new ArrayList<>();
             Automata.stateCharacterizingSet(automaton, inputs, state, suffixSet);
             localSuffixSets.put(state, suffixSet);
@@ -129,9 +132,10 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Constructs the random middle sequence of an expected length.
      *
-     * @param minimalSize  the minimal size of the sequence
-     * @param rndLength    length used for the random length generation
-     * @param rand         a Random instance used for the random length generation
+     * @param  minimalSize the minimal size of the sequence
+     * @param  rndLength   length used for the random length generation
+     * @param  rand        a Random instance used for the random length generation
+     *
      * @return             the constructed middle sequence
      */
     public Word<I> getRandomMiddleSequence(int minimalSize, int rndLength, Random rand) {
@@ -141,7 +145,8 @@ public class WpEQSequenceGenerator<I, D, S> {
 
         while ((size > 0) || (rand.nextDouble() > 1 / (rndLength + 1.0))) {
             wb.append(arrayAlphabet.get(rand.nextInt(arrayAlphabet.size())));
-            if (size > 0) size--;
+            if (size > 0)
+                size--;
         }
 
         return wb.toWord();
@@ -153,8 +158,9 @@ public class WpEQSequenceGenerator<I, D, S> {
      * <p>
      * The {@link #automaton} and {@link #inputs} are also used.
      *
-     * @param fromSequence  the initial sequence to be used
-     * @param rand          a Random instance to be used
+     * @param  fromSequence the initial sequence to be used
+     * @param  rand         a Random instance to be used
+     *
      * @return              the random characterizing sequence
      */
     public Word<I> getRandomCharacterizingSequence(Iterable<I> fromSequence, Random rand) {
@@ -164,10 +170,11 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Returns a random characterizing sequence of the given sequence.
      *
-     * @param automaton     the automaton to be used
-     * @param inputs        the inputs of the automaton
-     * @param fromSequence  the initial sequence to be used
-     * @param rand          a Random instance to be used
+     * @param  automaton    the automaton to be used
+     * @param  inputs       the inputs of the automaton
+     * @param  fromSequence the initial sequence to be used
+     * @param  rand         a Random instance to be used
+     *
      * @return              the random characterizing sequence
      */
     protected Word<I> getRandomCharacterizingSequence(
@@ -203,11 +210,12 @@ public class WpEQSequenceGenerator<I, D, S> {
      * <p>
      * The {@link #automaton} and {@link #inputs} are also used.
      *
-     * @param toState  the target state to be used
-     * @param rand     a Random instance to be used
-     * @return         the random access sequence
+     * @param  toState               the target state to be used
+     * @param  rand                  a Random instance to be used
      *
-     * @throws IllegalStateException  if the access sequence cannot be generated
+     * @return                       the random access sequence
+     *
+     * @throws IllegalStateException if the access sequence cannot be generated
      */
     public Word<I> getRandomAccessSequence(S toState, Random rand) {
         return getRandomAccessSequence(automaton, inputs, toState, rand);
@@ -217,13 +225,14 @@ public class WpEQSequenceGenerator<I, D, S> {
      * Returns a random access sequence of the given state using
      * {@link #getRandomAccessSequence(UniversalDeterministicAutomaton, Collection, Object, Random, Object, Set, List)}.
      *
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs of the automaton
-     * @param toState    the target state to be used
-     * @param rand       a Random instance to be used
-     * @return           the random access sequence
+     * @param  automaton             the automaton to be used
+     * @param  inputs                the inputs of the automaton
+     * @param  toState               the target state to be used
+     * @param  rand                  a Random instance to be used
      *
-     * @throws IllegalStateException  if the access sequence cannot be generated
+     * @return                       the random access sequence
+     *
+     * @throws IllegalStateException if the access sequence cannot be generated
      */
     protected Word<I> getRandomAccessSequence(
         UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
@@ -234,7 +243,8 @@ public class WpEQSequenceGenerator<I, D, S> {
         Set<S> hs = new HashSet<>();
         hs.add(toState);
 
-        Word<I> accessSequence = getRandomAccessSequence(automaton, inputs, toState, rand, toState, hs, new ArrayList<>());
+        Word<I> accessSequence = getRandomAccessSequence(automaton, inputs, toState, rand, toState, hs,
+            new ArrayList<>());
 
         if (accessSequence == null) {
             throw new IllegalStateException("Access sequence could not be generated");
@@ -246,13 +256,14 @@ public class WpEQSequenceGenerator<I, D, S> {
     /**
      * Returns a random access sequence of the given state.
      *
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs of the automaton
-     * @param toState    the target state to be used
-     * @param rand       a Random instance to be used
-     * @param visiting   the state that is being visited
-     * @param visited    the set of visited states
-     * @param sequence   an external list of input sequence
+     * @param  automaton the automaton to be used
+     * @param  inputs    the inputs of the automaton
+     * @param  toState   the target state to be used
+     * @param  rand      a Random instance to be used
+     * @param  visiting  the state that is being visited
+     * @param  visited   the set of visited states
+     * @param  sequence  an external list of input sequence
+     *
      * @return           the random access sequence or null
      */
     protected Word<I> getRandomAccessSequence(
@@ -274,14 +285,13 @@ public class WpEQSequenceGenerator<I, D, S> {
             predStructs = new ArrayList<>(predStructs);
             Collections.shuffle(predStructs, rand);
 
-            for (PredStruct<S, I> predStruct : predStructs) {
+            for (PredStruct<S, I> predStruct: predStructs) {
                 if (!visited.contains(predStruct.getState())) {
                     visited.add(predStruct.getState());
                     sequence.add(0, predStruct.getInput());
 
                     Word<I> result = getRandomAccessSequence(
-                        automaton, inputs, toState, rand, predStruct.getState(), visited, sequence
-                    );
+                        automaton, inputs, toState, rand, predStruct.getState(), visited, sequence);
 
                     if (result != null) {
                         return result;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpSampledTestsEQOracle.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/WpSampledTestsEQOracle.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
-
 /**
  * Equivalence Oracle for the
  * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.learner.factory.EquivalenceAlgorithmName#WP_SAMPLED_TESTS}.
@@ -24,8 +23,8 @@ import java.util.Random;
  * sequence is obtained by selecting a suffix of arbitrary length from an
  * arbitrarily chosen log.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class WpSampledTestsEQOracle<I, O> implements EquivalenceOracle.MealyEquivalenceOracle<I, O> {
 
@@ -50,12 +49,12 @@ public class WpSampledTestsEQOracle<I, O> implements EquivalenceOracle.MealyEqui
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param tests        the list of tests to be sampled
-     * @param sulOracle    the sul oracle to be used
-     * @param minimalSize  the minimal size of middle sequence
-     * @param rndLength    the random length of middle sequence
-     * @param seed         the seed used for randomness
-     * @param bound        the upper bound of sampling iterations
+     * @param tests       the list of tests to be sampled
+     * @param sulOracle   the sul oracle to be used
+     * @param minimalSize the minimal size of middle sequence
+     * @param rndLength   the random length of middle sequence
+     * @param seed        the seed used for randomness
+     * @param bound       the upper bound of sampling iterations
      */
     public WpSampledTestsEQOracle(List<Word<I>> tests,
         MealyMembershipOracle<I, O> sulOracle, int minimalSize,
@@ -72,13 +71,14 @@ public class WpSampledTestsEQOracle<I, O> implements EquivalenceOracle.MealyEqui
     /**
      * Tries to find a counterexample using {@link #doFindCounterExample(MealyMachine, Collection)}.
      *
-     * @param hypothesis  the hypothesis to be searched
-     * @param inputs      the inputs to be used
+     * @param  hypothesis the hypothesis to be searched
+     * @param  inputs     the inputs to be used
+     *
      * @return            the counterexample or null
      */
     @Override
     public @Nullable DefaultQuery<I, Word<O>> findCounterExample(
-            MealyMachine<?, I, ?, O> hypothesis, Collection<? extends I> inputs) {
+        MealyMachine<?, I, ?, O> hypothesis, Collection<? extends I> inputs) {
 
         return doFindCounterExample(hypothesis, inputs);
     }
@@ -86,13 +86,14 @@ public class WpSampledTestsEQOracle<I, O> implements EquivalenceOracle.MealyEqui
     /**
      * Implements the search technique.
      *
-     * @param <S>         the type of states
-     * @param hypothesis  the hypothesis to be searched
-     * @param inputs      the inputs to be used
+     * @param  <S>        the type of states
+     * @param  hypothesis the hypothesis to be searched
+     * @param  inputs     the inputs to be used
+     *
      * @return            the counterexample or null
      */
     protected <S> DefaultQuery<I, Word<O>> doFindCounterExample(
-            MealyMachine<S, I, ?, O> hypothesis, Collection<? extends I> inputs) {
+        MealyMachine<S, I, ?, O> hypothesis, Collection<? extends I> inputs) {
 
         WpEQSequenceGenerator<I, Word<O>, S> generator = new WpEQSequenceGenerator<>(hypothesis, inputs);
         List<S> states = new ArrayList<>(hypothesis.getStates());

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/AggregatedCounter.java
@@ -24,7 +24,7 @@ public class AggregatedCounter extends Counter {
      * when {@link #getCount()} is called.
      * </p>
      *
-     * @param counters  a list of {@link Counter} instances to aggregate.
+     * @param counters a list of {@link Counter} instances to aggregate.
      */
     public AggregatedCounter(List<Counter> counters) {
         super("AggregatedCounter", "#");
@@ -34,7 +34,7 @@ public class AggregatedCounter extends Counter {
     @Override
     public long getCount() {
         long total = 0;
-        for (Counter counter : counters) {
+        for (Counter counter: counters) {
             total += counter.getCount();
         }
         return total;
@@ -43,7 +43,6 @@ public class AggregatedCounter extends Counter {
     @Override
     public void increment() {
         throw new UnsupportedOperationException(
-                "Increment should be called on individual counters, not on the aggregated counter"
-        );
+            "Increment should be called on individual counters, not on the aggregated counter");
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/HypothesisStatistics.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/HypothesisStatistics.java
@@ -3,9 +3,9 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statis
 /**
  * Statistics that concern a specific hypothesis identified by an index number.
  *
- * @param <ID>  the type of input domain
- * @param <OD>  the type of output domain
- * @param <CE>  the type of output domain
+ * @param <ID> the type of input domain
+ * @param <OD> the type of output domain
+ * @param <CE> the type of output domain
  */
 public class HypothesisStatistics<ID, OD, CE> {
 
@@ -24,16 +24,15 @@ public class HypothesisStatistics<ID, OD, CE> {
     /** Statistics Snapshot of the counterexample. */
     protected StatisticsSnapshot counterexampleSnapshot;
 
-
     /**
      * Constructor
      */
-    public HypothesisStatistics() { }
+    public HypothesisStatistics() {}
 
     /**
      * Returns the stored {@link #hypothesis}.
      *
-     * @return  the stored {@link #hypothesis}
+     * @return the stored {@link #hypothesis}
      */
     public StateMachineWrapper<ID, OD> getHypothesis() {
         return hypothesis;
@@ -42,7 +41,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Sets the {@link #hypothesis}.
      *
-     * @param hypothesis  the hypothesis to be set
+     * @param hypothesis the hypothesis to be set
      */
     public void setHypothesis(StateMachineWrapper<ID, OD> hypothesis) {
         this.hypothesis = hypothesis;
@@ -51,7 +50,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Returns the stored {@link #index}.
      *
-     * @return  the stored {@link #index}
+     * @return the stored {@link #index}
      */
     public int getIndex() {
         return index;
@@ -60,7 +59,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Sets the {@link #index}.
      *
-     * @param index  the index to be set
+     * @param index the index to be set
      */
     public void setIndex(int index) {
         this.index = index;
@@ -69,7 +68,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Returns the stored {@link #snapshot}.
      *
-     * @return  the stored {@link #snapshot}
+     * @return the stored {@link #snapshot}
      */
     public StatisticsSnapshot getSnapshot() {
         return snapshot;
@@ -78,7 +77,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Sets the {@link #snapshot}.
      *
-     * @param snapshot  the snapshot to be set
+     * @param snapshot the snapshot to be set
      */
     public void setSnapshot(StatisticsSnapshot snapshot) {
         this.snapshot = snapshot;
@@ -87,7 +86,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Returns the stored {@link #counterexample}.
      *
-     * @return  the stored {@link #counterexample}
+     * @return the stored {@link #counterexample}
      */
     public CE getCounterexample() {
         return counterexample;
@@ -96,7 +95,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Sets the {@link #counterexample}.
      *
-     * @param counterexample  the counterexample to be set
+     * @param counterexample the counterexample to be set
      */
     public void setCounterexample(CE counterexample) {
         this.counterexample = counterexample;
@@ -105,7 +104,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Returns the stored {@link #counterexampleSnapshot}.
      *
-     * @return  the stored {@link #counterexampleSnapshot}
+     * @return the stored {@link #counterexampleSnapshot}
      */
     public StatisticsSnapshot getCounterexampleSnapshot() {
         return counterexampleSnapshot;
@@ -114,7 +113,7 @@ public class HypothesisStatistics<ID, OD, CE> {
     /**
      * Sets the {@link #counterexampleSnapshot}.
      *
-     * @param counterexampleSnapshot  the counterexample snapshot to be set
+     * @param counterexampleSnapshot the counterexample snapshot to be set
      */
     public void setCounterexampleSnapshot(StatisticsSnapshot counterexampleSnapshot) {
         this.counterexampleSnapshot = counterexampleSnapshot;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/MealyMachineWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/MealyMachineWrapper.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 /**
  * Wraps a Mealy Machine and its input alphabet.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class MealyMachineWrapper<I, O> implements StateMachineWrapper<Word<I>, Word<O>> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -36,8 +36,8 @@ public class MealyMachineWrapper<I, O> implements StateMachineWrapper<Word<I>, W
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param mealyMachine  the Mealy Machine to be used
-     * @param alphabet      the input alphabet of the Mealy Machine
+     * @param mealyMachine the Mealy Machine to be used
+     * @param alphabet     the input alphabet of the Mealy Machine
      */
     public MealyMachineWrapper(MealyMachine<?, I, ?, O> mealyMachine, Alphabet<I> alphabet) {
         this.mealyMachine = mealyMachine;
@@ -47,7 +47,7 @@ public class MealyMachineWrapper<I, O> implements StateMachineWrapper<Word<I>, W
     /**
      * Returns the stored {@link #mealyMachine}.
      *
-     * @return  the stored {@link #mealyMachine}
+     * @return the stored {@link #mealyMachine}
      */
     public MealyMachine<?, I, ?, O> getMealyMachine() {
         return mealyMachine;
@@ -57,13 +57,14 @@ public class MealyMachineWrapper<I, O> implements StateMachineWrapper<Word<I>, W
      * Creates the destination file, to which the hypothesis is exported and provides
      * the option to also generate a PDF file if the dot utility is found in the system.
      *
-     * @param graphFile    the destination file that is created
+     * @param graphFile the destination file that is created
      */
     @Override
     public void export(File graphFile) {
         try (FileWriter fWriter = new FileWriter(graphFile, StandardCharsets.UTF_8)) {
             GraphDOT.write(mealyMachine, alphabet, fWriter);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not export model to file: {}", graphFile.getAbsolutePath());
         }
     }
@@ -71,7 +72,7 @@ public class MealyMachineWrapper<I, O> implements StateMachineWrapper<Word<I>, W
     /**
      * Creates and returns a low level copy of the state machine.
      *
-     * @return  the low level copy of the state machine
+     * @return the low level copy of the state machine
      */
     @Override
     public MealyMachineWrapper<I, O> copy() {
@@ -93,14 +94,15 @@ public class MealyMachineWrapper<I, O> implements StateMachineWrapper<Word<I>, W
     /**
      * Overrides the default method.
      *
-     * @return  the string representation of this instance
+     * @return the string representation of this instance
      */
     @Override
     public String toString() {
         try (StringWriter sWriter = new StringWriter()) {
             GraphDOT.write(mealyMachine, alphabet, sWriter);
             return sWriter.toString();
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not convert model to string");
             return "";
         }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/RegisterAutomatonWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/RegisterAutomatonWrapper.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
  * @param <D> the type domain of inputs and outputs
  */
 public class RegisterAutomatonWrapper<B extends ParameterizedSymbol, D extends PSymbolInstance>
-        implements StateMachineWrapper<Word<D>, Boolean> {
+    implements StateMachineWrapper<Word<D>, Boolean> {
     private static final Logger LOGGER = LogManager.getLogger();
 
     /** Stores the constructor parameter. */
@@ -74,7 +74,8 @@ public class RegisterAutomatonWrapper<B extends ParameterizedSymbol, D extends P
 
         try (FileWriter fWriter = new FileWriter(graphFile, StandardCharsets.UTF_8)) {
             fWriter.write(dotString);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not export model to file: {}", graphFile.getAbsolutePath());
         }
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/RunDescriptionPrinter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/RunDescriptionPrinter.java
@@ -9,9 +9,9 @@ import java.util.stream.Collectors;
  * <p>
  * The run description is split into two parts:
  * <ul>
- * <li> self, which refers to the run configuration of the implementing class
- * <li> rec (recursive), which refers to the run configuration of the inner classes
- *      of the implementing class that also implement this interface
+ * <li>self, which refers to the run configuration of the implementing class
+ * <li>rec (recursive), which refers to the run configuration of the inner classes
+ * of the implementing class that also implement this interface
  * </ul>
  * <p>
  * The default implementation of {@link #printRunDescription(PrintWriter)}
@@ -26,7 +26,7 @@ public interface RunDescriptionPrinter {
     /**
      * Prints the run description of the implementing and inner classes.
      *
-     * @param printWriter  the PrintWriter to be used
+     * @param printWriter the PrintWriter to be used
      */
     default void printRunDescription(PrintWriter printWriter) {
         printWriter.println();
@@ -37,14 +37,14 @@ public interface RunDescriptionPrinter {
     /**
      * Prints the run description of the implementing class only.
      *
-     * @param printWriter  the PrintWriter to be used
+     * @param printWriter the PrintWriter to be used
      */
     void printRunDescriptionSelf(PrintWriter printWriter);
 
     /**
      * Prints the run description of the inner classes only of the implementing class.
      *
-     * @param printWriter  the PrintWriter to be used
+     * @param printWriter the PrintWriter to be used
      */
     default void printRunDescriptionRec(PrintWriter printWriter) {
         // do nothing
@@ -56,9 +56,9 @@ public interface RunDescriptionPrinter {
      * This targets generic parameters.
      * </p>
      *
-     * @param printWriter   the PrintWriter to be used
-     * @param name          the parameter name
-     * @param value         the parameter value
+     * @param printWriter the PrintWriter to be used
+     * @param name        the parameter name
+     * @param value       the parameter value
      */
     default void printRDParam(PrintWriter printWriter, String name, Object value) {
         if (value == null) {
@@ -74,10 +74,10 @@ public interface RunDescriptionPrinter {
      * This targets list parameters that require comma-separation without brackets.
      * </p>
      *
-     * @param <T>           the element type
-     * @param printWriter   the PrintWriter to be used
-     * @param name          the parameter name
-     * @param values        the parameter values
+     * @param <T>         the element type
+     * @param printWriter the PrintWriter to be used
+     * @param name        the parameter name
+     * @param values      the parameter values
      */
     default <T> void printRDListParam(PrintWriter printWriter, String name, List<T> values) {
         if (values == null || values.isEmpty()) {
@@ -92,9 +92,10 @@ public interface RunDescriptionPrinter {
      * <p>
      * This targets String parameters that can be empty (or null).
      * </p>
-     * @param printWriter   the PrintWriter to be used
-     * @param name          the parameter name
-     * @param value         the parameter value
+     *
+     * @param printWriter the PrintWriter to be used
+     * @param name        the parameter name
+     * @param value       the parameter value
      */
     default void printRDStringParam(PrintWriter printWriter, String name, String value) {
         if (value == null) {
@@ -114,9 +115,9 @@ public interface RunDescriptionPrinter {
      * be false by default.
      * </p>
      *
-     * @param printWriter   the PrintWriter to be used
-     * @param name          the parameter name
-     * @param value         the parameter value
+     * @param printWriter the PrintWriter to be used
+     * @param name        the parameter name
+     * @param value       the parameter value
      */
     default void printRDBooleanParam(PrintWriter printWriter, String name, Boolean value) {
         if (value == null || value == false) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StateMachineWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StateMachineWrapper.java
@@ -5,21 +5,22 @@ import java.io.File;
 /**
  * Interface that wraps a given state machine.
  *
- * @param <ID>  the type of the input domain
- * @param <OD>  the type of the output domain
+ * @param <ID> the type of the input domain
+ * @param <OD> the type of the output domain
  */
 public interface StateMachineWrapper<ID, OD> {
     /**
      * Returns the size of the state machine.
      *
-     * @return  the size of the state machine
+     * @return the size of the state machine
      */
     int getMachineSize();
 
     /**
      * Computes the output of the given input.
      *
-     * @param input  the input to be provided to the state machine
+     * @param  input the input to be provided to the state machine
+     *
      * @return       the computed output
      */
     OD computeOutput(ID input);
@@ -27,14 +28,14 @@ public interface StateMachineWrapper<ID, OD> {
     /**
      * Exports the state machine to the specified file.
      *
-     * @param destFile  the destination file
+     * @param destFile the destination file
      */
     void export(File destFile);
 
     /**
      * Creates a new copy of the state machine.
      *
-     * @return  a new copy of the state machine
+     * @return a new copy of the state machine
      */
     StateMachineWrapper<ID, OD> copy();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/Statistics.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/Statistics.java
@@ -12,10 +12,10 @@ import java.util.List;
 /**
  * Statistics collected over the learning process.
  *
- * @param <I>   the type of inputs
- * @param <ID>  the type of input domain
- * @param <OD>  the type of output domain
- * @param <CE>  the type of counterexamples
+ * @param <I>  the type of inputs
+ * @param <ID> the type of input domain
+ * @param <OD> the type of output domain
+ * @param <CE> the type of counterexamples
  */
 public class Statistics<I, ID, OD, CE> {
 
@@ -74,7 +74,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the result of {@link #export(Writer)} converted to String.
      *
-     * @return  the string representation of this instance
+     * @return the string representation of this instance
      */
     @Override
     public String toString() {
@@ -86,7 +86,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Exports the stored {@link #runDescription} and other statistics to the given Writer.
      *
-     * @param writer  the Writer to be used for exporting
+     * @param writer the Writer to be used for exporting
      */
     public void export(Writer writer) {
         PrintWriter pw = new PrintWriter(writer);
@@ -109,20 +109,20 @@ public class Statistics<I, ID, OD, CE> {
 
         pw.println("Counterexamples:");
         int ind = 1;
-        for (Object ce : counterexamples) {
+        for (Object ce: counterexamples) {
             pw.println("CE " + ind + ":" + ce);
             ind++;
         }
 
         if (!hypStats.isEmpty()) {
             pw.println("Number of inputs when hypothesis was generated: "
-                    + hypStats.stream().map(s -> s.getSnapshot().getInputs()).toList());
+                + hypStats.stream().map(s -> s.getSnapshot().getInputs()).toList());
 
             pw.println("Number of tests when hypothesis was generated: "
-                    + hypStats.stream().map(s -> s.getSnapshot().getTests()).toList());
+                + hypStats.stream().map(s -> s.getSnapshot().getTests()).toList());
 
             pw.println("Time (ms) when hypothesis was generated: "
-                    + hypStats.stream().map(s -> s.getSnapshot().getTime()).toList());
+                + hypStats.stream().map(s -> s.getSnapshot().getTime()).toList());
 
             List<HypothesisStatistics<ID, OD, CE>> invalidatedHypStates = new ArrayList<>(hypStats);
             if (invalidatedHypStates.get(invalidatedHypStates.size() - 1).getCounterexample() == null) {
@@ -130,13 +130,13 @@ public class Statistics<I, ID, OD, CE> {
             }
 
             pw.println("Number of inputs when counterexample was found: "
-                    + invalidatedHypStates.stream().map(s -> s.getCounterexampleSnapshot().getInputs()).toList());
+                + invalidatedHypStates.stream().map(s -> s.getCounterexampleSnapshot().getInputs()).toList());
 
             pw.println("Number of tests when counterexample was found: "
-                    + invalidatedHypStates.stream().map(s -> s.getCounterexampleSnapshot().getTests()).toList());
+                + invalidatedHypStates.stream().map(s -> s.getCounterexampleSnapshot().getTests()).toList());
 
             pw.println("Time (ms) when counterexample was found: "
-                    + invalidatedHypStates.stream().map(s -> s.getCounterexampleSnapshot().getTime()).toList());
+                + invalidatedHypStates.stream().map(s -> s.getCounterexampleSnapshot().getTime()).toList());
         }
         pw.close();
     }
@@ -157,11 +157,10 @@ public class Statistics<I, ID, OD, CE> {
         runDescription = sw.toString();
     }
 
-
     /**
      * Returns the stored value of {@link #stateFuzzerEnabler}.
      *
-     * @return  the stored value of {@link #stateFuzzerEnabler}
+     * @return the stored value of {@link #stateFuzzerEnabler}
      */
     public StateFuzzerEnabler getStateFuzzerEnabler() {
         return stateFuzzerEnabler;
@@ -170,7 +169,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #stateFuzzerEnabler}.
      *
-     * @param stateFuzzerEnabler  the configuration that enables state fuzzing
+     * @param stateFuzzerEnabler the configuration that enables state fuzzing
      */
     public void setStateFuzzerEnabler(StateFuzzerEnabler stateFuzzerEnabler) {
         this.stateFuzzerEnabler = stateFuzzerEnabler;
@@ -179,7 +178,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #runDescription}.
      *
-     * @return  the stored value of {@link #runDescription}
+     * @return the stored value of {@link #runDescription}
      */
     public String getRunDescription() {
         return runDescription;
@@ -188,7 +187,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #alphabet}.
      *
-     * @return  the stored value of {@link #alphabet}
+     * @return the stored value of {@link #alphabet}
      */
     public Alphabet<I> getAlphabet() {
         return alphabet;
@@ -197,7 +196,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #alphabet}.
      *
-     * @param alphabet  the alphabet used
+     * @param alphabet the alphabet used
      */
     public void setAlphabet(Alphabet<I> alphabet) {
         this.alphabet = alphabet;
@@ -206,7 +205,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #states}.
      *
-     * @return  the stored value of {@link #states}
+     * @return the stored value of {@link #states}
      */
     public int getStates() {
         return states;
@@ -215,7 +214,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #states}.
      *
-     * @param states  the number of states of the learned model
+     * @param states the number of states of the learned model
      */
     public void setStates(int states) {
         this.states = states;
@@ -224,7 +223,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #learnTests}.
      *
-     * @return  the stored value of {@link #learnTests}
+     * @return the stored value of {@link #learnTests}
      */
     public long getLearnTests() {
         return learnTests;
@@ -233,7 +232,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #learnTests}.
      *
-     * @param learnTests  the number of membership queries (or learning tests)
+     * @param learnTests the number of membership queries (or learning tests)
      */
     public void setLearnTests(long learnTests) {
         this.learnTests = learnTests;
@@ -242,7 +241,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #learnInputs}.
      *
-     * @return  the stored value of {@link #learnInputs}
+     * @return the stored value of {@link #learnInputs}
      */
     public long getLearnInputs() {
         return learnInputs;
@@ -251,7 +250,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #learnInputs}.
      *
-     * @param learnInputs  the number of inputs used in membership queries
+     * @param learnInputs the number of inputs used in membership queries
      */
     public void setLearnInputs(long learnInputs) {
         this.learnInputs = learnInputs;
@@ -260,7 +259,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #allTests}.
      *
-     * @return  the stored value of {@link #allTests}
+     * @return the stored value of {@link #allTests}
      */
     public long getAllTests() {
         return allTests;
@@ -269,7 +268,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #allTests}.
      *
-     * @param allTests  the number of total membership and equivalence queries (or tests)
+     * @param allTests the number of total membership and equivalence queries (or tests)
      */
     public void setAllTests(long allTests) {
         this.allTests = allTests;
@@ -278,7 +277,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #allInputs}.
      *
-     * @return  the stored value of {@link #allInputs}
+     * @return the stored value of {@link #allInputs}
      */
     public long getAllInputs() {
         return allInputs;
@@ -287,7 +286,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #allInputs}.
      *
-     * @param allInputs  the number of total inputs in membership and equivalence queries
+     * @param allInputs the number of total inputs in membership and equivalence queries
      */
     public void setAllInputs(long allInputs) {
         this.allInputs = allInputs;
@@ -296,7 +295,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #duration}.
      *
-     * @return  the stored value of {@link #duration}
+     * @return the stored value of {@link #duration}
      */
     public long getDuration() {
         return duration;
@@ -305,7 +304,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #duration}.
      *
-     * @param duration  the time (ms) of the learning
+     * @param duration the time (ms) of the learning
      */
     public void setDuration(long duration) {
         this.duration = duration;
@@ -314,7 +313,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #lastHypTests}.
      *
-     * @return  the stored value of {@link #lastHypTests}
+     * @return the stored value of {@link #lastHypTests}
      */
     public long getLastHypTests() {
         return lastHypTests;
@@ -323,7 +322,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #lastHypTests}.
      *
-     * @param lastHypTests  the number of tests up to last hypothesis
+     * @param lastHypTests the number of tests up to last hypothesis
      */
     public void setLastHypTests(long lastHypTests) {
         this.lastHypTests = lastHypTests;
@@ -332,7 +331,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #lastHypInputs}.
      *
-     * @return  the stored value of {@link #lastHypInputs}
+     * @return the stored value of {@link #lastHypInputs}
      */
     public long getLastHypInputs() {
         return lastHypInputs;
@@ -341,7 +340,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #lastHypInputs}.
      *
-     * @param lastHypInputs  the number of inputs up to last hypothesis
+     * @param lastHypInputs the number of inputs up to last hypothesis
      */
     public void setLastHypInputs(long lastHypInputs) {
         this.lastHypInputs = lastHypInputs;
@@ -350,7 +349,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #counterexamples}.
      *
-     * @param counterexamples  the list of counterexamples found
+     * @param counterexamples the list of counterexamples found
      */
     public void setCounterexamples(List<CE> counterexamples) {
         this.counterexamples = counterexamples;
@@ -359,7 +358,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #counterexamples}.
      *
-     * @return  the stored value of {@link #counterexamples}
+     * @return the stored value of {@link #counterexamples}
      */
     public List<CE> getCounterexamples() {
         return counterexamples;
@@ -368,7 +367,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the last counterexample in {@link #counterexamples} or null if not found.
      *
-     * @return  the last counterexample or null if not found
+     * @return the last counterexample or null if not found
      */
     public CE getLastCounterexample() {
         if (counterexamples == null || counterexamples.isEmpty()) {
@@ -380,8 +379,8 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #finished} and {@link #notFinishedReason}.
      *
-     * @param finished           {@code true} if the learning finished successfully
-     * @param notFinishedReason  the cause of failed learning, when finished is {@code false}
+     * @param finished          {@code true} if the learning finished successfully
+     * @param notFinishedReason the cause of failed learning, when finished is {@code false}
      */
     public void setFinished(boolean finished, String notFinishedReason) {
         this.finished = finished;
@@ -391,7 +390,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the stored value of {@link #hypStats}.
      *
-     * @return  the stored value of {@link #hypStats}
+     * @return the stored value of {@link #hypStats}
      */
     public List<HypothesisStatistics<ID, OD, CE>> getHypStats() {
         return hypStats;
@@ -400,7 +399,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Sets the value of {@link #hypStats}.
      *
-     * @param hypStats  the list of hypothesis statistics
+     * @param hypStats the list of hypothesis statistics
      */
     public void setHypStats(List<HypothesisStatistics<ID, OD, CE>> hypStats) {
         this.hypStats = hypStats;
@@ -409,7 +408,7 @@ public class Statistics<I, ID, OD, CE> {
     /**
      * Returns the last hypothesis statistics in {@link #hypStats} or null if not found.
      *
-     * @return  the last hypothesis statistics or null if not found
+     * @return the last hypothesis statistics or null if not found
      */
     public HypothesisStatistics<ID, OD, CE> getLastHypStats() {
         if (hypStats == null || hypStats.isEmpty()) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsSnapshot.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsSnapshot.java
@@ -17,7 +17,7 @@ public class StatisticsSnapshot {
     /**
      * Returns the stored value of {@link #tests}.
      *
-     * @return  the stored value of {@link #tests}
+     * @return the stored value of {@link #tests}
      */
     public long getTests() {
         return tests;
@@ -26,7 +26,7 @@ public class StatisticsSnapshot {
     /**
      * Returns the stored value of {@link #inputs}.
      *
-     * @return  the stored value of {@link #inputs}
+     * @return the stored value of {@link #inputs}
      */
     public long getInputs() {
         return inputs;
@@ -35,7 +35,7 @@ public class StatisticsSnapshot {
     /**
      * Returns the stored value of {@link #time}.
      *
-     * @return  the stored value of {@link #time}
+     * @return the stored value of {@link #time}
      */
     public long getTime() {
         return time;
@@ -44,9 +44,9 @@ public class StatisticsSnapshot {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param tests   the number of tests (queries) used
-     * @param inputs  the number of inputs (in all queries) used
-     * @param time    the time (ms) spent until this snapshot
+     * @param tests  the number of tests (queries) used
+     * @param inputs the number of inputs (in all queries) used
+     * @param time   the time (ms) spent until this snapshot
      */
     public StatisticsSnapshot(long tests, long inputs, long time) {
         this.tests = tests;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsTracker.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsTracker.java
@@ -13,10 +13,10 @@ import java.util.ArrayList;
 /**
  * Tracks learning related statistics during the learning process.
  *
- * @param <I>   the type of inputs
- * @param <ID>  the type of input domain
- * @param <OD>  the type of output domain
- * @param <CE>  the type of counterexamples
+ * @param <I>  the type of inputs
+ * @param <ID> the type of input domain
+ * @param <OD> the type of output domain
+ * @param <CE> the type of counterexamples
  */
 public abstract class StatisticsTracker<I, ID, OD, CE> {
 
@@ -59,8 +59,8 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Creates a new instance from the given parameters.
      *
-     * @param inputCounter  counter updated on every input of membership and equivalence queries
-     * @param testCounter   counter updated on every membership and equivalence query (also named test)
+     * @param inputCounter counter updated on every input of membership and equivalence queries
+     * @param testCounter  counter updated on every membership and equivalence query (also named test)
      */
     public StatisticsTracker(Counter inputCounter, Counter testCounter) {
         this.inputCounter = inputCounter;
@@ -71,7 +71,7 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
      * Enables the logging of learning states to the specified output stream
      * by initializing {@link #stateWriter}.
      *
-     * @param outputStream  the stream where the learning states should be logged
+     * @param outputStream the stream where the learning states should be logged
      */
     public void setRuntimeStateTracking(OutputStream outputStream) {
         this.stateWriter = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
@@ -84,7 +84,7 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
      * Should be called only after all data structures (e.g. counterexamples)
      * corresponding to the state have been updated.
      *
-     * @param newState  the new state to be logged
+     * @param newState the new state to be logged
      */
     protected void logStateChange(State newState) {
         if (stateWriter == null) {
@@ -94,7 +94,7 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
         stateWriter.printf("(%d) New State: %s %n", System.currentTimeMillis() - startTime, newState.name());
         stateWriter.flush();
 
-        switch(newState) {
+        switch (newState) {
             case FINISHED -> {
                 stateWriter.close();
                 stateWriter = null;
@@ -132,7 +132,8 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Returns the input of the given counterexample.
      *
-     * @param counterexample  the counterexample to be processed
+     * @param  counterexample the counterexample to be processed
+     *
      * @return                the input of the given counterexample
      */
     protected abstract ID getInputOfCE(CE counterexample);
@@ -140,7 +141,8 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Returns the output of the given counterexample.
      *
-     * @param counterexample  the counterexample to be processed
+     * @param  counterexample the counterexample to be processed
+     *
      * @return                the output of the given counterexample
      */
     protected abstract OD getOutputOfCE(CE counterexample);
@@ -148,8 +150,8 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Should be called before the learning starts.
      *
-     * @param stateFuzzerEnabler  the configuration that enables the state fuzzing
-     * @param alphabet            the alphabet used for learning
+     * @param stateFuzzerEnabler the configuration that enables the state fuzzing
+     * @param alphabet           the alphabet used for learning
      */
     public void startLearning(StateFuzzerEnabler stateFuzzerEnabler, Alphabet<I> alphabet) {
         startTime = System.currentTimeMillis();
@@ -176,7 +178,7 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Should be called every time learning produces a new hypothesis.
      *
-     * @param hypothesis  the new hypothesis that has been found
+     * @param hypothesis the new hypothesis that has been found
      */
     public void newHypothesis(StateMachineWrapper<ID, OD> hypothesis) {
         long lastHypTests = testCounter.getCount();
@@ -184,7 +186,6 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
 
         long newLearnTests = statistics.getLearnTests() + lastHypTests - lastCETests;
         statistics.setLearnTests(newLearnTests);
-
 
         long lastHypInputs = inputCounter.getCount();
         statistics.setLastHypInputs(lastHypInputs);
@@ -204,7 +205,7 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Should be called every time equivalence oracle testing produces a counterexample.
      *
-     * @param counterexample  the new counterexample that has been found
+     * @param counterexample the new counterexample that has been found
      */
     public void newCounterExample(CE counterexample) {
         lastCETests = testCounter.getCount();
@@ -229,9 +230,9 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
      * is abruptly terminated yet statistics are desired. In the latter
      * case the last hypothesis should be provided.
      *
-     * @param learnedModel       the final model that has been learned
-     * @param finished           {@code true} if the learning finished successfully
-     * @param notFinishedReason  the cause of failed learning, when finished is {@code false}
+     * @param learnedModel      the final model that has been learned
+     * @param finished          {@code true} if the learning finished successfully
+     * @param notFinishedReason the cause of failed learning, when finished is {@code false}
      */
     public void finishedLearning(StateMachineWrapper<ID, OD> learnedModel, boolean finished, String notFinishedReason) {
         statistics.setStates(0);
@@ -250,7 +251,7 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
     /**
      * Should be called after learning finishes and {@link #finishedLearning} has been called.
      *
-     * @return  the statistics that have been tracked
+     * @return the statistics that have been tracked
      */
     public Statistics<I, ID, OD, CE> generateStatistics() {
         statistics.generateRunDescription();
@@ -261,9 +262,10 @@ public abstract class StatisticsTracker<I, ID, OD, CE> {
      * Creates a new snapshot from the current values of {@link #testCounter},
      * {@link #inputCounter} and current running time.
      *
-     * @return  the current statistics snapshot
+     * @return the current statistics snapshot
      */
     protected StatisticsSnapshot createSnapshot() {
-        return new StatisticsSnapshot(testCounter.getCount(), inputCounter.getCount(), System.currentTimeMillis() - startTime);
+        return new StatisticsSnapshot(testCounter.getCount(), inputCounter.getCount(),
+            System.currentTimeMillis() - startTime);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsTrackerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsTrackerRA.java
@@ -18,9 +18,9 @@ public class StatisticsTrackerRA<B, D, OD> extends StatisticsTracker<B, Word<D>,
      * Creates a new instance from the given parameters.
      *
      * @param inputCounter counter updated on every input of membership and
-     *                     equivalence queries
+     *                         equivalence queries
      * @param testCounter  counter updated on every membership and equivalence query
-     *                     (also named test)
+     *                         (also named test)
      */
     public StatisticsTrackerRA(Counter inputCounter, Counter testCounter) {
         super(inputCounter, testCounter);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsTrackerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/StatisticsTrackerStandard.java
@@ -8,16 +8,16 @@ import net.automatalib.word.Word;
  * Standard implementation of the StatisticsTracker for specific input domain
  * and counterexample type.
  *
- * @param <I>   the type of inputs
- * @param <OD>  the type of output domain
+ * @param <I>  the type of inputs
+ * @param <OD> the type of output domain
  */
 public class StatisticsTrackerStandard<I, OD> extends StatisticsTracker<I, Word<I>, OD, DefaultQuery<I, OD>> {
 
     /**
      * Creates a new instance from the given parameters.
      *
-     * @param inputCounter  counter updated on every input of membership and equivalence queries
-     * @param testCounter   counter updated on every membership and equivalence query (also named test)
+     * @param inputCounter counter updated on every input of membership and equivalence queries
+     * @param testCounter  counter updated on every membership and equivalence query (also named test)
      */
     public StatisticsTrackerStandard(Counter inputCounter, Counter testCounter) {
         super(inputCounter, testCounter);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/AbstractSUL.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/AbstractSUL.java
@@ -9,51 +9,51 @@ import de.learnlib.sul.SUL;
 /**
  * Abstract class used as the SUL Oracle using the {@link Mapper} and the {@link SULAdapter}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <E> the type of execution context
  */
 public interface AbstractSUL<I, O, E> extends SUL<I, O> {
 
     /**
      * Returns the configuration of the SUL.
      *
-     * @return  the configuration of the SUL
+     * @return the configuration of the SUL
      */
     SULConfig getSULConfig();
 
     /**
      * Returns the tasks to be cleaned up.
      *
-     * @return  the tasks to be cleaned up
+     * @return the tasks to be cleaned up
      */
     CleanupTasks getCleanupTasks();
 
     /**
      * Sets the dynamic port provider.
      *
-     * @param dynamicPortProvider  the dynamic port provider to be set
+     * @param dynamicPortProvider the dynamic port provider to be set
      */
     void setDynamicPortProvider(DynamicPortProvider dynamicPortProvider);
 
     /**
      * Returns the stored dynamic port provider if any.
      *
-     * @return  the stored dynamic port provider
+     * @return the stored dynamic port provider
      */
     DynamicPortProvider getDynamicPortProvider();
 
     /**
      * Returns the stored mapper.
      *
-     * @return  the stored mapper
+     * @return the stored mapper
      */
     Mapper<I, O, E> getMapper();
 
     /**
      * Returns the stored SUL adapter if any.
      *
-     * @return  the stored SUL adapter
+     * @return the stored SUL adapter
      */
     SULAdapter getSULAdapter();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULAdapter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULAdapter.java
@@ -24,14 +24,14 @@ public interface SULAdapter {
     /**
      * Checks if the launch server reported that the SUL process has terminated.
      *
-     * @return  {@code true} if the previously running SUL process has terminated
+     * @return {@code true} if the previously running SUL process has terminated
      */
     boolean checkStopped();
 
     /**
      * Retrieves the local port of the running SUL process.
      *
-     * @return  the local port of the running SUL process
+     * @return the local port of the running SUL process
      */
     Integer getSULPort();
 
@@ -39,8 +39,8 @@ public interface SULAdapter {
      * Returns {@code true} if the launch server launches client SUL processes
      * and {@code false} if the launch server launches server SUL processes.
      *
-     * @return  {@code true} if the launch server launches client SUL processes
-     *          and {@code false} if the launch server launches server SUL processes
+     * @return {@code true} if the launch server launches client SUL processes
+     *             and {@code false} if the launch server launches server SUL processes
      */
     boolean isClientLauncher();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULBuilder.java
@@ -6,17 +6,18 @@ import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 /**
  * Builder interface for the {@link AbstractSUL}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <E> the type of execution context
  */
 public interface SULBuilder<I, O, E> {
 
     /**
      * Builds a new instance of the {@link AbstractSUL}.
      *
-     * @param sulConfig     the configuration of the sul
-     * @param cleanupTasks  the cleanup tasks to run in the end
+     * @param  sulConfig    the configuration of the sul
+     * @param  cleanupTasks the cleanup tasks to run in the end
+     *
      * @return              a new AbstractSUL instance
      */
     AbstractSUL<I, O, E> buildSUL(SULConfig sulConfig, CleanupTasks cleanupTasks);
@@ -24,7 +25,7 @@ public interface SULBuilder<I, O, E> {
     /**
      * Builds a new instance of the {@link AbstractSUL} wrapper.
      *
-     * @return  a new SULWrapper instance
+     * @return a new SULWrapper instance
      */
     SULWrapper<I, O, E> buildWrapper();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULWrapper.java
@@ -8,16 +8,17 @@ import java.time.Duration;
 /**
  * Interface for the wrapper of the {@link AbstractSUL}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <E> the type of execution context
  */
 public interface SULWrapper<I, O, E> {
 
     /**
      * Wrap the given abstract SUL with a series of wrappers.
      *
-     * @param abstractSUL  the SUL to be wrapped
+     * @param  abstractSUL the SUL to be wrapped
+     *
      * @return             the updated SULWrapper instance
      */
     SULWrapper<I, O, E> wrap(AbstractSUL<I, O, E> abstractSUL);
@@ -25,7 +26,8 @@ public interface SULWrapper<I, O, E> {
     /**
      * Set the specified time limit using a designated wrapper.
      *
-     * @param timeLimit  the time allowed for the underlying abstract SUL to be active
+     * @param  timeLimit the time allowed for the underlying abstract SUL to be active
+     *
      * @return           the updated SULWrapper instance
      */
     SULWrapper<I, O, E> setTimeLimit(Duration timeLimit);
@@ -33,7 +35,8 @@ public interface SULWrapper<I, O, E> {
     /**
      * Set the specified test (query) limit using a designated wrapper.
      *
-     * @param testLimit  the number of tests that the underlying abstract SUL is allowed to answer
+     * @param  testLimit the number of tests that the underlying abstract SUL is allowed to answer
+     *
      * @return           the updated SULWrapper instance
      */
     SULWrapper<I, O, E> setTestLimit(Long testLimit);
@@ -45,16 +48,17 @@ public interface SULWrapper<I, O, E> {
      * after different set of inner wrappers or once as the outermost wrapper
      * before the {@link getWrappedSUL}.
      *
-     * @param logPrefix  a distinctive prefix before the actual logging, which
-     *                   can be null or an empty string if not needed
-     * @return  the updated SULWrapper instance
+     * @param  logPrefix a distinctive prefix before the actual logging, which
+     *                       can be null or an empty string if not needed
+     *
+     * @return           the updated SULWrapper instance
      */
     SULWrapper<I, O, E> setLoggingWrapper(String logPrefix);
 
     /**
      * Returns the final wrapped SUL Oracle instance.
      *
-     * @return  the final wrapped SUL Oracle instance
+     * @return the final wrapped SUL Oracle instance
      */
     SUL<I, O> getWrappedSUL();
 
@@ -62,7 +66,7 @@ public interface SULWrapper<I, O, E> {
      * Returns the input counter used for counting all the inputs directed at
      * the underlying abstract SUL.
      *
-     * @return  the input counter of the underlying abstract SUL
+     * @return the input counter of the underlying abstract SUL
      */
     Counter getInputCounter();
 
@@ -70,7 +74,7 @@ public interface SULWrapper<I, O, E> {
      * Returns the test counter used for counting all the tests (queries)
      * directed at the underlying abstract SUL.
      *
-     * @return  the test counter of the underlying abstract SUL
+     * @return the test counter of the underlying abstract SUL
      */
     Counter getTestCounter();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULWrapperStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/SULWrapperStandard.java
@@ -19,11 +19,12 @@ import java.time.Duration;
 
 /**
  * The standard implementation of {@link SULWrapper} using wrappers from the package
- * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwrappers  sulwrappers}.
+ * {@link com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.sulwrappers
+ * sulwrappers}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <E> the type of execution context
  */
 public class SULWrapperStandard<I, O, E> implements SULWrapper<I, O, E> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -46,7 +47,7 @@ public class SULWrapperStandard<I, O, E> implements SULWrapper<I, O, E> {
     /**
      * Constructor
      */
-    public SULWrapperStandard() { }
+    public SULWrapperStandard() {}
 
     @Override
     public SULWrapper<I, O, E> wrap(AbstractSUL<I, O, E> abstractSUL) {
@@ -110,7 +111,6 @@ public class SULWrapperStandard<I, O, E> implements SULWrapper<I, O, E> {
         wrappedSUL = new LoggingWrapper<>(wrappedSUL, logPrefix);
         return this;
     }
-
 
     @Override
     public SUL<I, O> getWrappedSUL() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/InputResponseTimeoutConverter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/InputResponseTimeoutConverter.java
@@ -16,12 +16,13 @@ public class InputResponseTimeoutConverter implements IStringConverter<Map<Strin
     /**
      * Constructor
      */
-    public InputResponseTimeoutConverter() { }
+    public InputResponseTimeoutConverter() {}
 
     /**
      * Converts a String to {@code Map<String, Long>} and uses {@link PropertyResolver#resolve(String)}.
      *
-     * @param value  the value to be converted
+     * @param  value the value to be converted
+     *
      * @return       the converted value
      */
     @Override
@@ -30,7 +31,7 @@ public class InputResponseTimeoutConverter implements IStringConverter<Map<Strin
         String resolvedValue = PropertyResolver.resolve(value);
         String[] inputValuePairs = resolvedValue.split("\\,", -1);
 
-        for (String inputValuePair : inputValuePairs) {
+        for (String inputValuePair: inputValuePairs) {
             String[] split = inputValuePair.split("\\:", -1);
 
             if (split.length != 2) {
@@ -39,7 +40,8 @@ public class InputResponseTimeoutConverter implements IStringConverter<Map<Strin
 
             try {
                 inputResponseTimeoutMap.put(split[0], Long.valueOf(split[1]));
-            } catch(Exception e) {
+            }
+            catch (Exception e) {
                 throw new ParameterException(errMessage(resolvedValue), e);
             }
         }
@@ -50,7 +52,8 @@ public class InputResponseTimeoutConverter implements IStringConverter<Map<Strin
     /**
      * Converts a {@code Map<String, Long>} to its respective String.
      *
-     * @param map  the map to be converted to string
+     * @param  map the map to be converted to string
+     *
      * @return     the converted string
      */
     public static String stringify(Map<String, Long> map) {
@@ -66,7 +69,8 @@ public class InputResponseTimeoutConverter implements IStringConverter<Map<Strin
     /**
      * Returns an error message containing the provided value.
      *
-     * @param value  the value that caused the error
+     * @param  value the value that caused the error
+     *
      * @return       the error message
      */
     protected String errMessage(String value) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULAdapterConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULAdapterConfig.java
@@ -15,7 +15,7 @@ public interface SULAdapterConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the port of the launch server to send commands to or null
+     * @return the port of the launch server to send commands to or null
      */
     default Integer getAdapterPort() {
         return null;
@@ -26,7 +26,7 @@ public interface SULAdapterConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: localhost.
      *
-     * @return  the address of the launch server to send commands to or null
+     * @return the address of the launch server to send commands to or null
      */
     default String getAdapterAddress() {
         return "localhost";

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULAdapterConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULAdapterConfigStandard.java
@@ -4,7 +4,6 @@ import com.beust.jcommander.Parameter;
 
 import java.io.PrintWriter;
 
-
 /**
  * The standard SULAdapter configuration.
  */
@@ -43,8 +42,8 @@ public class SULAdapterConfigStandard implements SULAdapterConfig {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param adapterPort     the adapterPort to set
-     * @param adapterAddress  the adapterAddress to set
+     * @param adapterPort    the adapterPort to set
+     * @param adapterAddress the adapterAddress to set
      */
     public SULAdapterConfigStandard(int adapterPort, String adapterAddress) {
         this.adapterPort = adapterPort;
@@ -54,7 +53,7 @@ public class SULAdapterConfigStandard implements SULAdapterConfig {
     /**
      * Constructor
      */
-    public SULAdapterConfigStandard() { }
+    public SULAdapterConfigStandard() {}
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfig.java
@@ -12,7 +12,7 @@ public interface SULClientConfig extends SULConfig {
      * <p>
      * Default value: 50L.
      *
-     * @return  the time (ms) before starting the client
+     * @return the time (ms) before starting the client
      */
     default Long getClientWait() {
         return 50L;
@@ -24,7 +24,7 @@ public interface SULClientConfig extends SULConfig {
      * <p>
      * Default value: null.
      *
-     * @return  the client SUL port or null
+     * @return the client SUL port or null
      */
     default Integer getPort() {
         return null;
@@ -36,15 +36,14 @@ public interface SULClientConfig extends SULConfig {
      * <p>
      * Default: does nothing.
      *
-     * @param port  the port number to be set
+     * @param port the port number to be set
      */
-    default void setPort(Integer port) {
-    }
+    default void setPort(Integer port) {}
 
     /**
      * Returns {@code "client"}.
      *
-     * @return  {@code "client"}
+     * @return {@code "client"}
      */
     @Override
     default String getFuzzingRole() {
@@ -54,7 +53,7 @@ public interface SULClientConfig extends SULConfig {
     /**
      * Returns {@code true}.
      *
-     * @return  {@code true}
+     * @return {@code true}
      */
     @Override
     default boolean isFuzzingClient() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfigStandard.java
@@ -5,7 +5,6 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.conf
 
 import java.io.PrintWriter;
 
-
 /**
  * The standard client SUL configuration.
  */
@@ -42,28 +41,26 @@ public class SULClientConfigStandard extends SULConfigStandard implements SULCli
     /**
      * Constructs a new instance from the corresponding super constructor.
      *
-     * @param mapperConfig      the configuration of the Mapper
-     * @param sulAdapterConfig  the configuration of the SULAdapter
+     * @param mapperConfig     the configuration of the Mapper
+     * @param sulAdapterConfig the configuration of the SULAdapter
      */
     public SULClientConfigStandard(MapperConfig mapperConfig, SULAdapterConfig sulAdapterConfig) {
         super(mapperConfig, sulAdapterConfig);
     }
 
-
     /**
      * It does nothing; left to be extended if needed.
      *
-     * @param <MCC>   the type of mapper connection configuration
-     * @param config  the configuration regarding the connection of the Mapper with the SUL process
+     * @param <MCC>  the type of mapper connection configuration
+     * @param config the configuration regarding the connection of the Mapper with the SUL process
      */
     @Override
-    public <MCC> void applyDelegate(MCC config) {
-    }
+    public <MCC> void applyDelegate(MCC config) {}
 
     /**
      * Returns the stored value of {@link #clientWait}.
      *
-     * @return  the stored value of {@link #clientWait}
+     * @return the stored value of {@link #clientWait}
      */
     @Override
     public Long getClientWait() {
@@ -73,7 +70,7 @@ public class SULClientConfigStandard extends SULConfigStandard implements SULCli
     /**
      * Returns the stored value of {@link #port}.
      *
-     * @return  the stored value of {@link #port}
+     * @return the stored value of {@link #port}
      */
     @Override
     public Integer getPort() {
@@ -83,7 +80,7 @@ public class SULClientConfigStandard extends SULConfigStandard implements SULCli
     /**
      * Sets the value of {@link #port}.
      *
-     * @param port  the port number to be set
+     * @param port the port number to be set
      */
     @Override
     public void setPort(Integer port) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfig.java
@@ -14,10 +14,12 @@ public interface SULConfig extends RunDescriptionPrinter {
 
     /**
      * Return a new instance of SUlConfig with the given threadId.
-     * @param threadId  used to change the port number
+     *
+     * @param  threadId used to change the port number
+     *
      * @return          a new instance of SUlConfig
      */
-    default SULConfig cloneWithThreadId(int threadId){
+    default SULConfig cloneWithThreadId(int threadId) {
         throw new UnsupportedOperationException("Not implemented yet! Your need to override this method.");
     }
 
@@ -26,7 +28,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: {@code "client"}.
      *
-     * @return  the role of the SUL under fuzzing that could be either "client" or "server"
+     * @return the role of the SUL under fuzzing that could be either "client" or "server"
      */
     default String getFuzzingRole() {
         return "client";
@@ -37,7 +39,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: {@code true}.
      *
-     * @return  {@code true} if the SUL under fuzzing is a client implementation.
+     * @return {@code true} if the SUL under fuzzing is a client implementation.
      */
     default boolean isFuzzingClient() {
         return true;
@@ -48,21 +50,20 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: does nothing.
      *
-     * @param <MCC>   the type of mapper connection configuration
-     * @param config  the configuration regarding the connection of the Mapper with the SUL process
+     * @param <MCC>  the type of mapper connection configuration
+     * @param config the configuration regarding the connection of the Mapper with the SUL process
      */
-    default <MCC> void applyDelegate(MCC config) {
-    }
+    default <MCC> void applyDelegate(MCC config) {}
 
     /**
      * Returns the associated MapperConfig.
      * <p>
      * Default value: new empty MapperConfig.
      *
-     * @return  the associated MapperConfig
+     * @return the associated MapperConfig
      */
     default MapperConfig getMapperConfig() {
-        return new MapperConfig(){};
+        return new MapperConfig() {};
     }
 
     /**
@@ -70,10 +71,10 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: new empty SULAdapterConfig.
      *
-     * @return  the associated SULAdapterConfig
+     * @return the associated SULAdapterConfig
      */
     default SULAdapterConfig getSULAdapterConfig() {
-        return new SULAdapterConfig(){};
+        return new SULAdapterConfig() {};
     }
 
     /**
@@ -81,7 +82,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 100L.
      *
-     * @return  the time (ms) the SUL spends waiting for a response or null
+     * @return the time (ms) the SUL spends waiting for a response or null
      */
     default Long getResponseWait() {
         return 100L;
@@ -92,10 +93,9 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default: does nothing.
      *
-     * @param responseWait  the response wait value to be set
+     * @param responseWait the response wait value to be set
      */
-    default void setResponseWait(Long responseWait) {
-    }
+    default void setResponseWait(Long responseWait) {}
 
     /**
      * Returns the map that indicates for each input the given time (ms) that
@@ -105,7 +105,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the map from input names to response times (ms)
+     * @return the map from input names to response times (ms)
      */
     default Map<String, Long> getInputResponseTimeout() {
         return null;
@@ -116,7 +116,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the command for starting the client/server process or null
+     * @return the command for starting the client/server process or null
      */
     default String getCommand() {
         return null;
@@ -127,7 +127,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the command for terminating the client/server process or null
+     * @return the command for terminating the client/server process or null
      */
     default String getTerminateCommand() {
         return null;
@@ -138,7 +138,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  the directory of the client/server process or null
+     * @return the directory of the client/server process or null
      */
     default String getProcessDir() {
         return null;
@@ -149,7 +149,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  true if the process output streams should be redirected
+     * @return true if the process output streams should be redirected
      */
     default boolean isRedirectOutputStreams() {
         return false;
@@ -160,7 +160,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: {@link ProcessLaunchTrigger#NEW_TEST}.
      *
-     * @return  a corresponding {@link ProcessLaunchTrigger}
+     * @return a corresponding {@link ProcessLaunchTrigger}
      */
     default ProcessLaunchTrigger getProcessTrigger() {
         return ProcessLaunchTrigger.NEW_TEST;
@@ -171,7 +171,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: 0L.
      *
-     * @return  the time (ms) waited after executing the command to start the SUL process
+     * @return the time (ms) waited after executing the command to start the SUL process
      */
     default Long getStartWait() {
         return 0L;
@@ -182,7 +182,7 @@ public interface SULConfig extends RunDescriptionPrinter {
      * <p>
      * Default: does nothing.
      *
-     * @param startWait  the start wait value to be set
+     * @param startWait the start wait value to be set
      */
     default void setStartWait(Long startWait) {}
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfigStandard.java
@@ -33,8 +33,7 @@ public abstract class SULConfigStandard implements SULConfig {
      * Default value: null.
      */
     @Parameter(names = "-inputResponseTimeout", description = "Time (ms) spent waiting for a "
-            + "response to a particular input. Expected format is: \"input1:value1,input2:value2...\" ",
-            converter = InputResponseTimeoutConverter.class)
+        + "response to a particular input. Expected format is: \"input1:value1,input2:value2...\" ", converter = InputResponseTimeoutConverter.class)
     protected Map<String, Long> inputResponseTimeout = null;
 
     /**
@@ -56,7 +55,7 @@ public abstract class SULConfigStandard implements SULConfig {
      * Default value: null.
      */
     @Parameter(names = {"-terminateCommand", "-termCmd"}, description = "Command for terminating "
-            + "the client/server process. If specified, it is used instead of java.lang.Process#destroy()")
+        + "the client/server process. If specified, it is used instead of java.lang.Process#destroy()")
     protected String terminateCommand = null;
 
     /**
@@ -77,7 +76,7 @@ public abstract class SULConfigStandard implements SULConfig {
      * Default value: false.
      */
     @Parameter(names = {"-redirectOutputStreams", "-ros"}, description = "Redirects process output "
-             + "streams to STDOUT and STDERR")
+        + "streams to STDOUT and STDERR")
     protected boolean redirectOutputStreams = false;
 
     /**
@@ -126,18 +125,18 @@ public abstract class SULConfigStandard implements SULConfig {
      * <p>
      * If any given parameter is null then the empty corresponding configuration is used.
      *
-     * @param mapperConfig      the configuration of the Mapper
-     * @param sulAdapterConfig  the configuration of the SULAdapter
+     * @param mapperConfig     the configuration of the Mapper
+     * @param sulAdapterConfig the configuration of the SULAdapter
      */
     public SULConfigStandard(MapperConfig mapperConfig, SULAdapterConfig sulAdapterConfig) {
-        this.mapperConfig = mapperConfig == null ? new MapperConfig(){} : mapperConfig;
-        this.sulAdapterConfig = sulAdapterConfig == null ? new SULAdapterConfig(){} : sulAdapterConfig;
+        this.mapperConfig = mapperConfig == null ? new MapperConfig() {} : mapperConfig;
+        this.sulAdapterConfig = sulAdapterConfig == null ? new SULAdapterConfig() {} : sulAdapterConfig;
     }
 
     /**
      * Returns the stored value of {@link #mapperConfig}.
      *
-     * @return  the stored value of {@link #mapperConfig}
+     * @return the stored value of {@link #mapperConfig}
      */
     @Override
     public MapperConfig getMapperConfig() {
@@ -147,7 +146,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #sulAdapterConfig}.
      *
-     * @return  the stored value of {@link #sulAdapterConfig}
+     * @return the stored value of {@link #sulAdapterConfig}
      */
     @Override
     public SULAdapterConfig getSULAdapterConfig() {
@@ -157,7 +156,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #responseWait}.
      *
-     * @return  the stored value of {@link #responseWait}
+     * @return the stored value of {@link #responseWait}
      */
     @Override
     public Long getResponseWait() {
@@ -167,7 +166,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Sets the value of {@link #responseWait}.
      *
-     * @param responseWait  the response wait value to be set
+     * @param responseWait the response wait value to be set
      */
     @Override
     public void setResponseWait(Long responseWait) {
@@ -177,7 +176,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #inputResponseTimeout}.
      *
-     * @return  the stored value of {@link #inputResponseTimeout}
+     * @return the stored value of {@link #inputResponseTimeout}
      */
     @Override
     public Map<String, Long> getInputResponseTimeout() {
@@ -187,7 +186,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #command}.
      *
-     * @return  the stored value of {@link #command}
+     * @return the stored value of {@link #command}
      */
     @Override
     public String getCommand() {
@@ -197,7 +196,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #terminateCommand}.
      *
-     * @return  the stored value of {@link #terminateCommand}
+     * @return the stored value of {@link #terminateCommand}
      */
     @Override
     public String getTerminateCommand() {
@@ -207,7 +206,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #processDir}.
      *
-     * @return  the stored value of {@link #processDir}
+     * @return the stored value of {@link #processDir}
      */
     @Override
     public String getProcessDir() {
@@ -217,7 +216,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #redirectOutputStreams}.
      *
-     * @return  the stored value of {@link #redirectOutputStreams}
+     * @return the stored value of {@link #redirectOutputStreams}
      */
     @Override
     public boolean isRedirectOutputStreams() {
@@ -227,7 +226,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #processTrigger}.
      *
-     * @return  the stored value of {@link #processTrigger}
+     * @return the stored value of {@link #processTrigger}
      */
     @Override
     public ProcessLaunchTrigger getProcessTrigger() {
@@ -237,7 +236,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Returns the stored value of {@link #startWait}.
      *
-     * @return  the stored value of {@link #startWait}
+     * @return the stored value of {@link #startWait}
      */
     @Override
     public Long getStartWait() {
@@ -247,7 +246,7 @@ public abstract class SULConfigStandard implements SULConfig {
     /**
      * Sets the value of {@link #startWait}.
      *
-     * @param startWait  the start wait value to be set
+     * @param startWait the start wait value to be set
      */
     @Override
     public void setStartWait(Long startWait) {
@@ -258,7 +257,8 @@ public abstract class SULConfigStandard implements SULConfig {
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### SULConfigStandard Parameters");
         printRDParam(printWriter, "-responseWait", responseWait);
-        printRDStringParam(printWriter, "-inputResponseTimeout", InputResponseTimeoutConverter.stringify(inputResponseTimeout));
+        printRDStringParam(printWriter, "-inputResponseTimeout",
+            InputResponseTimeoutConverter.stringify(inputResponseTimeout));
         printRDStringParam(printWriter, "-command", command);
         printRDStringParam(printWriter, "-terminateCommand", terminateCommand);
         printRDStringParam(printWriter, "-processDir", processDir);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfig.java
@@ -12,7 +12,7 @@ public interface SULServerConfig extends SULConfig {
      * <p>
      * Default value: null.
      *
-     * @return  the SUL server address to connect the state fuzzer client
+     * @return the SUL server address to connect the state fuzzer client
      */
     default String getHost() {
         return null;
@@ -23,15 +23,14 @@ public interface SULServerConfig extends SULConfig {
      * <p>
      * Default: does nothing.
      *
-     * @param host  the host to be set in the format {@code ip:port}
+     * @param host the host to be set in the format {@code ip:port}
      */
-    default void setHost(String host) {
-    }
+    default void setHost(String host) {}
 
     /**
      * Returns {@code "server"}.
      *
-     * @return  {@code "server"}
+     * @return {@code "server"}
      */
     @Override
     default String getFuzzingRole() {
@@ -41,7 +40,7 @@ public interface SULServerConfig extends SULConfig {
     /**
      * Returns {@code false}.
      *
-     * @return  {@code false}
+     * @return {@code false}
      */
     @Override
     default boolean isFuzzingClient() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfigStandard.java
@@ -5,7 +5,6 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.conf
 
 import java.io.PrintWriter;
 
-
 /**
  * The standard server SUL configuration.
  */
@@ -32,8 +31,8 @@ public class SULServerConfigStandard extends SULConfigStandard implements SULSer
     /**
      * Constructs a new instance from the corresponding super constructor.
      *
-     * @param mapperConfig      the configuration of the Mapper
-     * @param sulAdapterConfig  the configuration of the SULAdapter
+     * @param mapperConfig     the configuration of the Mapper
+     * @param sulAdapterConfig the configuration of the SULAdapter
      */
     public SULServerConfigStandard(MapperConfig mapperConfig, SULAdapterConfig sulAdapterConfig) {
         super(mapperConfig, sulAdapterConfig);
@@ -42,17 +41,16 @@ public class SULServerConfigStandard extends SULConfigStandard implements SULSer
     /**
      * It does nothing; left to be extended if needed.
      *
-     * @param <MCC>   the type of mapper connection configuration
-     * @param config  the configuration regarding the connection of the Mapper with the SUL process
+     * @param <MCC>  the type of mapper connection configuration
+     * @param config the configuration regarding the connection of the Mapper with the SUL process
      */
     @Override
-    public <MCC> void applyDelegate(MCC config) {
-    }
+    public <MCC> void applyDelegate(MCC config) {}
 
     /**
      * Returns the stored value of {@link #host}.
      *
-     * @return  the stored value of {@link #host}
+     * @return the stored value of {@link #host}
      */
     @Override
     public String getHost() {
@@ -62,7 +60,7 @@ public class SULServerConfigStandard extends SULConfigStandard implements SULSer
     /**
      * Sets the value of {@link #host}.
      *
-     * @param host  the host to be set
+     * @param host the host to be set
      */
     @Override
     public void setHost(String host) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/DynamicPortProvider.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/DynamicPortProvider.java
@@ -9,7 +9,7 @@ public interface DynamicPortProvider {
     /**
      * Returns the new port of the SUL process.
      *
-     * @return  the new port of the SUL process
+     * @return the new port of the SUL process
      */
     Integer getSULPort();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/LoggingWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/LoggingWrapper.java
@@ -7,8 +7,8 @@ import org.apache.logging.log4j.Logger;
 /**
  * SUL Wrapper used for logging the inputs to and outputs from the inner sul.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class LoggingWrapper<I, O> implements SUL<I, O> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -22,10 +22,10 @@ public class LoggingWrapper<I, O> implements SUL<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sul        the inner sul to be wrapped
-     * @param logPrefix  a distinctive prefix before the actual logging message
+     * @param sul       the inner sul to be wrapped
+     * @param logPrefix a distinctive prefix before the actual logging message
      */
-    public LoggingWrapper(SUL<I,O> sul, String logPrefix) {
+    public LoggingWrapper(SUL<I, O> sul, String logPrefix) {
         this.sul = sul;
         this.logPrefix = logPrefix == null ? "" : logPrefix;
     }
@@ -50,10 +50,11 @@ public class LoggingWrapper<I, O> implements SUL<I, O> {
      * Propagates the inputs of a test to the inner {@link #sul} and logs the
      * inputs and outputs.
      *
-     * @param input  the input of the test
-     * @return       the corresponding output
+     * @param  input                              the input of the test
      *
-     * @throws de.learnlib.exception.SULException  from the step method of the {@link #sul}
+     * @return                                    the corresponding output
+     *
+     * @throws de.learnlib.exception.SULException from the step method of the {@link #sul}
      */
     @Override
     public O step(I input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/ProcessHandler.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/ProcessHandler.java
@@ -50,14 +50,14 @@ public class ProcessHandler {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param sulConfig  the configuration of the SUL
+     * @param sulConfig the configuration of the SUL
      */
     public ProcessHandler(SULConfig sulConfig) {
         this(sulConfig.getCommand());
         this.sulConfig = sulConfig;
 
         if (sulConfig.getProcessDir() != null) {
-            pb.directory(new File(sulConfig.getProcessDir()));  // inlined setDirectory()
+            pb.directory(new File(sulConfig.getProcessDir())); // inlined setDirectory()
             LOGGER.info("Directory of SUL process: {}", sulConfig.getProcessDir());
         }
 
@@ -90,7 +90,7 @@ public class ProcessHandler {
     /**
      * Sets the value of {@link #output}.
      *
-     * @param toOutput  the new output stream
+     * @param toOutput the new output stream
      */
     public void redirectOutput(OutputStream toOutput) {
         output = toOutput;
@@ -99,7 +99,7 @@ public class ProcessHandler {
     /**
      * Sets the value of {@link #error}.
      *
-     * @param toOutput  the new error stream
+     * @param toOutput the new error stream
      */
     public void redirectError(OutputStream toOutput) {
         error = toOutput;
@@ -108,7 +108,7 @@ public class ProcessHandler {
     /**
      * Sets the current working directory before the process is launched.
      *
-     * @param procDir  the directory of the process
+     * @param procDir the directory of the process
      */
     public void setDirectory(File procDir) {
         pb.directory(procDir);
@@ -138,7 +138,8 @@ public class ProcessHandler {
             if (startWait > 0) {
                 Thread.sleep(startWait);
             }
-        } catch (IOException | InterruptedException e) {
+        }
+        catch (IOException | InterruptedException e) {
             LOGGER.error("Couldn't start process due to exec:", e);
             throw new RuntimeException(e);
         }
@@ -160,7 +161,8 @@ public class ProcessHandler {
             try {
                 // '+' after \\s takes care of multiple consecutive spaces
                 Runtime.getRuntime().exec(terminateCommand.split("\\s+"));
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -177,7 +179,8 @@ public class ProcessHandler {
             if (isAlive()) {
                 throw new RuntimeException("SUL process is still alive after " + TERM_WAIT_MS + " ms");
             }
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e) {
             LOGGER.error("Interrupted while waiting for process to terminate: ", e.getMessage());
             throw new RuntimeException(e);
         }
@@ -188,7 +191,7 @@ public class ProcessHandler {
     /**
      * Returns {@code true} if {@link #currentProcess} is alive.
      *
-     * @return  {@code true} if {@link #currentProcess} is alive
+     * @return {@code true} if {@link #currentProcess} is alive
      */
     public boolean isAlive() {
         return currentProcess != null && currentProcess.isAlive();
@@ -197,7 +200,7 @@ public class ProcessHandler {
     /**
      * Returns the value of {@link #hasLaunched}.
      *
-     * @return  the value of {@link #hasLaunched}
+     * @return the value of {@link #hasLaunched}
      */
     public boolean hasLaunched() {
         return hasLaunched;
@@ -206,8 +209,8 @@ public class ProcessHandler {
     /**
      * Starts a new thread that copies the source stream to the destination stream.
      *
-     * @param src   the source stream
-     * @param dest  the destination stream
+     * @param src  the source stream
+     * @param dest the destination stream
      */
     protected void pipe(final InputStream src, final OutputStream dest) {
         new Thread(new Runnable() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULAdapterWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULAdapterWrapper.java
@@ -7,8 +7,8 @@ import de.learnlib.sul.SUL;
  * SUL Wrapper that uses the {@link SULAdapter} in case the SUL processes are
  * launched using a launch server.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class SULAdapterWrapper<I, O> implements SUL<I, O>, DynamicPortProvider {
 
@@ -24,9 +24,9 @@ public class SULAdapterWrapper<I, O> implements SUL<I, O>, DynamicPortProvider {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sul                 the SUL to be wrapped
-     * @param sulAdapter          the SULAdapter of the launch server
-     * @param sulLivenessTracker  the liveness tracker of the SUL
+     * @param sul                the SUL to be wrapped
+     * @param sulAdapter         the SULAdapter of the launch server
+     * @param sulLivenessTracker the liveness tracker of the SUL
      */
     public SULAdapterWrapper(SUL<I, O> sul, SULAdapter sulAdapter, SULLivenessTracker sulLivenessTracker) {
         this.sul = sul;
@@ -78,10 +78,11 @@ public class SULAdapterWrapper<I, O> implements SUL<I, O>, DynamicPortProvider {
      * then this is reflected in the {@link #sulLivenessTracker}.
      * method.
      *
-     * @param input  the input of the test
-     * @return       the corresponding output
+     * @param  input                              the input of the test
      *
-     * @throws de.learnlib.exception.SULException  from the step method of the {@link #sul}
+     * @return                                    the corresponding output
+     *
+     * @throws de.learnlib.exception.SULException from the step method of the {@link #sul}
      */
     @Override
     public O step(I input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULLivenessTracker.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULLivenessTracker.java
@@ -13,7 +13,7 @@ public class SULLivenessTracker {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param alive  {@code true} if the SUL is initially alive
+     * @param alive {@code true} if the SUL is initially alive
      */
     public SULLivenessTracker(boolean alive) {
         this.alive = alive;
@@ -22,7 +22,7 @@ public class SULLivenessTracker {
     /**
      * Returns {@code true} if the SUL is alive.
      *
-     * @return  {@code true} if the SUL is alive
+     * @return {@code true} if the SUL is alive
      */
     public boolean isAlive() {
         return alive;
@@ -31,7 +31,7 @@ public class SULLivenessTracker {
     /**
      * Sets the liveness status of the SUL.
      *
-     * @param alive  indicates if the SUL is still alive
+     * @param alive indicates if the SUL is still alive
      */
     public void setAlive(boolean alive) {
         this.alive = alive;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULLivenessWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULLivenessWrapper.java
@@ -5,8 +5,8 @@ import de.learnlib.sul.SUL;
 /**
  * SUL Wrapper that checks for the liveness of the wrapped sul.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class SULLivenessWrapper<I, O> implements SUL<I, O> {
 
@@ -25,10 +25,10 @@ public class SULLivenessWrapper<I, O> implements SUL<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sul                 the SUL to be wrapped
-     * @param sulLivenessTracker  the liveness tracker of the SUL
-     * @param terminatedOutput    the output to be returned when the {@link #sul}
-     *                            is found to have terminated.
+     * @param sul                the SUL to be wrapped
+     * @param sulLivenessTracker the liveness tracker of the SUL
+     * @param terminatedOutput   the output to be returned when the {@link #sul}
+     *                               is found to have terminated.
      */
     public SULLivenessWrapper(SUL<I, O> sul, SULLivenessTracker sulLivenessTracker, O terminatedOutput) {
         this.sul = sul;
@@ -57,11 +57,13 @@ public class SULLivenessWrapper<I, O> implements SUL<I, O> {
      * Propagates the inputs of a test to the inner {@link #sul} and checks its
      * liveness via the {@link #sulLivenessTracker}.
      *
-     * @param input  the input of the test
-     * @return       the corresponding output or {@link #terminatedOutput} in case
-     *               the {@link #sul} is observed to have terminated
+     * @param  input                              the input of the test
      *
-     * @throws de.learnlib.exception.SULException  from the step method of the {@link #sul}
+     * @return                                    the corresponding output or {@link #terminatedOutput}
+     *                                                in case
+     *                                                the {@link #sul} is observed to have terminated
+     *
+     * @throws de.learnlib.exception.SULException from the step method of the {@link #sul}
      */
     @Override
     public O step(I input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULProcessWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/SULProcessWrapper.java
@@ -10,16 +10,17 @@ import java.util.Map;
  * SUL wrapper responsible for launching and terminating the SUL process.
  * Launches can be made at two distinct trigger points:
  * <ul>
- * <li> {@link ProcessLaunchTrigger#START} or
- * <li> {@link ProcessLaunchTrigger#NEW_TEST}
+ * <li>{@link ProcessLaunchTrigger#START} or
+ * <li>{@link ProcessLaunchTrigger#NEW_TEST}
  * </ul>
  *
- *  @param <I>  the type of inputs
- *  @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class SULProcessWrapper<I, O> implements SUL<I, O> {
 
-    // TODO introduce ProcessConfig class and handlers should be a map from ProcessConfig to ProcessHandler
+    // TODO introduce ProcessConfig class and handlers should be a map from ProcessConfig to
+    // ProcessHandler
 
     /** Static map that stores process handlers associated with a {@link SULConfig#getCommand()}. */
     protected static final Map<String, ProcessHandler> handlers = new LinkedHashMap<>();
@@ -32,7 +33,9 @@ public class SULProcessWrapper<I, O> implements SUL<I, O> {
 
     // TODO having the trigger here limits the trigger options; it should be outside
 
-    /** Stores the trigger of this instance's handler specified in {@link SULConfig#getProcessTrigger()}. */
+    /**
+     * Stores the trigger of this instance's handler specified in {@link SULConfig#getProcessTrigger()}.
+     */
     protected ProcessLaunchTrigger trigger;
 
     /** Stores the liveness tracker of the SUL. */
@@ -41,9 +44,9 @@ public class SULProcessWrapper<I, O> implements SUL<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sul                 the inner SUL to be wrapped
-     * @param sulConfig           the configuration of the SUL
-     * @param sulLivenessTracker  the liveness tracker of the SUL
+     * @param sul                the inner SUL to be wrapped
+     * @param sulConfig          the configuration of the SUL
+     * @param sulLivenessTracker the liveness tracker of the SUL
      */
     public SULProcessWrapper(SUL<I, O> sul, SULConfig sulConfig, SULLivenessTracker sulLivenessTracker) {
         this.sul = sul;
@@ -87,10 +90,11 @@ public class SULProcessWrapper<I, O> implements SUL<I, O> {
     /**
      * Propagates the inputs of a test to the inner {@link #sul}.
      *
-     * @param input  the input of the test
-     * @return       the corresponding output
+     * @param  input                              the input of the test
      *
-     * @throws de.learnlib.exception.SULException  from the step method of the {@link #sul}
+     * @return                                    the corresponding output
+     *
+     * @throws de.learnlib.exception.SULException from the step method of the {@link #sul}
      */
     @Override
     public O step(I input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/TestLimitWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/TestLimitWrapper.java
@@ -6,8 +6,8 @@ import de.learnlib.sul.SUL;
 /**
  * SUL Wrapper used for setting a limit on the tests directed at the inner sul.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class TestLimitWrapper<I, O> implements SUL<I, O> {
 
@@ -23,10 +23,10 @@ public class TestLimitWrapper<I, O> implements SUL<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sul    the inner sul to be wrapped
-     * @param testLimit  the maximum number of tests to be allowed
+     * @param sul       the inner sul to be wrapped
+     * @param testLimit the maximum number of tests to be allowed
      */
-    public TestLimitWrapper(SUL<I,O> sul, long testLimit) {
+    public TestLimitWrapper(SUL<I, O> sul, long testLimit) {
         this.sul = sul;
         this.testLimit = testLimit;
     }
@@ -42,7 +42,7 @@ public class TestLimitWrapper<I, O> implements SUL<I, O> {
     /**
      * Runs after each test; used for shutdown.
      *
-     * @throws TestLimitReachedException  if {@link #numTests} equals {@link #testLimit}
+     * @throws TestLimitReachedException if {@link #numTests} equals {@link #testLimit}
      */
     @Override
     public void post() {
@@ -56,10 +56,11 @@ public class TestLimitWrapper<I, O> implements SUL<I, O> {
     /**
      * Propagates the inputs of a test to the inner {@link #sul}.
      *
-     * @param input  the input of the test
-     * @return       the corresponding output
+     * @param  input                              the input of the test
      *
-     * @throws de.learnlib.exception.SULException  from the step method of the {@link #sul}
+     * @return                                    the corresponding output
+     *
+     * @throws de.learnlib.exception.SULException from the step method of the {@link #sul}
      */
     @Override
     public O step(I input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/TimeoutWrapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/sulwrappers/TimeoutWrapper.java
@@ -8,8 +8,8 @@ import java.time.Duration;
 /**
  * SUL Wrapper used for setting a limit on the active time of the inner sul.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class TimeoutWrapper<I, O> implements SUL<I, O> {
 
@@ -25,8 +25,8 @@ public class TimeoutWrapper<I, O> implements SUL<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param sul       the inner sul to be wrapped
-     * @param duration  the duration of the inner sul allowed to run
+     * @param sul      the inner sul to be wrapped
+     * @param duration the duration of the inner sul allowed to run
      */
     public TimeoutWrapper(SUL<I, O> sul, Duration duration) {
         this.sul = sul;
@@ -45,7 +45,7 @@ public class TimeoutWrapper<I, O> implements SUL<I, O> {
     /**
      * Runs after each test; used for shutdown.
      *
-     * @throws TimeLimitReachedException  if the allowed duration is exceeded
+     * @throws TimeLimitReachedException if the allowed duration is exceeded
      */
     @Override
     public void post() {
@@ -58,10 +58,11 @@ public class TimeoutWrapper<I, O> implements SUL<I, O> {
     /**
      * Propagates the inputs of a test to the inner {@link #sul}.
      *
-     * @param input  the input of the test
-     * @return    the corresponding output
+     * @param  input                              the input of the test
      *
-     * @throws de.learnlib.exception.SULException  from the step method of the {@link #sul}
+     * @return                                    the corresponding output
+     *
+     * @throws de.learnlib.exception.SULException from the step method of the {@link #sul}
      */
     @Override
     public O step(I input) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/Mapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/Mapper.java
@@ -9,23 +9,24 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.conf
  * <p>
  * Given an input symbol, the mapper should:
  * <ol>
- * <li> convert the input symbol to a protocol message
- * <li> send the protocol message to the SUL
- * <li> receive the protocol message response of the SUL
- * <li> convert the protocol message response to an output symbol
+ * <li>convert the input symbol to a protocol message
+ * <li>send the protocol message to the SUL
+ * <li>receive the protocol message response of the SUL
+ * <li>convert the protocol message response to an output symbol
  * </ol>
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <E> the type of execution context
  */
 public interface Mapper<I, O, E> {
 
     /**
      * Executes an input and returns the corresponding output.
      *
-     * @param input    the input symbol to be executed
-     * @param context  the active execution context
+     * @param  input   the input symbol to be executed
+     * @param  context the active execution context
+     *
      * @return         the corresponding output symbol
      */
     O execute(I input, E context);
@@ -33,21 +34,21 @@ public interface Mapper<I, O, E> {
     /**
      * Returns the configuration of the Mapper.
      *
-     * @return  the configuration of the Mapper
+     * @return the configuration of the Mapper
      */
     MapperConfig getMapperConfig();
 
     /**
      * Returns the instance that builds the output symbols.
      *
-     * @return  the instance that builds the output symbols
+     * @return the instance that builds the output symbols
      */
     OutputBuilder<O> getOutputBuilder();
 
     /**
      * Returns the instance that checks the output symbols.
      *
-     * @return  the instance that checks the output symbols
+     * @return the instance that checks the output symbols
      */
     OutputChecker<O> getOutputChecker();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractInputXml.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractInputXml.java
@@ -6,9 +6,9 @@ import jakarta.xml.bind.annotation.XmlAttribute;
  * Abstract extension of the AbstractSymbol for inputs obtained via an xml file,
  * which also should implement MapperInput.
  *
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
 public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implements MapperInput<O, P, E> {
 
@@ -31,7 +31,7 @@ public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implement
      * Constructs a new instance from the corresponding super constructor and
      * initializes also the {@link #xmlName}.
      *
-     * @param name  the input symbol name
+     * @param name the input symbol name
      */
     public AbstractInputXml(String name) {
         super(name, true);
@@ -41,7 +41,7 @@ public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implement
     /**
      * Returns the stored value of {@link #xmlName}.
      *
-     * @return  the stored value of {@link #xmlName}
+     * @return the stored value of {@link #xmlName}
      */
     @Override
     public String getName() {
@@ -51,7 +51,7 @@ public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implement
     /**
      * Sets the value of {@link #xmlName}.
      *
-     * @param name  the symbol name to be set
+     * @param name the symbol name to be set
      */
     @Override
     protected void setName(String name) {
@@ -61,7 +61,7 @@ public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implement
     /**
      * Returns the stored value of {@link #xmlExtendedWait}.
      *
-     * @return  the stored value of {@link #xmlExtendedWait}
+     * @return the stored value of {@link #xmlExtendedWait}
      */
     @Override
     public Long getExtendedWait() {
@@ -71,7 +71,7 @@ public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implement
     /**
      * Sets the value of {@link #xmlExtendedWait}.
      *
-     * @param extendedWait  the additional waiting time to be set
+     * @param extendedWait the additional waiting time to be set
      */
     @Override
     public void setExtendedWait(Long extendedWait) {
@@ -81,7 +81,7 @@ public abstract class AbstractInputXml<O, P, E> extends AbstractSymbol implement
     /**
      * Overrides the default method.
      *
-     * @return  the {@link #xmlName} of this symbol
+     * @return the {@link #xmlName} of this symbol
      */
     @Override
     public String toString() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractOutput.java
@@ -12,8 +12,8 @@ import java.util.Objects;
  * <p>
  * It also encapsulates the corresponding concrete messages created during learning.
  *
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
  */
 public abstract class AbstractOutput<O, P> extends AbstractSymbol implements MapperOutput<O, P> {
 
@@ -32,7 +32,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
      * Constructs a new instance from the given parameter and
      * initializes {@link #messages} to null.
      *
-     * @param name  the output symbol name
+     * @param name the output symbol name
      */
     public AbstractOutput(String name) {
         super(name, false);
@@ -43,8 +43,8 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
      * Constructs a new instance from the given parameters and
      * initializes {@link #messages} to the given ones.
      *
-     * @param name      the output symbol name
-     * @param messages  the list of received protocol messages
+     * @param name     the output symbol name
+     * @param messages the list of received protocol messages
      */
     public AbstractOutput(String name, List<P> messages) {
         super(name, false);
@@ -54,7 +54,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
     /**
      * Returns the stored value of {@link #messages}.
      *
-     * @return  the stored value of {@link #messages}
+     * @return the stored value of {@link #messages}
      */
     @Override
     public List<P> getMessages() {
@@ -65,7 +65,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
      * Indicates whether the output also contains the concrete {@link #messages}
      * from which the abstraction was derived.
      *
-     * @return  {@code true} if {@link #messages} are not null or empty
+     * @return {@code true} if {@link #messages} are not null or empty
      */
     @Override
     public boolean hasMessages() {
@@ -96,7 +96,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
             return outputs;
         }
 
-        for (String absOutput : getAtomicAbstractionStrings(unrollRepeating)) {
+        for (String absOutput: getAtomicAbstractionStrings(unrollRepeating)) {
             O output = buildOutput(absOutput);
             outputs.add(output);
         }
@@ -113,7 +113,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
         String[] atoms = getName().split("\\" + MESSAGE_SEPARATOR, -1);
         List<String> newAtoms = new ArrayList<>();
 
-        for (String atom : atoms) {
+        for (String atom: atoms) {
             if (atom.endsWith(REPEATING_INDICATOR)) {
                 String repeatingAtom = atom.substring(0, atom.length() - REPEATING_INDICATOR.length());
                 for (Integer i = 0; i < unrollRepeating; i++) {
@@ -143,7 +143,8 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
     /**
      * Builds a new O output given its name.
      *
-     * @param name  the name of the output
+     * @param  name the name of the output
+     *
      * @return      the build O output
      */
     protected abstract O buildOutput(String name);
@@ -151,7 +152,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
     /**
      * Converts the current AbstractOutput to an O output.
      *
-     * @return  the converted O output
+     * @return the converted O output
      */
     protected abstract O convertOutput();
 
@@ -165,7 +166,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
     /**
      * Returns the content information of this output symbol.
      *
-     * @return  the content string of this output symbol
+     * @return the content string of this output symbol
      */
     protected String buildContentInfo() {
         StringBuilder builder = new StringBuilder();
@@ -176,7 +177,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
         }
 
         builder.append("{");
-        for (Map.Entry<String, String> entry : printMap.entrySet()) {
+        for (Map.Entry<String, String> entry: printMap.entrySet()) {
             builder.append(entry.getKey());
             builder.append("=");
             builder.append(entry.getValue());
@@ -190,7 +191,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
     /**
      * Overrides the default method.
      *
-     * @return  {@code true} if this instance equals the given object
+     * @return {@code true} if this instance equals the given object
      */
     @Override
     public boolean equals(Object o) {
@@ -211,7 +212,7 @@ public abstract class AbstractOutput<O, P> extends AbstractSymbol implements Map
     /**
      * Overrides the default method.
      *
-     * @return  the hash code of this instance
+     * @return the hash code of this instance
      */
     @Override
     public int hashCode() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractSymbol.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/AbstractSymbol.java
@@ -14,7 +14,7 @@ public abstract class AbstractSymbol {
     /**
      * Constructs a new instance from the given parameter without a name.
      *
-     * @param isInput  {@code true} if the symbol is an input symbol
+     * @param isInput {@code true} if the symbol is an input symbol
      */
     public AbstractSymbol(boolean isInput) {
         this.isInput = isInput;
@@ -23,8 +23,8 @@ public abstract class AbstractSymbol {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param name     the name of the symbol
-     * @param isInput  {@code true} if the symbol is an input symbol
+     * @param name    the name of the symbol
+     * @param isInput {@code true} if the symbol is an input symbol
      */
     public AbstractSymbol(String name, boolean isInput) {
         this.name = name;
@@ -34,7 +34,7 @@ public abstract class AbstractSymbol {
     /**
      * Returns the stored value of {@link #name}.
      *
-     * @return  the stored value of {@link #name}
+     * @return the stored value of {@link #name}
      */
     public String getName() {
         return name;
@@ -43,7 +43,7 @@ public abstract class AbstractSymbol {
     /**
      * Sets the value of {@link #name}.
      *
-     * @param name  the symbol name to be set
+     * @param name the symbol name to be set
      */
     protected void setName(String name) {
         this.name = name;
@@ -52,7 +52,7 @@ public abstract class AbstractSymbol {
     /**
      * Returns the stored value of {@link #isInput}.
      *
-     * @return  the stored value of {@link #isInput}
+     * @return the stored value of {@link #isInput}
      */
     public boolean getIsInput() {
         return isInput;
@@ -62,7 +62,7 @@ public abstract class AbstractSymbol {
      * Returns the stored value of {@link #name} with a distinguishing prefix
      * different for an input and an output.
      *
-     * @return  the stored value of {@link #name} with a distinguishing prefix
+     * @return the stored value of {@link #name} with a distinguishing prefix
      */
     public String inputDistinguishingName() {
         return (isInput ? "I_" : "O_") + name;
@@ -71,7 +71,7 @@ public abstract class AbstractSymbol {
     /**
      * Overrides the default method.
      *
-     * @return  the {@link #name} of this symbol
+     * @return the {@link #name} of this symbol
      */
     @Override
     public String toString() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/MapperInput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/MapperInput.java
@@ -3,23 +3,24 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abs
 /**
  * The interface needed by the input symbols of the Mapper.
  *
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
 public interface MapperInput<O, P, E> {
 
     /**
      * Returns the name of the input.
      *
-     * @return  the name of the input
+     * @return the name of the input
      */
     String getName();
 
     /**
      * Returns {@code true} if this input symbol is enabled for execution.
      *
-     * @param context  the active execution context
+     * @param  context the active execution context
+     *
      * @return         {@code true} if this input symbol is enabled for execution
      */
     default boolean isEnabled(E context) {
@@ -29,22 +30,22 @@ public interface MapperInput<O, P, E> {
     /**
      * Returns the extended wait time needed for this input symbol.
      *
-     * @return  the extended wait time needed for this input symbol
+     * @return the extended wait time needed for this input symbol
      */
     Long getExtendedWait();
 
     /**
      * Sets the extended wait time needed for this input symbol.
      *
-     * @param extendedWait  the additional waiting time before sending this input symbol
+     * @param extendedWait the additional waiting time before sending this input symbol
      */
     void setExtendedWait(Long extendedWait);
 
     /**
      * Updates the context before sending the input and before calling
-     * {@link generateProtocolMessage  generateProtocolMessage}.
+     * {@link generateProtocolMessage generateProtocolMessage}.
      *
-     * @param context  the active execution context
+     * @param context the active execution context
      */
     abstract void preSendUpdate(E context);
 
@@ -53,7 +54,8 @@ public interface MapperInput<O, P, E> {
      * of the current abstract input symbol, providing this way the
      * functionality of abstract-to-concrete Mapper.
      *
-     * @param context  the active execution context
+     * @param  context the active execution context
+     *
      * @return         the corresponding protocol message
      */
     abstract P generateProtocolMessage(E context);
@@ -61,16 +63,16 @@ public interface MapperInput<O, P, E> {
     /**
      * Updates the context after sending the input.
      *
-     * @param context  the active execution context
+     * @param context the active execution context
      */
     abstract void postSendUpdate(E context);
 
     /**
      * Updates the context after receiving an output.
      *
-     * @param output         the output obtained as the response
-     * @param outputChecker  the output checker to check the output if needed
-     * @param context        the active execution context
+     * @param output        the output obtained as the response
+     * @param outputChecker the output checker to check the output if needed
+     * @param context       the active execution context
      */
     abstract void postReceiveUpdate(
         O output, OutputChecker<O> outputChecker, E context);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/MapperOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/MapperOutput.java
@@ -8,8 +8,8 @@ import java.util.List;
  * The protocol messages are the concrete message that used to identify and
  * generate the corresponding output symbol.
  *
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
  */
 public interface MapperOutput<O, P> {
 
@@ -22,14 +22,14 @@ public interface MapperOutput<O, P> {
     /**
      * Returns the name of the input.
      *
-     * @return  the name of the input
+     * @return the name of the input
      */
     String getName();
 
     /**
      * Returns the stored protocol messages.
      *
-     * @return  the stored protocol messages
+     * @return the stored protocol messages
      */
     List<P> getMessages();
 
@@ -37,14 +37,14 @@ public interface MapperOutput<O, P> {
      * Indicates whether the output also contains the concrete messages
      * from which the abstraction was derived.
      *
-     * @return  {@code true} if messages are contained
+     * @return {@code true} if messages are contained
      */
     boolean hasMessages();
 
     /**
      * Identifies whether the output was derived from multiple distinct messages.
      *
-     * @return  {@code true} if the output contains multiple messages
+     * @return {@code true} if the output contains multiple messages
      */
     boolean isComposite();
 
@@ -53,12 +53,12 @@ public interface MapperOutput<O, P> {
      * <p>
      * This means the output can be:
      * <ul>
-     * <li> a single message or
-     * <li> repeating occurrences of the same message or
-     * <li> no message
+     * <li>a single message or
+     * <li>repeating occurrences of the same message or
+     * <li>no message
      * </ul>
      *
-     * @return  {@code true} if the output is not composite
+     * @return {@code true} if the output is not composite
      */
     boolean isAtomic();
 
@@ -66,7 +66,7 @@ public interface MapperOutput<O, P> {
      * Returns a list of output symbols, one for each individual message in the output,
      * unrolling repeating messages only one time.
      *
-     * @return  the list of output symbol instances
+     * @return the list of output symbol instances
      */
     List<O> getAtomicOutputs();
 
@@ -74,8 +74,9 @@ public interface MapperOutput<O, P> {
      * Returns a list of output symbols, one for each individual message in the output,
      * unrolling repeating messages the given number of times.
      *
-     * @param unrollRepeating  the number of times a repeating output should be unrolled
-     * @return  the list of output symbol instances
+     * @param  unrollRepeating the number of times a repeating output should be unrolled
+     *
+     * @return                 the list of output symbol instances
      */
     List<O> getAtomicOutputs(int unrollRepeating);
 
@@ -83,7 +84,7 @@ public interface MapperOutput<O, P> {
      * Returns a list of abstraction strings, one for each individual message in the output,
      * unrolling repeating messages only one time.
      *
-     * @return  the list of output strings
+     * @return the list of output strings
      */
     List<String> getAtomicAbstractionStrings();
 
@@ -91,7 +92,8 @@ public interface MapperOutput<O, P> {
      * Returns a list of abstraction strings, one for each individual message in the output,
      * unrolling repeating messages the given number of times.
      *
-     * @param unrollRepeating  the number of times a repeating output should be unrolled
+     * @param  unrollRepeating the number of times a repeating output should be unrolled
+     *
      * @return                 the list of output strings
      */
     List<String> getAtomicAbstractionStrings(int unrollRepeating);
@@ -99,7 +101,7 @@ public interface MapperOutput<O, P> {
     /**
      * Identifies whether the output contains only a single repeating message.
      *
-     * @return  {@code true} if the output is a single repeating message
+     * @return {@code true} if the output is a single repeating message
      */
     boolean isRepeating();
 
@@ -107,7 +109,7 @@ public interface MapperOutput<O, P> {
      * Returns the repeating output of the message if {@link #isRepeating()} or
      * this instance.
      *
-     * @return  the repeating output of the message if {@link #isRepeating()} or this instance
+     * @return the repeating output of the message if {@link #isRepeating()} or this instance
      */
     O getRepeatedOutput();
 
@@ -116,7 +118,7 @@ public interface MapperOutput<O, P> {
      * <p>
      * For instance, it can contain the protocol messages.
      *
-     * @return  a detailed string of this output symbol
+     * @return a detailed string of this output symbol
      */
     String toDetailedString();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/OutputBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/OutputBuilder.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /**
  * Abstract class for building output symbols.
  *
- * @param <O>  the type of outputs
+ * @param <O> the type of outputs
  */
 public abstract class OutputBuilder<O> {
     /** Special output symbol to show that no response was received during the waiting time. */
@@ -27,12 +27,13 @@ public abstract class OutputBuilder<O> {
     /**
      * Constructor
      */
-    public OutputBuilder() { }
+    public OutputBuilder() {}
 
     /**
      * Builds the exact output symbol corresponding to the provided name.
      *
-     * @param name  the name of the output symbol
+     * @param  name the name of the output symbol
+     *
      * @return      the output symbol
      */
     public abstract O buildOutputExact(String name);
@@ -46,7 +47,8 @@ public abstract class OutputBuilder<O> {
      * The {@link #userSpecificMap} is mostly used for special symbol replacements,
      * stemming from the user-specified mapper configuration.
      *
-     * @param name  the name of the output symbol
+     * @param  name the name of the output symbol
+     *
      * @return      the output symbol
      */
     public O buildOutput(String name) {
@@ -58,7 +60,7 @@ public abstract class OutputBuilder<O> {
      * <p>
      * The default implementation uses the name of {@link #TIMEOUT}.
      *
-     * @return  the special output symbol for timeout
+     * @return the special output symbol for timeout
      */
     public O buildTimeout() {
         return buildOutput(TIMEOUT);
@@ -69,7 +71,7 @@ public abstract class OutputBuilder<O> {
      * <p>
      * The default implementation uses the name of {@link #UNKNOWN}.
      *
-     * @return  the special output symbol for unknown
+     * @return the special output symbol for unknown
      */
     public O buildUnknown() {
         return buildOutput(UNKNOWN);
@@ -80,7 +82,7 @@ public abstract class OutputBuilder<O> {
      * <p>
      * The default implementation uses the name of {@link #SOCKET_CLOSED}.
      *
-     * @return  the special output symbol for socket closed
+     * @return the special output symbol for socket closed
      */
     public O buildSocketClosed() {
         return buildOutput(SOCKET_CLOSED);
@@ -91,7 +93,7 @@ public abstract class OutputBuilder<O> {
      * <p>
      * The default implementation uses the name of {@link #DISABLED}.
      *
-     * @return  the special output symbol for disabled
+     * @return the special output symbol for disabled
      */
     public O buildDisabled() {
         return buildOutput(DISABLED);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/OutputChecker.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/abstractsymbols/OutputChecker.java
@@ -4,7 +4,7 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abs
  * Interface for analyzing and checking output symbols so that
  * checking is decoupled from the formation of the output symbols.
  *
- * @param <O>  the type of outputs
+ * @param <O> the type of outputs
  */
 public interface OutputChecker<O> {
 
@@ -15,7 +15,8 @@ public interface OutputChecker<O> {
      * It is useful in cases when the SUL client starts the protocol, while
      * the state fuzzer server is waiting for the initial message.
      *
-     * @param output  the output to be checked
+     * @param  output the output to be checked
+     *
      * @return        {@code true} if the output contains the initial client message
      */
     boolean hasInitialClientMessage(O output);
@@ -23,7 +24,8 @@ public interface OutputChecker<O> {
     /**
      * Returns {@code true} if the output is the special symbol for timeout.
      *
-     * @param output  the output to be checked
+     * @param  output the output to be checked
+     *
      * @return        {@code true} if the output special symbol for timeout
      */
     boolean isTimeout(O output);
@@ -31,7 +33,8 @@ public interface OutputChecker<O> {
     /**
      * Returns {@code true} if the output is the special symbol for unknown.
      *
-     * @param output  the output to be checked
+     * @param  output the output to be checked
+     *
      * @return        {@code true} if the output special symbol for unknown
      */
     boolean isUnknown(O output);
@@ -39,7 +42,8 @@ public interface OutputChecker<O> {
     /**
      * Returns {@code true} if the output is the special symbol for socket closed.
      *
-     * @param output  the output to be checked
+     * @param  output the output to be checked
+     *
      * @return        {@code true} if the output special symbol for socket closed
      */
     boolean isSocketClosed(O output);
@@ -47,7 +51,8 @@ public interface OutputChecker<O> {
     /**
      * Returns {@code true} if the output is the special symbol for disabled.
      *
-     * @param output  the output to be checked
+     * @param  output the output to be checked
+     *
      * @return        {@code true} if the output special symbol for disabled
      */
     boolean isDisabled(O output);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfig.java
@@ -25,7 +25,7 @@ public interface MapperConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  null or the provided configuration file
+     * @return null or the provided configuration file
      */
     default String getMapperConnectionConfig() {
         return null;
@@ -33,14 +33,17 @@ public interface MapperConfig extends RunDescriptionPrinter {
 
     /**
      * Returns the input stream of the provided configuration file if {@link #getMapperConnectionConfig}
-     * is not null or the input stream of the {@link #DEFAULT_MAPPER_CONNECTION_CONFIG} file in resources,
+     * is not null or the input stream of the {@link #DEFAULT_MAPPER_CONNECTION_CONFIG} file in
+     * resources,
      * which can be null if the file is missing.
      *
-     * @return  the input stream of the provided configuration file if {@link #getMapperConnectionConfig}
-     *          is not null or the input stream of the {@link #DEFAULT_MAPPER_CONNECTION_CONFIG} file in resources,
-     *          which can be null if the file is missing
+     * @return             the input stream of the provided configuration file if
+     *                         {@link #getMapperConnectionConfig}
+     *                         is not null or the input stream of the
+     *                         {@link #DEFAULT_MAPPER_CONNECTION_CONFIG} file in resources,
+     *                         which can be null if the file is missing
      *
-     * @throws IOException  if an IO error occurs
+     * @throws IOException if an IO error occurs
      */
     default InputStream getMapperConnectionConfigInputStream() throws IOException {
         if (getMapperConnectionConfig() == null) {
@@ -60,7 +63,7 @@ public interface MapperConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: null.
      *
-     * @return  a list of repeating outputs or null if not provided
+     * @return a list of repeating outputs or null if not provided
      */
     default List<String> getRepeatingOutputs() {
         return null;
@@ -76,7 +79,7 @@ public interface MapperConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if the substitution of symbols should occur
+     * @return {@code true} if the substitution of symbols should occur
      */
     default boolean isSocketClosedAsTimeout() {
         return false;
@@ -88,7 +91,7 @@ public interface MapperConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if the substitution of symbols should occur
+     * @return {@code true} if the substitution of symbols should occur
      */
     default boolean isDisabledAsTimeout() {
         return false;
@@ -103,7 +106,7 @@ public interface MapperConfig extends RunDescriptionPrinter {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if merging of repeated outputs should occur
+     * @return {@code true} if merging of repeated outputs should occur
      */
     default boolean isMergeRepeating() {
         return false;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigStandard.java
@@ -7,7 +7,6 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abst
 import java.io.PrintWriter;
 import java.util.List;
 
-
 /**
  * The standard Mapper configuration.
  */
@@ -21,8 +20,8 @@ public class MapperConfigStandard implements MapperConfig {
      * Default value: null.
      */
     @Parameter(names = "-mapperConnectionConfig", description = "Configuration file for the connection of "
-            + "Mapper with the running SUL process. Defaults to " + DEFAULT_MAPPER_CONNECTION_CONFIG
-            + " file in resources")
+        + "Mapper with the running SUL process. Defaults to " + DEFAULT_MAPPER_CONNECTION_CONFIG
+        + " file in resources")
     protected String mapperConnectionConfig = null;
 
     /**
@@ -36,9 +35,9 @@ public class MapperConfigStandard implements MapperConfig {
      * Default value: null.
      */
     @Parameter(names = "-repeatingOutputs", description = "Single or repeated occurrences of these "
-            + "outputs are mapped to a single repeating output with the " + MapperOutput.REPEATING_INDICATOR
-            + " appended. Used for outputs that the SUL may repeat an arbitrary number "
-            + "of times which may cause non-determinism")
+        + "outputs are mapped to a single repeating output with the " + MapperOutput.REPEATING_INDICATOR
+        + " appended. Used for outputs that the SUL may repeat an arbitrary number "
+        + "of times which may cause non-determinism")
     protected List<String> repeatingOutputs = null;
 
     /**
@@ -52,10 +51,10 @@ public class MapperConfigStandard implements MapperConfig {
      * Default value: false.
      */
     @Parameter(names = "-socketClosedAsTimeout", description = "Uses "
-            + OutputBuilder.TIMEOUT + " instead of " + OutputBuilder.SOCKET_CLOSED
-            + " outputs to identify when the system process has terminated. "
-            + "Useful for preventing non-determinism due to the arbitrary waiting duration "
-            + "caused by the non-responding SUL while its process eventually terminates")
+        + OutputBuilder.TIMEOUT + " instead of " + OutputBuilder.SOCKET_CLOSED
+        + " outputs to identify when the system process has terminated. "
+        + "Useful for preventing non-determinism due to the arbitrary waiting duration "
+        + "caused by the non-responding SUL while its process eventually terminates")
     protected boolean socketClosedAsTimeout = false;
 
     /**
@@ -66,7 +65,7 @@ public class MapperConfigStandard implements MapperConfig {
      * Default value: false.
      */
     @Parameter(names = "-disabledAsTimeout", description = "Uses " + OutputBuilder.TIMEOUT + " instead of "
-            + OutputBuilder.DISABLED)
+        + OutputBuilder.DISABLED)
     protected boolean disabledAsTimeout = false;
 
     /**
@@ -79,14 +78,14 @@ public class MapperConfigStandard implements MapperConfig {
      * Default value: false.
      */
     @Parameter(names = "-dontMergeRepeating", description = "Disables merging of repeated outputs. "
-            + "By default the mapper merges outputs which are repeated in immediate succession  "
-            + "into a single output with '" + MapperOutput.REPEATING_INDICATOR + "' appended")
+        + "By default the mapper merges outputs which are repeated in immediate succession  "
+        + "into a single output with '" + MapperOutput.REPEATING_INDICATOR + "' appended")
     protected boolean dontMergeRepeating = false;
 
     /**
      * Constructor
      */
-    public MapperConfigStandard() { }
+    public MapperConfigStandard() {}
 
     @Override
     public String getMapperConnectionConfig() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/context/ExecutionContext.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/context/ExecutionContext.java
@@ -4,16 +4,16 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.con
  * Interface that incorporates an inner state used for the protocol-specific state
  * and is also capable of enabling and disabling the execution.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <S>  the type of execution context's state
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <S> the type of execution context's state
  */
 public interface ExecutionContext<I, O, S> {
 
     /**
      * Returns the current state.
      *
-     * @return  the current state.
+     * @return the current state.
      */
     S getState();
 
@@ -30,21 +30,21 @@ public interface ExecutionContext<I, O, S> {
     /**
      * Indicates if this execution context is enabled.
      *
-     * @return  {@code true} if this execution context is enabled
+     * @return {@code true} if this execution context is enabled
      */
     boolean isExecutionEnabled();
 
     /**
      * Adds the given input to this execution context.
      *
-     * @param input  the input to be added
+     * @param input the input to be added
      */
     void setInput(I input);
 
     /**
      * Adds the given output to this execution context.
      *
-     * @param output  the output to be added
+     * @param output the output to be added
      */
     void setOutput(O output);
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/context/ExecutionContextStepped.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/context/ExecutionContextStepped.java
@@ -10,12 +10,13 @@ import java.util.List;
  * <p>
  * Each time the last step context is the currently active one.
  *
- * @param <I>   the type of inputs
- * @param <O>   the type of outputs
- * @param <S>   the type of execution context's state
- * @param <SC>  the type of step context
+ * @param <I>  the type of inputs
+ * @param <O>  the type of outputs
+ * @param <S>  the type of execution context's state
+ * @param <SC> the type of step context
  */
-public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I, O>> implements ExecutionContext<I, O, S> {
+public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I, O>>
+    implements ExecutionContext<I, O, S> {
 
     /** The state of the outer execution context. */
     protected S state;
@@ -29,7 +30,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param state  the state of the context
+     * @param state the state of the context
      */
     public ExecutionContextStepped(S state) {
         stepContexts = new ArrayList<>();
@@ -59,7 +60,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Adds the given input to the last step context, which is currently active.
      *
-     * @param input  the input to be added
+     * @param input the input to be added
      */
     @Override
     public void setInput(I input) {
@@ -72,7 +73,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Adds the given output to the last step context, which is currently active.
      *
-     * @param output  the output to be added
+     * @param output the output to be added
      */
     @Override
     public void setOutput(O output) {
@@ -92,7 +93,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Returns the last step context or null if there is not one.
      *
-     * @return  the last step context or null if there is not one
+     * @return the last step context or null if there is not one
      */
     public SC getStepContext() {
         if (stepContexts != null && !stepContexts.isEmpty()) {
@@ -104,7 +105,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Returns the list of {@link #stepContexts}.
      *
-     * @return  the list of {@link #stepContexts}
+     * @return the list of {@link #stepContexts}
      */
     public List<SC> getStepContexts() {
         return Collections.unmodifiableList(stepContexts);
@@ -113,10 +114,11 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Returns the step context at the given index.
      *
-     * @param index  the index of the context
-     * @return       the step context at the given index
+     * @param  index                     the index of the context
      *
-     * @throws IndexOutOfBoundsException  if the specified index is out of bounds
+     * @return                           the step context at the given index
+     *
+     * @throws IndexOutOfBoundsException if the specified index is out of bounds
      */
     public SC getStepContext(int index) {
         return stepContexts.get(index);
@@ -125,7 +127,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Returns the size of {@link #stepContexts}.
      *
-     * @return  the size of {@link #stepContexts}
+     * @return the size of {@link #stepContexts}
      */
     public int getStepCount() {
         return stepContexts.size();
@@ -134,7 +136,7 @@ public abstract class ExecutionContextStepped<I, O, S, SC extends StepContext<I,
     /**
      * Build a new step context from the current parameters.
      *
-     * @return  a new step context from the current parameters
+     * @return a new step context from the current parameters
      */
     protected abstract SC buildStepContext();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/context/StepContext.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/context/StepContext.java
@@ -3,8 +3,8 @@ package com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.con
 /**
  * Context used by {@link ExecutionContextStepped}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class StepContext<I, O> {
 
@@ -23,7 +23,7 @@ public class StepContext<I, O> {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param index  the unique identifier of this step context
+     * @param index the unique identifier of this step context
      */
     public StepContext(int index) {
         disabled = false;
@@ -35,7 +35,7 @@ public class StepContext<I, O> {
     /**
      * Returns the stored value of {@link #index}.
      *
-     * @return  the stored value of {@link #index}
+     * @return the stored value of {@link #index}
      */
     public int getIndex() {
         return index;
@@ -44,7 +44,7 @@ public class StepContext<I, O> {
     /**
      * Returns the stored value of {@link #input}.
      *
-     * @return  the stored value of {@link #input}
+     * @return the stored value of {@link #input}
      */
     public I getInput() {
         return input;
@@ -53,7 +53,7 @@ public class StepContext<I, O> {
     /**
      * Sets the value of {@link #input}.
      *
-     * @param input  the input to be set
+     * @param input the input to be set
      */
     public void setInput(I input) {
         this.input = input;
@@ -62,7 +62,7 @@ public class StepContext<I, O> {
     /**
      * Returns the stored value of {@link #output}.
      *
-     * @return  the stored value of {@link #output}
+     * @return the stored value of {@link #output}
      */
     public O getOutput() {
         return output;
@@ -71,7 +71,7 @@ public class StepContext<I, O> {
     /**
      * Sets the value of {@link #output}.
      *
-     * @param output  the output to be set
+     * @param output the output to be set
      */
     public void setOutput(O output) {
         this.output = output;
@@ -80,7 +80,7 @@ public class StepContext<I, O> {
     /**
      * Returns the stored value of {@link #disabled}.
      *
-     * @return  the stored value of {@link #disabled}
+     * @return the stored value of {@link #disabled}
      */
     public boolean isDisabled() {
         return disabled;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/InputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/InputMapper.java
@@ -10,16 +10,16 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.conf
  * <p>
  * It performs the following:
  * <ol>
- * <li> Updates the execution context prior to the protocol message generation
- * <li> Generate the protocol message from the input symbol
- * <li> Sends the protocol message to the SUL
- * <li> Updates the execution context after sending the protocol message
+ * <li>Updates the execution context prior to the protocol message generation
+ * <li>Generate the protocol message from the input symbol
+ * <li>Sends the protocol message to the SUL
+ * <li>Updates the execution context after sending the protocol message
  * </ol>
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
 public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
 
@@ -32,8 +32,8 @@ public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param mapperConfig   the configuration of the Mapper
-     * @param outputChecker  the output checker for checking the output symbols if needed
+     * @param mapperConfig  the configuration of the Mapper
+     * @param outputChecker the output checker for checking the output symbols if needed
      */
     public InputMapper(MapperConfig mapperConfig, OutputChecker<O> outputChecker) {
         this.mapperConfig = mapperConfig;
@@ -43,7 +43,7 @@ public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
     /**
      * Returns the stored value of {@link #mapperConfig}.
      *
-     * @return  the stored value of {@link #mapperConfig}
+     * @return the stored value of {@link #mapperConfig}
      */
     public MapperConfig getMapperConfig() {
         return mapperConfig;
@@ -52,7 +52,7 @@ public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
     /**
      * Returns the stored value of {@link #outputChecker}.
      *
-     * @return  the stored value of {@link #outputChecker}
+     * @return the stored value of {@link #outputChecker}
      */
     public OutputChecker<O> getOutputChecker() {
         return outputChecker;
@@ -63,8 +63,8 @@ public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
      * generates and sends the protocol message derived from
      * the given input symbol.
      *
-     * @param input    the input symbol to be used
-     * @param context  the active execution context
+     * @param input   the input symbol to be used
+     * @param context the active execution context
      */
     public void sendInput(I input, E context) {
         input.preSendUpdate(context);
@@ -75,8 +75,8 @@ public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
     /**
      * Sends the protocol message to the SUL.
      *
-     * @param message  the protocol message to be sent
-     * @param context  the active execution context holding the protocol state
+     * @param message the protocol message to be sent
+     * @param context the active execution context holding the protocol state
      */
     protected abstract void sendMessage(P message, E context);
 
@@ -84,9 +84,9 @@ public abstract class InputMapper<I extends MapperInput<O, P, E>, O, P, E> {
      * Enables the update of the context after the response from the SUL and the
      * generated output symbol.
      *
-     * @param input    the input symbol converted to protocol message and sent
-     * @param output   the output symbol converted from the received protocol message
-     * @param context  the active execution context
+     * @param input   the input symbol converted to protocol message and sent
+     * @param output  the output symbol converted from the received protocol message
+     * @param context the active execution context
      */
     public void postReceive(I input, O output, E context) {
         input.postReceiveUpdate(output, outputChecker, context);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/InputMapperRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/InputMapperRA.java
@@ -31,12 +31,12 @@ public abstract class InputMapperRA<D, P, E> {
      * TODO Not great design, but there are no good options.
      * The use of PSymbolInstance means it is more complicated to attach behaviour
      * to the inputs and outputs rather than have this implemented here.
-     *
      * Returns {@code true} if this input symbol is enabled for execution.
      *
-     * @param input   the input to check if it is enabled or not
-     * @param context the active execution context
-     * @return {@code true} if this input symbol is enabled for execution
+     * @param  input   the input to check if it is enabled or not
+     * @param  context the active execution context
+     *
+     * @return         {@code true} if this input symbol is enabled for execution
      */
     public boolean isEnabled(D input, E context) {
         return true;
@@ -47,7 +47,7 @@ public abstract class InputMapperRA<D, P, E> {
      *
      * @param mapperConfig  the configuration of the Mapper
      * @param outputChecker the output checker for checking the output symbols if
-     *                      needed
+     *                          needed
      */
     public InputMapperRA(MapperConfig mapperConfig, OutputChecker<D> outputChecker) {
         this.mapperConfig = mapperConfig;
@@ -112,7 +112,6 @@ public abstract class InputMapperRA<D, P, E> {
      *
      * @param input   the input symbol converted to protocol message and sent
      * @param context the active execution context
-     *
      */
     public abstract void preSendUpdate(D input, E context);
 
@@ -121,9 +120,10 @@ public abstract class InputMapperRA<D, P, E> {
      * of the current abstract input symbol, providing this way the
      * functionality of abstract-to-concrete Mapper.
      *
-     * @param input   the input symbol converted to protocol message and sent
-     * @param context the active execution context
-     * @return the corresponding protocol message
+     * @param  input   the input symbol converted to protocol message and sent
+     * @param  context the active execution context
+     *
+     * @return         the corresponding protocol message
      */
     public abstract P generateProtocolMessage(D input, E context);
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposer.java
@@ -14,14 +14,14 @@ import org.apache.logging.log4j.Logger;
  * Implementation of the {@link Mapper} that is comprised of
  * the {@link InputMapper} and the {@link OutputMapper}.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
- * @param <S>  the type of execution context's state
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
+ * @param <S> the type of execution context's state
  */
 public class MapperComposer<I extends MapperInput<O, P, E>, O extends MapperOutput<O, P>, P, E extends ExecutionContext<I, O, S>, S>
-implements Mapper<I, O, E> {
+    implements Mapper<I, O, E> {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -34,8 +34,8 @@ implements Mapper<I, O, E> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param inputMapper   the InputMapper to be used
-     * @param outputMapper  the OutputMapper to be used
+     * @param inputMapper  the InputMapper to be used
+     * @param outputMapper the OutputMapper to be used
      */
     public MapperComposer(InputMapper<I, O, P, E> inputMapper, OutputMapper<O, P, E> outputMapper) {
         this.inputMapper = inputMapper;
@@ -45,7 +45,7 @@ implements Mapper<I, O, E> {
     /**
      * Returns the stored value of {@link #inputMapper}.
      *
-     * @return  the stored value of {@link #inputMapper}
+     * @return the stored value of {@link #inputMapper}
      */
     public InputMapper<I, O, P, E> getInputMapper() {
         return inputMapper;
@@ -54,7 +54,7 @@ implements Mapper<I, O, E> {
     /**
      * Returns the stored value of {@link #outputMapper}.
      *
-     * @return  the stored value of {@link #outputMapper}
+     * @return the stored value of {@link #outputMapper}
      */
     public OutputMapper<O, P, E> getOutputMapper() {
         return outputMapper;
@@ -68,7 +68,7 @@ implements Mapper<I, O, E> {
     /**
      * Returns the OutputBuilder contained in the {@link #outputMapper}.
      *
-     * @return  the OutputBuilder contained in the {@link #outputMapper}
+     * @return the OutputBuilder contained in the {@link #outputMapper}
      */
     @Override
     public OutputBuilder<O> getOutputBuilder() {
@@ -78,7 +78,7 @@ implements Mapper<I, O, E> {
     /**
      * Returns the OutputChecker contained in the {@link #inputMapper}.
      *
-     * @return  the OutputChecker contained in the {@link #inputMapper}
+     * @return the OutputChecker contained in the {@link #inputMapper}
      */
     @Override
     public OutputChecker<O> getOutputChecker() {
@@ -106,8 +106,9 @@ implements Mapper<I, O, E> {
      * Executes the input symbol using the {@link #inputMapper} and returns the
      * corresponding output symbol using the {@link #outputMapper}.
      *
-     * @param input    the input symbol to be executed
-     * @param context  the active execution context
+     * @param  input   the input symbol to be executed
+     * @param  context the active execution context
+     *
      * @return         the corresponding output symbol
      */
     protected O doExecute(I input, E context) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/MapperComposerRA.java
@@ -18,7 +18,7 @@ import org.apache.logging.log4j.Logger;
  * @param <S> the type of execution state
  */
 public class MapperComposerRA<D, P, E extends ExecutionContext<D, D, S>, S>
-        implements Mapper<D, D, E> {
+    implements Mapper<D, D, E> {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -35,7 +35,7 @@ public class MapperComposerRA<D, P, E extends ExecutionContext<D, D, S>, S>
      * @param outputMapper the OutputMapper to be used
      */
     public MapperComposerRA(InputMapperRA<D, P, E> inputMapper,
-            OutputMapperRA<D, P, E> outputMapper) {
+        OutputMapperRA<D, P, E> outputMapper) {
         this.inputMapper = inputMapper;
         this.outputMapper = outputMapper;
     }
@@ -104,9 +104,10 @@ public class MapperComposerRA<D, P, E extends ExecutionContext<D, D, S>, S>
      * Executes the input symbol using the {@link #inputMapper} and returns the
      * corresponding output symbol using the {@link #outputMapper}.
      *
-     * @param input   the input symbol to be executed
-     * @param context the active execution context
-     * @return the corresponding output symbol
+     * @param  input   the input symbol to be executed
+     * @param  context the active execution context
+     *
+     * @return         the corresponding output symbol
      */
     protected D doExecute(D input, E context) {
         inputMapper.sendInput(input, context);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapper.java
@@ -8,16 +8,15 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.conf
 import java.util.ArrayList;
 import java.util.List;
 
-
 /**
  * It is responsible for receiving protocol messages from the SUL and for
  * the concrete-to-abstract function of the Mapper.
  * <p>
  * It performs the following:
  * <ol>
- * <li> Receives the response from the SUL
- * <li> Updates the execution context
- * <li> Converts the response to a corresponding O
+ * <li>Receives the response from the SUL
+ * <li>Updates the execution context
+ * <li>Converts the response to a corresponding O
  * </ol>
  * <p>
  * It contains everything related to the conversion of a response to an O.
@@ -27,9 +26,9 @@ import java.util.List;
  * The contained OutputBuilder is used to create special symbols or create
  * output symbols after coalescing two outputs.
  *
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
 public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
 
@@ -49,9 +48,9 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      * according to the mapperConfig's special symbol replacement preferences
      * {@link MapperConfig#isSocketClosedAsTimeout()}, {@link MapperConfig#isDisabledAsTimeout()}.
      *
-     * @param mapperConfig   the configuration of the Mapper
-     * @param outputBuilder  the builder of the output symbols
-     * @param outputChecker  the checker of the output symbols
+     * @param mapperConfig  the configuration of the Mapper
+     * @param outputBuilder the builder of the output symbols
+     * @param outputChecker the checker of the output symbols
      */
     public OutputMapper(MapperConfig mapperConfig, OutputBuilder<O> outputBuilder, OutputChecker<O> outputChecker) {
         this.mapperConfig = mapperConfig;
@@ -70,7 +69,7 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
     /**
      * Returns the stored value of {@link #mapperConfig}.
      *
-     * @return  the stored value of {@link #mapperConfig}
+     * @return the stored value of {@link #mapperConfig}
      */
     public MapperConfig getMapperConfig() {
         return mapperConfig;
@@ -79,7 +78,7 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
     /**
      * Returns the stored value of {@link #outputBuilder}.
      *
-     * @return  the stored value of {@link #outputBuilder}
+     * @return the stored value of {@link #outputBuilder}
      */
     public OutputBuilder<O> getOutputBuilder() {
         return outputBuilder;
@@ -89,7 +88,8 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      * Receives the response from the SUL and converts it to a corresponding
      * output symbol.
      *
-     * @param context  the active execution context holding the protocol-specific state
+     * @param  context the active execution context holding the protocol-specific state
+     *
      * @return         the corresponding output symbol
      */
     public abstract O receiveOutput(E context);
@@ -97,7 +97,7 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
     /**
      * Returns the timeout symbol according to {@link #outputBuilder}.
      *
-     * @return  the timeout symbol according to {@link #outputBuilder}
+     * @return the timeout symbol according to {@link #outputBuilder}
      */
     public O timeout() {
         return outputBuilder.buildTimeout();
@@ -107,7 +107,8 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      * Returns the timeout symbol or the socket closed symbol according to
      * {@link #outputBuilder} respecting the {@link MapperConfig#isSocketClosedAsTimeout()}.
      *
-     * @return  the timeout symbol or the socket closed symbol */
+     * @return the timeout symbol or the socket closed symbol
+     */
     public O socketClosed() {
         return outputBuilder.buildSocketClosed();
     }
@@ -116,7 +117,7 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      * Returns the timeout symbol or the disabled symbol according to
      * {@link #outputBuilder} respecting the {@link MapperConfig#isSocketClosedAsTimeout()}.
      *
-     * @return  the timeout symbol or the disabled symbol
+     * @return the timeout symbol or the disabled symbol
      */
     public O disabled() {
         return outputBuilder.buildDisabled();
@@ -125,10 +126,11 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
     /**
      * Coalesces the messages of two output symbols into one output symbol.
      *
-     * @param output1  the first output symbol
-     * @param output2  the second output symbol
+     * @param  output1 the first output symbol
+     * @param  output2 the second output symbol
+     *
      * @return         the coalesced output symbol or either one of output1 and
-     *                 output2 if the other one is the timeout symbol
+     *                     output2 if the other one is the timeout symbol
      */
     public O coalesceOutputs(O output1, O output2) {
         if (outputChecker.isDisabled(output1)
@@ -137,7 +139,7 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
             || outputChecker.isSocketClosed(output2)) {
             throw new RuntimeException(
                 "Cannot coalesce " + OutputBuilder.DISABLED + " or "
-                + OutputBuilder.SOCKET_CLOSED + " outputs");
+                    + OutputBuilder.SOCKET_CLOSED + " outputs");
         }
 
         if (outputChecker.isTimeout(output1)) {
@@ -166,8 +168,9 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
     /**
      * Builds the O output from the given parameters.
      *
-     * @param name      the name of the output
-     * @param messages  the messages of the output
+     * @param  name     the name of the output
+     * @param  messages the messages of the output
+     *
      * @return          the corresponding O output
      */
     protected abstract O buildOutput(String name, List<P> messages);
@@ -179,11 +182,13 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
      * If a message is repeated in the list of strings, then it is merged into one
      * message appended with {@link MapperOutput#REPEATING_INDICATOR}.
      * <p>
-     * In the final string the different messages are separated using {@link MapperOutput#MESSAGE_SEPARATOR}.
+     * In the final string the different messages are separated using
+     * {@link MapperOutput#MESSAGE_SEPARATOR}.
      *
-     * @param abstractMessageStrings  the list of abstract symbol names to be merged
+     * @param  abstractMessageStrings the list of abstract symbol names to be merged
+     *
      * @return                        the final string of all the messages in the given list
-     *                                with the repeating ones having been merged
+     *                                    with the repeating ones having been merged
      */
     protected String mergeRepeatingMessages(List<String> abstractMessageStrings) {
         // in case we find repeated occurrences of types of messages, we coalesce them under +,
@@ -192,7 +197,7 @@ public abstract class OutputMapper<O extends MapperOutput<O, P>, P, E> {
         String lastSeen = null;
         boolean skipStar = false;
 
-        for (String abstractMessageString : abstractMessageStrings) {
+        for (String abstractMessageString: abstractMessageStrings) {
             if (lastSeen != null && lastSeen.equals(abstractMessageString) && mapperConfig.isMergeRepeating()) {
                 if (!skipStar) {
                     // insert before ,

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapperRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/mappers/OutputMapperRA.java
@@ -68,9 +68,10 @@ public abstract class OutputMapperRA<O, P, E> {
      * Receives the response from the SUL and converts it to a corresponding
      * output symbol.
      *
-     * @param context the active execution context holding the protocol-specific
-     *                state
-     * @return the corresponding output symbol
+     * @param  context the active execution context holding the protocol-specific
+     *                     state
+     *
+     * @return         the corresponding output symbol
      */
     public abstract O receiveOutput(E context);
 
@@ -114,9 +115,10 @@ public abstract class OutputMapperRA<O, P, E> {
     /**
      * Builds the O output from the given parameters.
      *
-     * @param name     the name of the output
-     * @param messages the messages of the output
-     * @return the corresponding O output
+     * @param  name     the name of the output
+     * @param  messages the messages of the output
+     *
+     * @return          the corresponding O output
      */
     protected abstract O buildOutput(String name, List<P> messages);
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParser.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  * Parses the provided command-line arguments and initiates the appropriate
  * action; starts the fuzzing or the testing.
  *
- * @param <M>  the type of machine model
+ * @param <M> the type of machine model
  */
 public class CommandLineParser<M> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -70,16 +70,17 @@ public class CommandLineParser<M> {
     /**
      * Extracts from the given packageName at most the first depth components.
      * <ul>
-     * <li> If packageName = "suffix.inner2.inner1.base.name" and depth = 4
-     *      then basePackageName = "suffix.inner2.inner1.base".
-     * <li> If {@code depth < 1 or depth > (depth of packageName)}
-     *      then basePackageName = packageName.
+     * <li>If packageName = "suffix.inner2.inner1.base.name" and depth = 4
+     * then basePackageName = "suffix.inner2.inner1.base".
+     * <li>If {@code depth < 1 or depth > (depth of packageName)}
+     * then basePackageName = packageName.
      * </ul>
      *
-     * @param packageName  the name of the package from which the base name will be derived
-     * @param depth        the depth of the original package name to keep in the derived one
+     * @param  packageName the name of the package from which the base name will be derived
+     * @param  depth       the depth of the original package name to keep in the derived one
+     *
      * @return             the derived base package name; if it cannot be derived,
-     *                     then the provided package name is returned
+     *                         then the provided package name is returned
      */
     public static String getBasePackageName(String packageName, int depth) {
         if (depth < 1) {
@@ -96,28 +97,27 @@ public class CommandLineParser<M> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param stateFuzzerConfigBuilder  the builder of the StateFuzzerClientConfig
-     *                                  and StateFuzzerServerConfig
-     * @param stateFuzzerBuilder        the builder of the StateFuzzer
-     * @param testRunnerBuilder         the builder of the TestRunner
-     * @param timingProbeBuilder        the builder of the TimingProbe
+     * @param stateFuzzerConfigBuilder the builder of the StateFuzzerClientConfig
+     *                                     and StateFuzzerServerConfig
+     * @param stateFuzzerBuilder       the builder of the StateFuzzer
+     * @param testRunnerBuilder        the builder of the TestRunner
+     * @param timingProbeBuilder       the builder of the TimingProbe
      */
     public CommandLineParser(
         StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
         StateFuzzerBuilder<M> stateFuzzerBuilder,
         TestRunnerBuilder testRunnerBuilder,
-        TimingProbeBuilder timingProbeBuilder
-    ){
+        TimingProbeBuilder timingProbeBuilder) {
         this.stateFuzzerBuilder = stateFuzzerBuilder;
         this.stateFuzzerConfigBuilder = stateFuzzerConfigBuilder;
         this.testRunnerBuilder = testRunnerBuilder;
-        this.timingProbeBuilder =  timingProbeBuilder;
+        this.timingProbeBuilder = timingProbeBuilder;
     }
 
     /**
      * Sets the program name that appears in usage; to be used before parsing.
      *
-     * @param programName  the name of the program
+     * @param programName the name of the program
      */
     public void setProgramName(String programName) {
         this.programName = programName;
@@ -129,7 +129,7 @@ public class CommandLineParser<M> {
      * <p>
      * In order to take effect, this function should be called before parsing.
      *
-     * @param externalParentLoggers  the external parent logger names
+     * @param externalParentLoggers the external parent logger names
      */
     public void setExternalParentLoggers(String[] externalParentLoggers) {
         this.externalParentLoggers = externalParentLoggers;
@@ -141,12 +141,14 @@ public class CommandLineParser<M> {
      * <p>
      * Multiple independent commands can be separated using {@literal --}.
      *
-     * @param args         the command-line arguments to be parsed
-     * @param exportToPDF  {@code true} if the DOT models should be exported to PDF
-     * @param consumers    the list of consumers to be used consecutively on the results
+     * @param  args        the command-line arguments to be parsed
+     * @param  exportToPDF {@code true} if the DOT models should be exported to PDF
+     * @param  consumers   the list of consumers to be used consecutively on the results
+     *
      * @return             the list of each command's learning result
      */
-    public List<LearnerResult<M>> parse(String[] args, boolean exportToPDF, List<Consumer<LearnerResult<M>>> consumers) {
+    public List<LearnerResult<M>> parse(String[] args, boolean exportToPDF,
+        List<Consumer<LearnerResult<M>>> consumers) {
         int startCmd;
         int endCmd = 0;
         String[] cmdArgs;
@@ -191,21 +193,22 @@ public class CommandLineParser<M> {
      * <p>
      * Multiple independent commands can be separated using {@literal --}.
      *
-     * @param args         the command-line arguments to be parsed
-     * @param exportToPDF  {@code true} if the DOT models should be exported to PDF
+     * @param  args        the command-line arguments to be parsed
+     * @param  exportToPDF {@code true} if the DOT models should be exported to PDF
+     *
      * @return             the list of each command's learning result
      */
     public List<LearnerResult<M>> parse(String[] args, boolean exportToPDF) {
         return parse(args, exportToPDF, List.of());
     }
 
-
     /**
      * Parses and executes the arguments and returns the results.
      * <p>
      * Multiple independent commands can be separated using {@literal --}.
      *
-     * @param args  the command-line arguments to be parsed
+     * @param  args the command-line arguments to be parsed
+     *
      * @return      the list of each command's learning result
      */
     public List<LearnerResult<M>> parse(String[] args) {
@@ -217,14 +220,16 @@ public class CommandLineParser<M> {
      * <p>
      * It uses the {@link #parseCommand(String[])} and {@link #executeCommand(ParseResult)}.
      *
-     * @param args  the command-line arguments to be parsed
+     * @param  args the command-line arguments to be parsed
+     *
      * @return      if the command involves state fuzzing then the corresponding LearnerResult,
-     *              which can be empty if fuzzing fails, otherwise an empty LearnerResult
+     *                  which can be empty if fuzzing fails, otherwise an empty LearnerResult
      */
     protected LearnerResult<M> parseAndExecuteCommand(String[] args) {
         try {
             return executeCommand(parseCommand(args));
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             LOGGER.error("Encountered an exception, see below for more info");
             e.printStackTrace();
             return new LearnerResult<M>().toEmpty();
@@ -242,9 +247,10 @@ public class CommandLineParser<M> {
      * It uses the {@link #buildCommander(boolean, StateFuzzerClientConfig, StateFuzzerServerConfig)}
      * for the acquisition of different JCommanders per parse.
      *
-     * @param args  the command-line arguments to be parsed
+     * @param  args the command-line arguments to be parsed
+     *
      * @return      null or the ParseResult that contains the arguments and the
-     *              JCommander instance used to parse them
+     *                  JCommander instance used to parse them
      */
     protected ParseResult parseCommand(String[] args) {
         PropertyResolver.initializeParsing();
@@ -264,9 +270,9 @@ public class CommandLineParser<M> {
         JCommander commander = buildCommander(true, stateFuzzerClientConfig, stateFuzzerServerConfig);
 
         if (args.length > 0
-                && !commander.getCommands().containsKey(args[0])
-                && !args[0].startsWith("@")
-                && new File(args[0]).exists()) {
+            && !commander.getCommands().containsKey(args[0])
+            && !args[0].startsWith("@")
+            && new File(args[0]).exists()) {
             LOGGER.info("The first argument is a file path. Processing it as an argument file.");
             args[0] = "@" + args[0];
         }
@@ -281,11 +287,13 @@ public class CommandLineParser<M> {
 
             return new ParseResult(args, commander);
 
-        } catch (ParameterException e) {
+        }
+        catch (ParameterException e) {
             LOGGER.error("Parameter parse error: {}", e.getMessage());
             return null;
 
-        } finally {
+        }
+        finally {
             PropertyResolver.finalizeParsing();
         }
     }
@@ -297,11 +305,12 @@ public class CommandLineParser<M> {
      * The possible executions are: 1) testing using a test runner or a
      * timing probe or 2) fuzzing using the state fuzzer.
      *
-     * @param parseResult  the ParseResult with the parsed arguments and the
-     *                     JCommander instance used
+     * @param  parseResult the ParseResult with the parsed arguments and the
+     *                         JCommander instance used
+     *
      * @return             if the command involves state fuzzing then the
-     *                     corresponding LearnerResult, which can be empty if
-     *                     fuzzing fails, otherwise an empty LearnerResult
+     *                         corresponding LearnerResult, which can be empty if
+     *                         fuzzing fails, otherwise an empty LearnerResult
      */
     protected LearnerResult<M> executeCommand(ParseResult parseResult) {
         LearnerResult<M> emptyLearnerResult = new LearnerResult<M>().toEmpty();
@@ -362,12 +371,13 @@ public class CommandLineParser<M> {
      * be used; either the one that stores only dynamic parameters (first parse)
      * or the one that parses all the parameters (second parse).
      *
-     * @param parseOnlyDynamicParameters  boolean that determines the type of
-     *                                    the JCommander instance to be built
-     * @param stateFuzzerClientConfig     the configuration of the client fuzzing command
-     *                                    used in the second parse
-     * @param stateFuzzerServerConfig     the configuration of the server fuzzing command
-     *                                    used in the second parse
+     * @param  parseOnlyDynamicParameters boolean that determines the type of
+     *                                        the JCommander instance to be built
+     * @param  stateFuzzerClientConfig    the configuration of the client fuzzing command
+     *                                        used in the second parse
+     * @param  stateFuzzerServerConfig    the configuration of the server fuzzing command
+     *                                        used in the second parse
+     *
      * @return                            a new instance of the specified JCommander
      */
     protected JCommander buildCommander(boolean parseOnlyDynamicParameters,
@@ -379,22 +389,22 @@ public class CommandLineParser<M> {
             // only dynamic parameters are parsed and stored without any converter
 
             return JCommander.newBuilder()
-                    .allowParameterOverwriting(true)
-                    .programName(programName)
-                    .addCommand(CMD_STATE_FUZZER_CLIENT, stateFuzzerClientConfig.getPropertyResolver())
-                    .addCommand(CMD_STATE_FUZZER_SERVER, stateFuzzerServerConfig.getPropertyResolver())
-                    .acceptUnknownOptions(true)
-                    .build();
+                .allowParameterOverwriting(true)
+                .programName(programName)
+                .addCommand(CMD_STATE_FUZZER_CLIENT, stateFuzzerClientConfig.getPropertyResolver())
+                .addCommand(CMD_STATE_FUZZER_SERVER, stateFuzzerServerConfig.getPropertyResolver())
+                .acceptUnknownOptions(true)
+                .build();
         }
 
         // normal parse with all converters active
         return JCommander.newBuilder()
-                .allowParameterOverwriting(true)
-                .programName(programName)
-                .addCommand(CMD_STATE_FUZZER_CLIENT, stateFuzzerClientConfig)
-                .addCommand(CMD_STATE_FUZZER_SERVER, stateFuzzerServerConfig)
-                .addConverterFactory(new BasicConverterFactory())
-                .build();
+            .allowParameterOverwriting(true)
+            .programName(programName)
+            .addCommand(CMD_STATE_FUZZER_CLIENT, stateFuzzerClientConfig)
+            .addCommand(CMD_STATE_FUZZER_SERVER, stateFuzzerServerConfig)
+            .addConverterFactory(new BasicConverterFactory())
+            .build();
     }
 
     /**
@@ -404,8 +414,8 @@ public class CommandLineParser<M> {
      * If the provided array for the external parent loggers is null or empty,
      * then only the logging level of ProtocolState-Fuzzer is updated.
      *
-     * @param externalParentLoggers  list of Logger names external to this project
-     * @param level                  the logging level to be set
+     * @param externalParentLoggers list of Logger names external to this project
+     * @param level                 the logging level to be set
      */
     protected void updateLoggingLevel(String[] externalParentLoggers, Level level) {
         String ownParentLogger = getBasePackageName(this.getClass().getPackageName(), 4);
@@ -424,8 +434,8 @@ public class CommandLineParser<M> {
      * <p>
      * For the copying of the arguments it uses the {@link #copyArgsToOutDir(String[], String)}.
      *
-     * @param args    the arguments that were parsed
-     * @param outDir  the output directory name of this parse
+     * @param args   the arguments that were parsed
+     * @param outDir the output directory name of this parse
      */
     protected void prepareOutputDir(String[] args, String outDir) {
         File dirFile = new File(outDir);
@@ -438,7 +448,8 @@ public class CommandLineParser<M> {
 
         try {
             copyArgsToOutDir(args, outDir);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.error("Failed to copy arguments");
             e.printStackTrace();
             LOGGER.error(e);
@@ -450,14 +461,14 @@ public class CommandLineParser<M> {
      * <p>
      * All the arguments provided either in a file or in the command-line are copied.
      *
-     * @param args    the arguments that were parsed
-     * @param outDir  the output directory name of this parse
+     * @param  args        the arguments that were parsed
+     * @param  outDir      the output directory name of this parse
      *
-     * @throws IOException  if an error during writing occurs
+     * @throws IOException if an error during writing occurs
      */
     protected void copyArgsToOutDir(String[] args, String outDir) throws IOException {
         try (FileOutputStream fileOutputStream = new FileOutputStream(new File(outDir, ARGS_FILE))) {
-            for (String arg : args) {
+            for (String arg: args) {
                 if (!arg.startsWith("@")) {
                     // command-line argument
                     fileOutputStream.write((arg + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
@@ -497,8 +508,8 @@ public class CommandLineParser<M> {
         /**
          * Constructs a new instance from the given parameters.
          *
-         * @param args       the arguments that were parsed
-         * @param commander  the JCommander instance that parsed the arguments
+         * @param args      the arguments that were parsed
+         * @param commander the JCommander instance that parsed the arguments
          */
         public ParseResult(String[] args, JCommander commander) {
             this.args = args;
@@ -508,7 +519,7 @@ public class CommandLineParser<M> {
         /**
          * Returns the arguments.
          *
-         * @return  the arguments
+         * @return the arguments
          */
         public String[] getArgs() {
             return args;
@@ -517,7 +528,7 @@ public class CommandLineParser<M> {
         /**
          * Returns the JCommander instance.
          *
-         * @return  the JCommander instance
+         * @return the JCommander instance
          */
         public JCommander getCommander() {
             return commander;
@@ -526,8 +537,8 @@ public class CommandLineParser<M> {
         /**
          * Checks if the ParseResult is valid.
          *
-         * @return  {@code true} if neither of {@link #args} or
-         *          {@link #commander} are null
+         * @return {@code true} if neither of {@link #args} or
+         *             {@link #commander} are null
          */
         public boolean isValid() {
             return args != null && commander != null;
@@ -542,7 +553,7 @@ public class CommandLineParser<M> {
          * <p>
          * The appropriate downcasting is left to the user.
          *
-         * @return  the object at index 0
+         * @return the object at index 0
          */
         public Object getObjectFromParsedCommand() {
             return getObjectFromParsedCommand(0);
@@ -557,13 +568,14 @@ public class CommandLineParser<M> {
          * <p>
          * The appropriate downcasting is left to the user.
          *
-         * @param index  the index of the JCommander objects
+         * @param  index the index of the JCommander objects
+         *
          * @return       the object at this index
          */
         public Object getObjectFromParsedCommand(int index) {
             if (commander == null
-                    || commander.getCommands() == null || commander.getCommands().isEmpty()
-                    || commander.getParsedCommand() == null) {
+                || commander.getCommands() == null || commander.getCommands().isEmpty()
+                || commander.getParsedCommand() == null) {
                 return null;
             }
 
@@ -574,7 +586,8 @@ public class CommandLineParser<M> {
 
             try {
                 return parsedCommander.getObjects().get(index);
-            } catch (IndexOutOfBoundsException e) {
+            }
+            catch (IndexOutOfBoundsException e) {
                 LOGGER.error("get Object from parsed command: " + e.getMessage());
                 return null;
             }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzer.java
@@ -5,7 +5,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.Learner
 /**
  * Interface for the state fuzzing process.
  *
- * @param <M>  the type of machine model
+ * @param <M> the type of machine model
  */
 public interface StateFuzzer<M> {
 
@@ -30,7 +30,7 @@ public interface StateFuzzer<M> {
     /**
      * Used to start the state fuzzing process.
      *
-     * @return  the corresponding LearnerResult, which can be empty
+     * @return the corresponding LearnerResult, which can be empty
      */
     LearnerResult<M> startFuzzing();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerBuilder.java
@@ -5,14 +5,15 @@ import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.St
 /**
  * Builder Interface for the StateFuzzer.
  *
- * @param <M>  the type of machine model
+ * @param <M> the type of machine model
  */
 public interface StateFuzzerBuilder<M> {
 
     /**
      * Builds a new StateFuzzer instance.
      *
-     * @param stateFuzzerEnabler  the configuration that enables the state fuzzing
+     * @param  stateFuzzerEnabler the configuration that enables the state fuzzing
+     *
      * @return                    a new StateFuzzer instance
      */
     StateFuzzer<M> build(StateFuzzerEnabler stateFuzzerEnabler);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposer.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposer.java
@@ -11,10 +11,10 @@ import java.io.InputStream;
 /**
  * Interface for the setup of the components of the state fuzzing process.
  *
- * @param <I>   the type of inputs
- * @param <ST>  the type of statistics tracker
- * @param <LE>  the type of learner
- * @param <EQ>  the type of equivalence oracle
+ * @param <I>  the type of inputs
+ * @param <ST> the type of statistics tracker
+ * @param <LE> the type of learner
+ * @param <EQ> the type of equivalence oracle
  */
 public interface StateFuzzerComposer<I, ST extends StatisticsTracker<?, ?, ?, ?>, LE, EQ> {
 
@@ -27,63 +27,63 @@ public interface StateFuzzerComposer<I, ST extends StatisticsTracker<?, ?, ?, ?>
     /**
      * Returns the StatisticsTracker that will be used during the state fuzzing.
      *
-     * @return  the StatisticsTracker that will be used during the state fuzzing
+     * @return the StatisticsTracker that will be used during the state fuzzing
      */
     ST getStatisticsTracker();
 
     /**
      * Returns the Learner that will be used during the state fuzzing.
      *
-     * @return  the Learner that will be used during the state fuzzing
+     * @return the Learner that will be used during the state fuzzing
      */
     LE getLearner();
 
     /**
      * Returns the Equivalence Oracle that will be used during the state fuzzing.
      *
-     * @return  the Equivalence Oracle that will be used during the state fuzzing
+     * @return the Equivalence Oracle that will be used during the state fuzzing
      */
     EQ getEquivalenceOracle();
 
     /**
      * Returns the alphabet that will be used during the state fuzzing.
      *
-     * @return  the alphabet that will be used during the state fuzzing
+     * @return the alphabet that will be used during the state fuzzing
      */
     Alphabet<I> getAlphabet();
 
     /**
      * Returns an input stream of the provided file of the alphabet.
      *
-     * @return  an input stream of the provided file of the alphabet
+     * @return an input stream of the provided file of the alphabet
      */
     InputStream getAlphabetFileInputStream();
 
     /**
      * Returns the alphabet file extension.
      *
-     * @return  the alphabet file extension
+     * @return the alphabet file extension
      */
     String getAlphabetFileExtension();
 
     /**
      * Returns the configuration that will enable the state fuzzing.
      *
-     * @return  the configuration that will enable the state fuzzing
+     * @return the configuration that will enable the state fuzzing
      */
     StateFuzzerEnabler getStateFuzzerEnabler();
 
     /**
      * Returns the output directory of this state fuzzing process.
      *
-     * @return  the output directory of this state fuzzing process
+     * @return the output directory of this state fuzzing process
      */
     File getOutputDir();
 
     /**
      * Returns the cleanup tasks registered with this composer.
      *
-     * @return  the cleanup tasks registered with this composer
+     * @return the cleanup tasks registered with this composer
      */
     CleanupTasks getCleanupTasks();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerRA.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * @param <E> the execution context
  */
 public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
-        StateFuzzerComposer<B, StatisticsTracker<B, Word<PSymbolInstance>, Boolean, DefaultQuery<PSymbolInstance, Boolean>>, RaLearningAlgorithm, IOEquivalenceOracle> {
+    StateFuzzerComposer<B, StatisticsTracker<B, Word<PSymbolInstance>, Boolean, DefaultQuery<PSymbolInstance, Boolean>>, RaLearningAlgorithm, IOEquivalenceOracle> {
 
     /** Stores the constructor parameter. */
     protected StateFuzzerEnabler stateFuzzerEnabler;
@@ -101,10 +101,10 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
      * @param teachers           the teachers to be used
      */
     public StateFuzzerComposerRA(
-            StateFuzzerEnabler stateFuzzerEnabler,
-            AlphabetBuilder<B> alphabetBuilder,
-            SULBuilder<PSymbolInstance, PSymbolInstance, E> sulBuilder,
-            Map<DataType, Theory> teachers) {
+        StateFuzzerEnabler stateFuzzerEnabler,
+        AlphabetBuilder<B> alphabetBuilder,
+        SULBuilder<PSymbolInstance, PSymbolInstance, E> sulBuilder,
+        Map<DataType, Theory> teachers) {
 
         this.stateFuzzerEnabler = stateFuzzerEnabler;
         this.learnerConfig = stateFuzzerEnabler.getLearnerConfig();
@@ -122,25 +122,25 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
 
         // set up wrapped SUL (System Under Learning)
         AbstractSUL<PSymbolInstance, PSymbolInstance, E> abstractSUL = sulBuilder
-                .buildSUL(stateFuzzerEnabler.getSULConfig(), cleanupTasks);
+            .buildSUL(stateFuzzerEnabler.getSULConfig(), cleanupTasks);
 
         SULWrapper<PSymbolInstance, PSymbolInstance, E> sulWrapper = sulBuilder.buildWrapper();
 
         SUL<PSymbolInstance, PSymbolInstance> sul = sulWrapper
-                .wrap(abstractSUL)
-                .setTimeLimit(learnerConfig.getTimeLimit())
-                .setTestLimit(learnerConfig.getTestLimit())
-                .setLoggingWrapper("")
-                .getWrappedSUL();
+            .wrap(abstractSUL)
+            .setTimeLimit(learnerConfig.getTimeLimit())
+            .setTestLimit(learnerConfig.getTestLimit())
+            .setLoggingWrapper("")
+            .getWrappedSUL();
 
         this.sulOracle = new MultiQuerySULOracle(
-                new DataWordSULWrapper(sul),
-                new OutputSymbol("_io_err"),
-                learnerConfig.getRunsPerMembershipQuery());
+            new DataWordSULWrapper(sul),
+            new OutputSymbol("_io_err"),
+            learnerConfig.getRunsPerMembershipQuery());
 
         // initialize statistics tracker
         this.statisticsTracker = new StatisticsTrackerRA<B, PSymbolInstance, Boolean>(
-                sulWrapper.getInputCounter(), sulWrapper.getTestCounter());
+            sulWrapper.getInputCounter(), sulWrapper.getTestCounter());
     }
 
     /**
@@ -231,7 +231,7 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
         ConstraintSolver solver = new ConstraintSolver();
 
         this.learner = LearningSetupFactory.createRALearner(this.learnerConfig, this.sulOracle,
-                this.alphabet, this.teachers, solver, this.consts);
+            this.alphabet, this.teachers, solver, this.consts);
     }
 
     /**
@@ -240,6 +240,6 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
      */
     protected void composeEquivalenceOracle() {
         this.equivalenceOracle = LearningSetupFactory.createEquivalenceOracle(this.learnerConfig,
-                this.sulOracle.getDataWordSUL(), this.alphabet, this.teachers, this.consts);
+            this.sulOracle.getDataWordSUL(), this.alphabet, this.teachers, this.consts);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerRA.java
@@ -62,9 +62,6 @@ public class StateFuzzerComposerRA<B extends ParameterizedSymbol, E> implements
 
     /**
      * The teachers for the RALib learning algorithm.
-     * Note: Theory is used as a rawtype like this in RALib as theories of different
-     * types can be used for the same learner so we don't know how to solve this
-     * warning
      */
     protected Map<DataType, Theory> teachers;
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerComposerStandard.java
@@ -41,15 +41,13 @@ import java.util.List;
 /**
  * The standard implementation of the StateFuzzerComposer Interface.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <E> the type of execution context
  */
 public class StateFuzzerComposerStandard<I, O, E>
-implements StateFuzzerComposer<I,
-            StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>>,
-            MealyLearner<I, O>,
-            EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>> {
+    implements
+    StateFuzzerComposer<I, StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>>, MealyLearner<I, O>, EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>> {
 
     /** Stores the constructor parameter. */
     protected StateFuzzerEnabler stateFuzzerEnabler;
@@ -95,22 +93,21 @@ implements StateFuzzerComposer<I,
      * <p>
      * Specifically:
      * <ul>
-     * <li> the alphabet is built using the AlphabetBuilder parameter
-     * <li> the sul is built and wrapped using the SULBuilder parameter
-     * <li> the StatisticsTracker is created
+     * <li>the alphabet is built using the AlphabetBuilder parameter
+     * <li>the sul is built and wrapped using the SULBuilder parameter
+     * <li>the StatisticsTracker is created
      * </ul>
      * <p>
      * Invoke {@link #initialize()} afterwards.
      *
-     * @param stateFuzzerEnabler  the configuration that enables the state fuzzing
-     * @param alphabetBuilder     the builder of the alphabet
-     * @param sulBuilder          the builder of the SUL
+     * @param stateFuzzerEnabler the configuration that enables the state fuzzing
+     * @param alphabetBuilder    the builder of the alphabet
+     * @param sulBuilder         the builder of the SUL
      */
     public StateFuzzerComposerStandard(
         StateFuzzerEnabler stateFuzzerEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SULBuilder<I, O, E> sulBuilder
-    ){
+        SULBuilder<I, O, E> sulBuilder) {
         this.stateFuzzerEnabler = stateFuzzerEnabler;
         this.learnerConfig = stateFuzzerEnabler.getLearnerConfig();
 
@@ -129,21 +126,22 @@ implements StateFuzzerComposer<I,
         // set up wrapped SUL (System Under Learning)
         SULConfig sulConfig = stateFuzzerEnabler.getSULConfig();
         for (int i = 0; i < learnerConfig.getEquivalenceThreadCount(); i++) {
-            SULConfig config = (i==0) ? sulConfig : sulConfig.cloneWithThreadId(i);
+            SULConfig config = (i == 0) ? sulConfig : sulConfig.cloneWithThreadId(i);
             AbstractSUL<I, O, E> abstractSUL = sulBuilder.buildSUL(config, cleanupTasks);
 
             if (i == 0) {
                 // initialize the output for the socket closed
-                this.socketClosedOutput = abstractSUL.getMapper().getOutputBuilder().buildOutputExact(OutputBuilder.SOCKET_CLOSED);
+                this.socketClosedOutput = abstractSUL.getMapper().getOutputBuilder()
+                    .buildOutputExact(OutputBuilder.SOCKET_CLOSED);
             }
 
             SULWrapper<I, O, E> sulWrapper = sulBuilder.buildWrapper();
             SUL<I, O> sul = sulWrapper
-                    .wrap(abstractSUL)
-                    .setTimeLimit(learnerConfig.getTimeLimit())
-                    .setTestLimit(learnerConfig.getTestLimit())
-                    .setLoggingWrapper("")
-                    .getWrappedSUL();
+                .wrap(abstractSUL)
+                .setTimeLimit(learnerConfig.getTimeLimit())
+                .setTestLimit(learnerConfig.getTestLimit())
+                .setLoggingWrapper("")
+                .getWrappedSUL();
 
             this.suls.add(sul);
             inputCounters.add(sulWrapper.getInputCounter());
@@ -164,12 +162,12 @@ implements StateFuzzerComposer<I,
      * <p>
      * Specifically:
      * <ul>
-     * <li> the output directory is created if needed
-     * <li> the Learner is composed
-     * <li> the Equivalence Oracle is composed
+     * <li>the output directory is created if needed
+     * <li>the Learner is composed
+     * <li>the Equivalence Oracle is composed
      * </ul>
      *
-     * @return  the same instance
+     * @return the same instance
      */
     public StateFuzzerComposerStandard<I, O, E> initialize() {
         this.outputDir = new File(stateFuzzerEnabler.getOutputDir());
@@ -183,7 +181,8 @@ implements StateFuzzerComposer<I,
         // TODO the LOGGER instances should handle this, instead of passing non det writers as arguments.
         try {
             this.nonDetWriter = new FileWriter(new File(outputDir, NON_DET_FILENAME), StandardCharsets.UTF_8);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new RuntimeException("Could not create non-determinism file writer");
         }
 
@@ -249,7 +248,7 @@ implements StateFuzzerComposer<I,
     /**
      * Composes the Learner and stores it in the {@link #learner}.
      *
-     * @param terminatingOutputs  the terminating outputs used by the {@link CachingSULOracle}
+     * @param terminatingOutputs the terminating outputs used by the {@link CachingSULOracle}
      */
     protected void composeLearner(List<O> terminatingOutputs) {
 
@@ -257,7 +256,7 @@ implements StateFuzzerComposer<I,
 
         if (learnerConfig.getRunsPerMembershipQuery() > 1) {
             learningSULOracle = new MultipleRunsSULOracle<>(learnerConfig.getRunsPerMembershipQuery(),
-                    learningSULOracle,true, nonDetWriter);
+                learningSULOracle, true, nonDetWriter);
         }
 
         // an oracle which uses the cache to check for non-determinism
@@ -272,7 +271,8 @@ implements StateFuzzerComposer<I,
         if (learnerConfig.isLogQueries()) {
             try {
                 queryWriter = new FileWriter(new File(outputDir, QUERY_FILENAME), StandardCharsets.UTF_8);
-            } catch (IOException e1) {
+            }
+            catch (IOException e1) {
                 throw new RuntimeException("Could not create queryfile writer");
             }
         }
@@ -284,27 +284,29 @@ implements StateFuzzerComposer<I,
     /**
      * Composes the Equivalence Oracle and stores it in the {@link #equivalenceOracle}.
      *
-     * @param terminatingOutputs  the terminating outputs used by the {@link CachingSULOracle}
+     * @param terminatingOutputs the terminating outputs used by the {@link CachingSULOracle}
      */
     protected void composeEquivalenceOracle(List<O> terminatingOutputs) {
         List<MembershipOracle.MealyMembershipOracle<I, O>> equivalenceSULOracles = new ArrayList<>();
-        for (SUL<I, O> sul : suls) {
+        for (SUL<I, O> sul: suls) {
             MembershipOracle.MealyMembershipOracle<I, O> equivalenceSULOracle = new SULOracle<>(sul);
 
             // in case sanitization is enabled, we apply a CE verification wrapper
             // to check counterexamples before they are returned to the EQ oracle
             if (learnerConfig.isCeSanitization()) {
                 equivalenceSULOracle = new CESanitizingSULOracle<MealyMachine<?, I, ?, O>, I, O>(
-                        learnerConfig.getCeReruns(), equivalenceSULOracle, learnerConfig.isProbabilisticSanitization(),
-                        nonDetWriter, learner::getHypothesisModel, cache, learnerConfig.isSkipNonDetTests());
+                    learnerConfig.getCeReruns(), equivalenceSULOracle, learnerConfig.isProbabilisticSanitization(),
+                    nonDetWriter, learner::getHypothesisModel, cache, learnerConfig.isSkipNonDetTests());
             }
 
             // we are adding a cache and a logging oracle
-            equivalenceSULOracle = new CachingSULOracle<>(equivalenceSULOracle, cache, !learnerConfig.isCacheTests(), terminatingOutputs);
+            equivalenceSULOracle = new CachingSULOracle<>(equivalenceSULOracle, cache, !learnerConfig.isCacheTests(),
+                terminatingOutputs);
             equivalenceSULOracle = new LoggingSULOracle<>(equivalenceSULOracle);
             equivalenceSULOracles.add(equivalenceSULOracle);
         }
 
-        this.equivalenceOracle = LearningSetupFactory.createEquivalenceOracle(learnerConfig, suls, equivalenceSULOracles, alphabet);
+        this.equivalenceOracle = LearningSetupFactory.createEquivalenceOracle(learnerConfig, suls,
+            equivalenceSULOracles, alphabet);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerRA.java
@@ -43,7 +43,7 @@ import java.nio.charset.StandardCharsets;
  * @param <E> the execution context
  */
 public class StateFuzzerRA<B extends ParameterizedSymbol, E>
-        implements StateFuzzer<RegisterAutomatonWrapper<B, PSymbolInstance>> {
+    implements StateFuzzer<RegisterAutomatonWrapper<B, PSymbolInstance>> {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -87,10 +87,12 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
     public LearnerResult<RegisterAutomatonWrapper<B, PSymbolInstance>> startFuzzing() {
         try {
             return inferRegisterAutomata();
-        } catch (RuntimeException e) {
+        }
+        catch (RuntimeException e) {
             LOGGER.error("Exception encountered during state fuzzing");
             throw e;
-        } finally {
+        }
+        finally {
             cleanupTasks.execute();
         }
     }
@@ -102,7 +104,7 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
      * exports the final statistics.
      *
      * @return the corresponding LearnerResult, which can be empty if state
-     *         fuzzing fails
+     *             fuzzing fails
      */
     protected LearnerResult<RegisterAutomatonWrapper<B, PSymbolInstance>> inferRegisterAutomata() {
         // for convenience, we copy all the input files/streams
@@ -111,7 +113,7 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
 
         // setting up statistics tracker, learner and equivalence oracle
         StatisticsTracker<B, Word<PSymbolInstance>, Boolean, DefaultQuery<PSymbolInstance, Boolean>> statisticsTracker = stateFuzzerComposer
-                .getStatisticsTracker();
+            .getStatisticsTracker();
 
         RaLearningAlgorithm learner = stateFuzzerComposer.getLearner();
         IOEquivalenceOracle equivalenceOracle = stateFuzzerComposer.getEquivalenceOracle();
@@ -127,8 +129,9 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
 
         try {
             statisticsTracker
-                    .setRuntimeStateTracking(new FileOutputStream(new File(outputDir, LEARNING_STATE_FILENAME)));
-        } catch (FileNotFoundException e1) {
+                .setRuntimeStateTracking(new FileOutputStream(new File(outputDir, LEARNING_STATE_FILENAME)));
+        }
+        catch (FileNotFoundException e1) {
             throw new RuntimeException("Could not create runtime state tracking output stream");
         }
 
@@ -172,11 +175,11 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
 
                     LOGGER.info("Optimizing CE" + System.lineSeparator());
                     counterExample = loops.optimizeCE(counterExample.getInput(),
-                            (Hypothesis) hypothesis.getRegisterAutomaton());
+                        (Hypothesis) hypothesis.getRegisterAutomaton());
                     counterExample = asrep.optimizeCE(counterExample.getInput(),
-                            (Hypothesis) hypothesis.getRegisterAutomaton());
+                        (Hypothesis) hypothesis.getRegisterAutomaton());
                     counterExample = pref.optimizeCE(counterExample.getInput(),
-                            (Hypothesis) hypothesis.getRegisterAutomaton());
+                        (Hypothesis) hypothesis.getRegisterAutomaton());
 
                     LOGGER.info("Adding found CE to learner" + System.lineSeparator());
                     learner.addCounterexample(counterExample);
@@ -186,29 +189,34 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
 
             finished = true;
 
-        } catch (TimeLimitReachedException e) {
+        }
+        catch (TimeLimitReachedException e) {
             LOGGER.warn("Learning timed out after a duration of {} (i.e. {} hours, or {} minutes)",
-                    e.getDuration(), e.getDuration().toHours(), e.getDuration().toMinutes());
+                e.getDuration(), e.getDuration().toHours(), e.getDuration().toMinutes());
             notFinishedReason = "time limit reached";
 
-        } catch (TestLimitReachedException e) {
+        }
+        catch (TestLimitReachedException e) {
             LOGGER.warn("Learning exhausted the number of tests allowed ({} tests)", e.getTestLimit());
             notFinishedReason = "test limit reached";
 
-        } catch (RoundLimitReachedException e) {
+        }
+        catch (RoundLimitReachedException e) {
             LOGGER.info("Learning exhausted the number of hypothesis construction rounds allowed ({} rounds)",
-                    e.getRoundLimit());
+                e.getRoundLimit());
             notFinishedReason = "hypothesis construction round limit reached";
 
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             notFinishedReason = e.getMessage();
             LOGGER.error("Exception generated during learning\n" + e);
             // useful to log what actually went wrong
             try (PrintWriter pw = new PrintWriter(
-                    new FileWriter(new File(outputDir, ERROR_FILENAME), StandardCharsets.UTF_8))) {
+                new FileWriter(new File(outputDir, ERROR_FILENAME), StandardCharsets.UTF_8))) {
                 pw.println(e.getMessage());
                 e.printStackTrace(pw);
-            } catch (IOException exc) {
+            }
+            catch (IOException exc) {
                 LOGGER.error("Could not create error file writer");
             }
         }
@@ -232,7 +240,7 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
 
         statisticsTracker.finishedLearning(hypothesis, finished, notFinishedReason);
         Statistics<B, Word<PSymbolInstance>, Boolean, DefaultQuery<PSymbolInstance, Boolean>> statistics = statisticsTracker
-                .generateStatistics();
+            .generateStatistics();
         learnerResult.setStatistics(statistics);
         LOGGER.info(statistics);
 
@@ -243,7 +251,8 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
 
         try {
             statistics.export(new FileWriter(new File(outputDir, STATISTICS_FILENAME), StandardCharsets.UTF_8));
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.error("Could not copy statistics to output directory");
         }
 
@@ -262,26 +271,29 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
     protected void copyInputsToOutputDir(File outputDir) {
         try (InputStream inputStream = stateFuzzerComposer.getAlphabetFileInputStream()) {
             writeToFile(inputStream, new File(outputDir, ALPHABET_FILENAME));
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not copy alphabet to output directory: " + e.getMessage());
         }
 
         if (stateFuzzerEnabler.getLearnerConfig().getEquivalenceAlgorithms()
-                .contains(EquivalenceAlgorithmName.SAMPLED_TESTS)) {
+            .contains(EquivalenceAlgorithmName.SAMPLED_TESTS)) {
             String testFile = stateFuzzerEnabler.getLearnerConfig().getTestFile();
             String testFilename = new File(testFile).getName();
 
             try (InputStream inputStream = new FileInputStream(testFile)) {
                 writeToFile(inputStream, new File(outputDir, testFilename));
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 LOGGER.warn("Could not copy sampled tests file to output directory: " + e.getMessage());
             }
         }
 
         try (InputStream inputStream = stateFuzzerEnabler.getSULConfig().getMapperConfig()
-                .getMapperConnectionConfigInputStream()) {
+            .getMapperConnectionConfigInputStream()) {
             writeToFile(inputStream, new File(outputDir, MAPPER_CONNECTION_CONFIG_FILENAME));
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not copy mapper connection config to output directory: " + e.getMessage());
         }
     }
@@ -289,8 +301,8 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
     /**
      * Writes the contents of the input stream to the output file.
      *
-     * @param inputStream the input stream of the source
-     * @param outputFile  the output file of the destination
+     * @param  inputStream the input stream of the source
+     * @param  outputFile  the output file of the destination
      *
      * @throws IOException if the reading or writing is not successful
      */
@@ -311,8 +323,9 @@ public class StateFuzzerRA<B extends ParameterizedSymbol, E>
     /**
      * Returns a valid round limit number, which is either an integer or -1.
      *
-     * @param roundLimit the integer to be converted, if it is needed
-     * @return -1 if roundLimit is null or non-positive and roundLimit otherwise
+     * @param  roundLimit the integer to be converted, if it is needed
+     *
+     * @return            -1 if roundLimit is null or non-positive and roundLimit otherwise
      */
     protected int roundLimitToInt(Integer roundLimit) {
         if (roundLimit == null || roundLimit <= 0) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerStandard.java
@@ -32,8 +32,8 @@ import java.nio.charset.StandardCharsets;
 /**
  * The standard implementation of the StateFuzzer Interface.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrapper<I, O>> {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -42,11 +42,7 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
     protected final String ALPHABET_FILENAME;
 
     /** Stores the constructor parameter. */
-    protected StateFuzzerComposer<I,
-        StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>>,
-        MealyLearner<I, O>,
-        EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>>
-    stateFuzzerComposer;
+    protected StateFuzzerComposer<I, StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>>, MealyLearner<I, O>, EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>> stateFuzzerComposer;
 
     /** The alphabet from the {@link #stateFuzzerComposer}. */
     protected Alphabet<I> alphabet;
@@ -63,13 +59,11 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param stateFuzzerComposer  contains the learning components to be used
-     *                             for the state fuzzing
+     * @param stateFuzzerComposer contains the learning components to be used
+     *                                for the state fuzzing
      */
     public StateFuzzerStandard(
-        StateFuzzerComposer<I, StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>>,
-            MealyLearner<I, O>, EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>> stateFuzzerComposer
-    ){
+        StateFuzzerComposer<I, StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>>, MealyLearner<I, O>, EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>> stateFuzzerComposer) {
         this.stateFuzzerComposer = stateFuzzerComposer;
         this.stateFuzzerEnabler = stateFuzzerComposer.getStateFuzzerEnabler();
         this.alphabet = stateFuzzerComposer.getAlphabet();
@@ -82,14 +76,15 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
     public LearnerResult<MealyMachineWrapper<I, O>> startFuzzing() {
         try {
             return inferStateMachine();
-        } catch (RuntimeException e) {
+        }
+        catch (RuntimeException e) {
             LOGGER.error("Exception encountered during state fuzzing");
             throw e;
-        } finally {
+        }
+        finally {
             cleanupTasks.execute();
         }
     }
-
 
     /**
      * Uses the learning components for the state fuzzing.
@@ -97,8 +92,8 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
      * Also it copies the necessary files, proceeds with the state fuzzing and
      * exports the final statistics.
      *
-     * @return  the corresponding LearnerResult, which can be empty if state
-     *          fuzzing fails
+     * @return the corresponding LearnerResult, which can be empty if state
+     *             fuzzing fails
      */
     protected LearnerResult<MealyMachineWrapper<I, O>> inferStateMachine() {
         // for convenience, we copy all the input files/streams
@@ -106,12 +101,13 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
         copyInputsToOutputDir(outputDir);
 
         // setting up statistics tracker, learner and equivalence oracle
-        StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>> statisticsTracker = stateFuzzerComposer.getStatisticsTracker();
+        StatisticsTracker<I, Word<I>, Word<O>, DefaultQuery<I, Word<O>>> statisticsTracker = stateFuzzerComposer
+            .getStatisticsTracker();
 
         MealyLearner<I, O> learner = stateFuzzerComposer.getLearner();
 
-        EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>>
-                equivalenceOracle = stateFuzzerComposer.getEquivalenceOracle();
+        EquivalenceOracle<MealyMachine<?, I, ?, O>, I, Word<O>> equivalenceOracle = stateFuzzerComposer
+            .getEquivalenceOracle();
 
         MealyMachine<?, I, ?, O> hypothesis = null;
         DefaultQuery<I, Word<O>> counterExample = null;
@@ -124,14 +120,16 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
 
         try {
             statisticsTracker.setRuntimeStateTracking(new FileOutputStream(
-                    new File(outputDir, LEARNING_STATE_FILENAME)));
-        } catch (FileNotFoundException e1) {
+                new File(outputDir, LEARNING_STATE_FILENAME)));
+        }
+        catch (FileNotFoundException e1) {
             throw new RuntimeException("Could not create runtime state tracking output stream");
         }
 
         try {
             LOGGER.info("Input alphabet: {}", alphabet);
-            LOGGER.info("Equivalence Thread Count: {}", stateFuzzerEnabler.getLearnerConfig().getEquivalenceThreadCount());
+            LOGGER.info("Equivalence Thread Count: {}",
+                stateFuzzerEnabler.getLearnerConfig().getEquivalenceThreadCount());
             LOGGER.info("Starting Learning" + System.lineSeparator());
             statisticsTracker.startLearning(stateFuzzerEnabler, alphabet);
             learner.startLearning();
@@ -169,28 +167,34 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
 
             finished = true;
 
-        } catch (TimeLimitReachedException e) {
+        }
+        catch (TimeLimitReachedException e) {
             LOGGER.warn("Learning timed out after a duration of {} (i.e. {} hours, or {} minutes)",
-                    e.getDuration(), e.getDuration().toHours(), e.getDuration().toMinutes());
+                e.getDuration(), e.getDuration().toHours(), e.getDuration().toMinutes());
             notFinishedReason = "time limit reached";
 
-        } catch (TestLimitReachedException e) {
+        }
+        catch (TestLimitReachedException e) {
             LOGGER.warn("Learning exhausted the number of tests allowed ({} tests)", e.getTestLimit());
             notFinishedReason = "test limit reached";
 
-        } catch (RoundLimitReachedException e) {
+        }
+        catch (RoundLimitReachedException e) {
             LOGGER.info("Learning exhausted the number of hypothesis construction rounds allowed ({} rounds)",
-                    e.getRoundLimit());
+                e.getRoundLimit());
             notFinishedReason = "hypothesis construction round limit reached";
 
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             notFinishedReason = e.getMessage();
             LOGGER.error("Exception generated during learning\n" + e);
             // useful to log what actually went wrong
-            try (PrintWriter pw = new PrintWriter(new FileWriter(new File(outputDir, ERROR_FILENAME), StandardCharsets.UTF_8))) {
+            try (PrintWriter pw = new PrintWriter(
+                new FileWriter(new File(outputDir, ERROR_FILENAME), StandardCharsets.UTF_8))) {
                 pw.println(e.getMessage());
                 e.printStackTrace(pw);
-            } catch (IOException exc) {
+            }
+            catch (IOException exc) {
                 LOGGER.error("Could not create error file writer");
             }
         }
@@ -216,7 +220,6 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
         learnerResult.setStatistics(statistics);
         LOGGER.info(statistics);
 
-
         // exporting to output files
         File learnedModelFile = new File(outputDir, LEARNED_MODEL_FILENAME);
         learnerResult.setLearnedModelFile(learnedModelFile);
@@ -224,7 +227,8 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
 
         try {
             statistics.export(new FileWriter(new File(outputDir, STATISTICS_FILENAME), StandardCharsets.UTF_8));
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.error("Could not copy statistics to output directory");
         }
 
@@ -238,29 +242,34 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
      * Also if a test file is given for the SAMPLED_TESTS equivalence algorithm to
      * be used, then that test file is also copied to the output directory.
      *
-     * @param outputDir  the output directory, in which the files should be copied
+     * @param outputDir the output directory, in which the files should be copied
      */
     protected void copyInputsToOutputDir(File outputDir) {
         try (InputStream inputStream = stateFuzzerComposer.getAlphabetFileInputStream()) {
             writeToFile(inputStream, new File(outputDir, ALPHABET_FILENAME));
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not copy alphabet to output directory: " + e.getMessage());
         }
 
-        if (stateFuzzerEnabler.getLearnerConfig().getEquivalenceAlgorithms().contains(EquivalenceAlgorithmName.SAMPLED_TESTS)) {
+        if (stateFuzzerEnabler.getLearnerConfig().getEquivalenceAlgorithms()
+            .contains(EquivalenceAlgorithmName.SAMPLED_TESTS)) {
             String testFile = stateFuzzerEnabler.getLearnerConfig().getTestFile();
             String testFilename = new File(testFile).getName();
 
             try (InputStream inputStream = new FileInputStream(testFile)) {
                 writeToFile(inputStream, new File(outputDir, testFilename));
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 LOGGER.warn("Could not copy sampled tests file to output directory: " + e.getMessage());
             }
         }
 
-        try (InputStream inputStream = stateFuzzerEnabler.getSULConfig().getMapperConfig().getMapperConnectionConfigInputStream()) {
+        try (InputStream inputStream = stateFuzzerEnabler.getSULConfig().getMapperConfig()
+            .getMapperConnectionConfigInputStream()) {
             writeToFile(inputStream, new File(outputDir, MAPPER_CONNECTION_CONFIG_FILENAME));
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not copy mapper connection config to output directory: " + e.getMessage());
         }
     }
@@ -268,10 +277,10 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
     /**
      * Writes the contents of the input stream to the output file.
      *
-     * @param inputStream   the input stream of the source
-     * @param outputFile    the output file of the destination
+     * @param  inputStream the input stream of the source
+     * @param  outputFile  the output file of the destination
      *
-     * @throws IOException  if the reading or writing is not successful
+     * @throws IOException if the reading or writing is not successful
      */
     protected void writeToFile(InputStream inputStream, File outputFile) throws IOException {
         if (inputStream == null) {
@@ -290,7 +299,8 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
     /**
      * Returns a valid round limit number, which is either an integer or -1.
      *
-     * @param roundLimit  the integer to be converted, if it is needed
+     * @param  roundLimit the integer to be converted, if it is needed
+     *
      * @return            -1 if roundLimit is null or non-positive and roundLimit otherwise
      */
     protected int roundLimitToInt(Integer roundLimit) {
@@ -306,8 +316,8 @@ public class StateFuzzerStandard<I, O> implements StateFuzzer<MealyMachineWrappe
     /**
      * Exports a hypothesis to a file.
      *
-     * @param hypothesis   the state machine hypothesis to be exported
-     * @param destination  the destination file
+     * @param hypothesis  the state machine hypothesis to be exported
+     * @param destination the destination file
      */
     protected void exportHypothesis(MealyMachineWrapper<I, O> hypothesis, File destination) {
         if (hypothesis == null) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/BasicConverterFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/BasicConverterFactory.java
@@ -6,7 +6,6 @@ import com.beust.jcommander.IStringConverterFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-
 /**
  * The implementation of JCommander's IStringConverterFactory for the basic
  * classes.
@@ -34,7 +33,8 @@ public class BasicConverterFactory implements IStringConverterFactory {
      * <p>
      * This method is used implicitly by JCommander.
      *
-     * @param forType  the class destination used as key in {@link #converters}
+     * @param  forType the class destination used as key in {@link #converters}
+     *
      * @return         the mapped converter value in {@link #converters} or null
      */
     @Override
@@ -50,12 +50,13 @@ public class BasicConverterFactory implements IStringConverterFactory {
         /**
          * Constructor
          */
-        public StringConverter() { }
+        public StringConverter() {}
 
         /**
          * Converts a String to String and uses {@link PropertyResolver#resolve(String)}.
          *
-         * @param value  the value to be converted
+         * @param  value the value to be converted
+         *
          * @return       the converted value
          */
         @Override
@@ -72,12 +73,13 @@ public class BasicConverterFactory implements IStringConverterFactory {
         /**
          * Constructor
          */
-        public IntegerConverter() { }
+        public IntegerConverter() {}
 
         /**
          * Converts a String to Integer and uses {@link PropertyResolver#resolve(String)}.
          *
-         * @param value  the value to be converted
+         * @param  value the value to be converted
+         *
          * @return       the converted value
          */
         @Override
@@ -94,12 +96,13 @@ public class BasicConverterFactory implements IStringConverterFactory {
         /**
          * Constructor
          */
-        public LongConverter() { }
+        public LongConverter() {}
 
         /**
          * Converts a String to Long and uses {@link PropertyResolver#resolve(String)}.
          *
-         * @param value  the value to be converted
+         * @param  value the value to be converted
+         *
          * @return       the converted value
          */
         @Override
@@ -116,12 +119,13 @@ public class BasicConverterFactory implements IStringConverterFactory {
         /**
          * Constructor
          */
-        public DoubleConverter() { }
+        public DoubleConverter() {}
 
         /**
          * Converts a String to Double and uses {@link PropertyResolver#resolve(String)}.
          *
-         * @param value  the value to be converted
+         * @param  value the value to be converted
+         *
          * @return       the converted value
          */
         @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/PropertyResolver.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/PropertyResolver.java
@@ -62,9 +62,9 @@ public class PropertyResolver {
      * properties in {@link #dynamicProps}.
      * <p>
      * The resolution priority (in decreasing order) is:
-     *  dynamic application properties {@literal >}
-     *  JVM/system properties {@literal >}
-     *  initial property from file.
+     * dynamic application properties {@literal >}
+     * JVM/system properties {@literal >}
+     * initial property from file.
      */
     protected static final Map<String, String> defaultProps = new LinkedHashMap<>();
 
@@ -80,10 +80,12 @@ public class PropertyResolver {
      */
     @SuppressFBWarnings
     @DynamicParameter(names = "-D", description = "Definitions for variables, which can be used as ${var}. "
-            + "Variables are replaced with their corresponding values before the arguments are parsed.")
+        + "Variables are replaced with their corresponding values before the arguments are parsed.")
     protected static Map<String, String> dynamicProps = new LinkedHashMap<>();
 
-    /** Stores loaded properties to avoid reloading them on next invocation of {@link #loadProperties()}. */
+    /**
+     * Stores loaded properties to avoid reloading them on next invocation of {@link #loadProperties()}.
+     */
     protected static final Map<String, Properties> propertiesCache = new LinkedHashMap<>();
 
     /** Caches resolved userStrings to avoid reparsing them if they occur again. */
@@ -98,7 +100,7 @@ public class PropertyResolver {
     /**
      * Returns the singleton instance of PropertyResolver.
      *
-     * @return  the singleton instance of PropertyResolver
+     * @return the singleton instance of PropertyResolver
      */
     public static synchronized PropertyResolver getInstance() {
         if (instance == null) {
@@ -120,7 +122,7 @@ public class PropertyResolver {
 
         // add fileLoadedProps properties to defaultProps
         // system defined properties have priority over them
-        for (String propName : fileLoadedProps.stringPropertyNames()) {
+        for (String propName: fileLoadedProps.stringPropertyNames()) {
             String fileProp = fileLoadedProps.getProperty(propName);
             String defaultProp = System.getProperty(propName, fileProp);
             defaultProps.put(propName, defaultProp);
@@ -160,7 +162,8 @@ public class PropertyResolver {
         // Timestamp
         if (!fileLoadedProps.containsKey(TIMESTAMP)) {
             String timestampFormat = defaultProps.getOrDefault(TIMESTAMP_FORMAT, defaultFormat);
-            String timestamp = DateTimeFormatter.ofPattern(timestampFormat).format(LocalDateTime.now(ZoneId.systemDefault()));
+            String timestamp = DateTimeFormatter.ofPattern(timestampFormat)
+                .format(LocalDateTime.now(ZoneId.systemDefault()));
             defaultProps.put(TIMESTAMP, timestamp);
         }
     }
@@ -182,7 +185,7 @@ public class PropertyResolver {
      * {@link #FUZZER_PROPS} and then {@link #DEFAULT_FUZZER_PROPS_FILE}.
      * If no file is available then no initial properties are loaded.
      *
-     * @return  the properties that either contain the loaded properties or are empty
+     * @return the properties that either contain the loaded properties or are empty
      */
     protected static Properties loadProperties() {
         Properties props = new Properties();
@@ -200,7 +203,8 @@ public class PropertyResolver {
                 propertiesCache.put(propsLocation, props);
                 LOGGER.trace("Loaded properties from " + propsLocation);
                 return props;
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 throw new RuntimeException("Could not load properties from " + propsLocation + ": " + e.getMessage());
             }
         }
@@ -219,7 +223,8 @@ public class PropertyResolver {
                 propertiesCache.put(DEFAULT_FUZZER_PROPS_FILE, props);
                 LOGGER.trace("Loaded properties from " + defaultPropsUrl);
                 return props;
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 throw new RuntimeException("Could not load properties from " + defaultPropsUrl + ": " + e.getMessage());
             }
         }
@@ -232,7 +237,7 @@ public class PropertyResolver {
      * Resolves all the application properties in a given userString by
      * substituting them for values.
      * <p>
-     * An example is the application property 'sul.port', which can  be used as
+     * An example is the application property 'sul.port', which can be used as
      * {@code -host localhost:${sul.port}}. If 'sul.port' has value 123
      * and this method is supplied with userString = "localhost:${sul.port}" then
      * the returned string will be "localhost:123".
@@ -241,7 +246,8 @@ public class PropertyResolver {
      * in the returned string. If the userString contains no application properties
      * then the userString is returned.
      *
-     * @param userString  the string that may contain application properties
+     * @param  userString the string that may contain application properties
+     *
      * @return            the resolved string
      */
     public static String resolve(String userString) {
@@ -277,11 +283,9 @@ public class PropertyResolver {
             // replace found pattern '${prop_key}' with the prop_key's value
             // first dynamic props are searched for the prop_key and then default props
             // if the provided prop_key is unknown, the pattern is not resolved
-            String replacement =
-                dynamicProps.getOrDefault(matcher.group(2),
+            String replacement = dynamicProps.getOrDefault(matcher.group(2),
                 defaultProps.getOrDefault(matcher.group(2),
-                null)
-            );
+                    null));
 
             if (replacement != null) {
                 matcher.appendReplacement(resolvedSB, replacement);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfig.java
@@ -8,7 +8,7 @@ public interface StateFuzzerClientConfig extends StateFuzzerConfig {
     /**
      * Returns {@code true}.
      *
-     * @return  {@code true}
+     * @return {@code true}
      */
     @Override
     default boolean isFuzzingClient() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigStandard.java
@@ -24,11 +24,11 @@ public class StateFuzzerClientConfigStandard extends StateFuzzerConfigStandard i
      * If the provided parameter is null, then the corresponding config is
      * initialized with a new empty corresponding configuration.
      *
-     * @param sulClientConfig  the {@link SULClientConfig} implementing class
+     * @param sulClientConfig the {@link SULClientConfig} implementing class
      */
     public StateFuzzerClientConfigStandard(SULClientConfig sulClientConfig) {
         super();
-        this.sulClientConfig = sulClientConfig == null ? new SULClientConfig(){} : sulClientConfig;
+        this.sulClientConfig = sulClientConfig == null ? new SULClientConfig() {} : sulClientConfig;
     }
 
     /**
@@ -37,16 +37,16 @@ public class StateFuzzerClientConfigStandard extends StateFuzzerConfigStandard i
      * If any provided parameter is null, then the corresponding config is
      * initialized with a new empty corresponding configuration.
      *
-     * @param learnerConfig      the {@link LearnerConfig} implementing class
-     * @param sulClientConfig    the {@link SULClientConfig} implementing class
-     * @param testRunnerConfig   the {@link TestRunnerConfig} implementing class
-     * @param timingProbeConfig  the {@link TimingProbeConfig} implementing class
+     * @param learnerConfig     the {@link LearnerConfig} implementing class
+     * @param sulClientConfig   the {@link SULClientConfig} implementing class
+     * @param testRunnerConfig  the {@link TestRunnerConfig} implementing class
+     * @param timingProbeConfig the {@link TimingProbeConfig} implementing class
      */
     public StateFuzzerClientConfigStandard(LearnerConfig learnerConfig, SULClientConfig sulClientConfig,
         TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
 
         super(learnerConfig, testRunnerConfig, timingProbeConfig);
-        this.sulClientConfig = sulClientConfig == null ? new SULClientConfig(){} : sulClientConfig;
+        this.sulClientConfig = sulClientConfig == null ? new SULClientConfig() {} : sulClientConfig;
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfig.java
@@ -23,7 +23,7 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if the help usage should be printed
+     * @return {@code true} if the help usage should be printed
      */
     default boolean isHelp() {
         return false;
@@ -34,7 +34,7 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if the logging level should be set to DEBUG
+     * @return {@code true} if the logging level should be set to DEBUG
      */
     default boolean isDebug() {
         return false;
@@ -46,8 +46,8 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if the logging level should be set high enough,
-     *          in order to let the output be quiet
+     * @return {@code true} if the logging level should be set high enough,
+     *             in order to let the output be quiet
      */
     default boolean isQuiet() {
         return false;
@@ -58,7 +58,7 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default: the singleton instance.
      *
-     * @return  the singleton PropertyResolver instance
+     * @return the singleton PropertyResolver instance
      */
     default PropertyResolver getPropertyResolver() {
         return PropertyResolver.getInstance();
@@ -68,10 +68,11 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * Returns a unique path of a directory of the format {@code output/o_<timestamp>},
      * in which results can be saved.
      *
-     * @return  a unique directory path, in which results can be saved
+     * @return a unique directory path, in which results can be saved
      */
     default String createUniqueOutputDir() {
-        String timestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss").format(LocalDateTime.now(ZoneId.systemDefault()));
+        String timestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
+            .format(LocalDateTime.now(ZoneId.systemDefault()));
         String outputDir = "output" + File.separator + "o_" + timestamp;
         return outputDir;
     }
@@ -81,7 +82,7 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: the result of {@link #createUniqueOutputDir()}.
      *
-     * @return  the output directory, in which results should be saved
+     * @return the output directory, in which results should be saved
      */
     @Override
     default String getOutputDir() {
@@ -93,7 +94,7 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: true.
      *
-     * @return  {@code true} if analysis concerns a client implementation
+     * @return {@code true} if analysis concerns a client implementation
      */
     @Override
     default boolean isFuzzingClient() {
@@ -105,11 +106,11 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: a new empty LearnerConfig.
      *
-     * @return  the LearnerConfig
+     * @return the LearnerConfig
      */
     @Override
     default LearnerConfig getLearnerConfig() {
-        return new LearnerConfig(){};
+        return new LearnerConfig() {};
     }
 
     /**
@@ -117,11 +118,11 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: a new empty SULConfig.
      *
-     * @return  the SULConfig
+     * @return the SULConfig
      */
     @Override
     default SULConfig getSULConfig() {
-        return new SULConfig(){};
+        return new SULConfig() {};
     }
 
     /**
@@ -129,11 +130,11 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: a new empty TestRunnerConfig.
      *
-     * @return  the TestRunnerConfig
+     * @return the TestRunnerConfig
      */
     @Override
     default TestRunnerConfig getTestRunnerConfig() {
-        return new TestRunnerConfig(){};
+        return new TestRunnerConfig() {};
     }
 
     /**
@@ -141,11 +142,11 @@ public interface StateFuzzerConfig extends StateFuzzerEnabler, TimingProbeEnable
      * <p>
      * Default value: a new empty TimingProbeConfig.
      *
-     * @return  the TimingProbeConfig
+     * @return the TimingProbeConfig
      */
     @Override
     default TimingProbeConfig getTimingProbeConfig() {
-        return new TimingProbeConfig(){};
+        return new TimingProbeConfig() {};
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigBuilder.java
@@ -8,14 +8,14 @@ public interface StateFuzzerConfigBuilder {
     /**
      * Builds the StateFuzzerClientConfig.
      *
-     * @return  the StateFuzzerClientConfig
+     * @return the StateFuzzerClientConfig
      */
     StateFuzzerClientConfig buildClientConfig();
 
     /**
      * Builds the StateFuzzerServerConfig.
      *
-     * @return  the StateFuzzerServerConfig
+     * @return the StateFuzzerServerConfig
      */
     StateFuzzerServerConfig buildServerConfig();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigStandard.java
@@ -20,7 +20,7 @@ public abstract class StateFuzzerConfigStandard implements StateFuzzerConfig {
      * <p>
      * Default value: false.
      */
-    @Parameter(names = { "-h", "-help" }, help = true, description = "Print usage for all existing commands")
+    @Parameter(names = {"-h", "-help"}, help = true, description = "Print usage for all existing commands")
     protected boolean help = false;
 
     /**
@@ -82,9 +82,9 @@ public abstract class StateFuzzerConfigStandard implements StateFuzzerConfig {
      * a new empty {@link TestRunnerConfig} and a new empty {@link TimingProbeConfig}.
      */
     public StateFuzzerConfigStandard() {
-        learnerConfig = new LearnerConfig(){};
-        testRunnerConfig = new TestRunnerConfig(){};
-        timingProbeConfig = new TimingProbeConfig(){};
+        learnerConfig = new LearnerConfig() {};
+        testRunnerConfig = new TestRunnerConfig() {};
+        timingProbeConfig = new TimingProbeConfig() {};
     }
 
     /**
@@ -94,21 +94,21 @@ public abstract class StateFuzzerConfigStandard implements StateFuzzerConfig {
      * initialized with a new empty corresponding configuration.
      * This means that a StateFuzzerConfig instance has always non-null inner configs.
      *
-     * @param learnerConfig      the {@link LearnerConfig} implementing class
-     * @param testRunnerConfig   the {@link TestRunnerConfig} implementing class
-     * @param timingProbeConfig  the {@link TimingProbeConfig} implementing class
+     * @param learnerConfig     the {@link LearnerConfig} implementing class
+     * @param testRunnerConfig  the {@link TestRunnerConfig} implementing class
+     * @param timingProbeConfig the {@link TimingProbeConfig} implementing class
      */
     public StateFuzzerConfigStandard(LearnerConfig learnerConfig, TestRunnerConfig testRunnerConfig,
-                             TimingProbeConfig timingProbeConfig) {
-        this.learnerConfig = learnerConfig == null ? new LearnerConfig(){} : learnerConfig;
-        this.testRunnerConfig = testRunnerConfig == null ? new TestRunnerConfig(){} : testRunnerConfig;
-        this.timingProbeConfig = timingProbeConfig == null ? new TimingProbeConfig(){} : timingProbeConfig;
+        TimingProbeConfig timingProbeConfig) {
+        this.learnerConfig = learnerConfig == null ? new LearnerConfig() {} : learnerConfig;
+        this.testRunnerConfig = testRunnerConfig == null ? new TestRunnerConfig() {} : testRunnerConfig;
+        this.timingProbeConfig = timingProbeConfig == null ? new TimingProbeConfig() {} : timingProbeConfig;
     }
 
     /**
      * Returns the value of {@link #help}.
      *
-     * @return  the value of {@link #help}
+     * @return the value of {@link #help}
      */
     @Override
     public boolean isHelp() {
@@ -118,7 +118,7 @@ public abstract class StateFuzzerConfigStandard implements StateFuzzerConfig {
     /**
      * Returns the value of {@link #debug}.
      *
-     * @return  the value of {@link #debug}
+     * @return the value of {@link #debug}
      */
     @Override
     public boolean isDebug() {
@@ -128,7 +128,7 @@ public abstract class StateFuzzerConfigStandard implements StateFuzzerConfig {
     /**
      * Returns the value of {@link #quiet}.
      *
-     * @return  the value of {@link #quiet}
+     * @return the value of {@link #quiet}
      */
     @Override
     public boolean isQuiet() {
@@ -138,7 +138,7 @@ public abstract class StateFuzzerConfigStandard implements StateFuzzerConfig {
     /**
      * Returns the singleton PropertyResolver instance.
      *
-     * @return  the singleton PropertyResolver instance
+     * @return the singleton PropertyResolver instance
      */
     @Override
     public PropertyResolver getPropertyResolver() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerEnabler.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerEnabler.java
@@ -12,28 +12,28 @@ public interface StateFuzzerEnabler extends RunDescriptionPrinter {
     /**
      * Returns the LearnerConfig.
      *
-     * @return  the LearnerConfig
+     * @return the LearnerConfig
      */
     LearnerConfig getLearnerConfig();
 
     /**
      * Returns the SULConfig.
      *
-     * @return  the SULConfig
+     * @return the SULConfig
      */
     SULConfig getSULConfig();
 
     /**
      * Returns {@code true} if analysis concerns a client implementation.
      *
-     * @return  {@code true} if analysis concerns a client implementation
+     * @return {@code true} if analysis concerns a client implementation
      */
     boolean isFuzzingClient();
 
     /**
      * Returns the directory, in which results should be saved.
      *
-     * @return  the directory, in which results should be saved
+     * @return the directory, in which results should be saved
      */
     String getOutputDir();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfig.java
@@ -8,7 +8,7 @@ public interface StateFuzzerServerConfig extends StateFuzzerConfig {
     /**
      * Returns {@code false}.
      *
-     * @return  {@code false}
+     * @return {@code false}
      */
     @Override
     default boolean isFuzzingClient() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigStandard.java
@@ -24,11 +24,11 @@ public class StateFuzzerServerConfigStandard extends StateFuzzerConfigStandard i
      * If the provided parameter is null, then the corresponding config is
      * initialized with a new empty corresponding configuration.
      *
-     * @param sulServerConfig  the {@link SULServerConfig} implementing class
+     * @param sulServerConfig the {@link SULServerConfig} implementing class
      */
     public StateFuzzerServerConfigStandard(SULServerConfig sulServerConfig) {
         super();
-        this.sulServerConfig = sulServerConfig == null ? new SULServerConfig(){} : sulServerConfig;
+        this.sulServerConfig = sulServerConfig == null ? new SULServerConfig() {} : sulServerConfig;
     }
 
     /**
@@ -37,16 +37,16 @@ public class StateFuzzerServerConfigStandard extends StateFuzzerConfigStandard i
      * If any provided parameter is null, then the corresponding config is
      * initialized with a new empty corresponding configuration.
      *
-     * @param learnerConfig      the {@link LearnerConfig} implementing class
-     * @param sulServerConfig    the {@link SULServerConfig} implementing class
-     * @param testRunnerConfig   the {@link TestRunnerConfig} implementing class
-     * @param timingProbeConfig  the {@link TimingProbeConfig} implementing class
+     * @param learnerConfig     the {@link LearnerConfig} implementing class
+     * @param sulServerConfig   the {@link SULServerConfig} implementing class
+     * @param testRunnerConfig  the {@link TestRunnerConfig} implementing class
+     * @param timingProbeConfig the {@link TimingProbeConfig} implementing class
      */
     public StateFuzzerServerConfigStandard(LearnerConfig learnerConfig, SULServerConfig sulServerConfig,
         TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
 
         super(learnerConfig, testRunnerConfig, timingProbeConfig);
-        this.sulServerConfig = sulServerConfig == null ? new SULServerConfig(){} : sulServerConfig;
+        this.sulServerConfig = sulServerConfig == null ? new SULServerConfig() {} : sulServerConfig;
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestParser.java
@@ -23,22 +23,22 @@ import java.util.Map;
  * Mutations of an input are encoded in the following way:
  * {@literal @} + input name + JSON encoding of the mutations.
  *
- * @param <I>  the type of inputs
+ * @param <I> the type of inputs
  */
 public class TestParser<I> {
 
     /**
      * Constructor
      */
-    public TestParser() { }
+    public TestParser() {}
 
     /**
      * Writes test to file given the filename.
      *
-     * @param test      the test to be written
-     * @param filename  the name of the destination file
+     * @param  test        the test to be written
+     * @param  filename    the name of the destination file
      *
-     * @throws IOException  if an error during writing occurs
+     * @throws IOException if an error during writing occurs
      */
     public void writeTest(Word<I> test, String filename) throws IOException {
         writeTest(test, new File(filename));
@@ -47,17 +47,18 @@ public class TestParser<I> {
     /**
      * Writes test to file.
      *
-     * @param test  the test to be written
-     * @param file  the destination file
+     * @param  test        the test to be written
+     * @param  file        the destination file
      *
-     * @throws IOException  if an error during writing occurs
+     * @throws IOException if an error during writing occurs
      */
     public void writeTest(Word<I> test, File file) throws IOException {
         if (!file.createNewFile()) {
             throw new IOException("Unable to create file at specified path. It already exists");
         }
-        try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
-            for (I input : test) {
+        try (PrintWriter pw = new PrintWriter(
+            new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+            for (I input: test) {
                 pw.println(input.toString());
             }
         }
@@ -66,11 +67,12 @@ public class TestParser<I> {
     /**
      * Reads a single test from file.
      *
-     * @param alphabet  the alphabet of the test
-     * @param filename  the name of the source file
-     * @return          the test as a word of inputs
+     * @param  alphabet    the alphabet of the test
+     * @param  filename    the name of the source file
      *
-     * @throws IOException  if an error during reading occurs
+     * @return             the test as a word of inputs
+     *
+     * @throws IOException if an error during reading occurs
      */
     public Word<I> readTest(Alphabet<I> alphabet, String filename) throws IOException {
         return readTest(alphabet, parseTestFile(filename));
@@ -79,8 +81,9 @@ public class TestParser<I> {
     /**
      * Reads a single test from a list of input strings.
      *
-     * @param alphabet          the alphabet of the test
-     * @param testInputStrings  the list containing input strings
+     * @param  alphabet         the alphabet of the test
+     * @param  testInputStrings the list containing input strings
+     *
      * @return                  the test as a word of inputs
      */
     public Word<I> readTest(Alphabet<I> alphabet, List<String> testInputStrings) {
@@ -88,7 +91,7 @@ public class TestParser<I> {
         alphabet.forEach(i -> inputs.put(i.toString(), i));
 
         Word<I> inputWord = Word.epsilon();
-        for (String inputString : testInputStrings) {
+        for (String inputString: testInputStrings) {
             inputString = inputString.trim();
             if (!inputs.containsKey(inputString)) {
                 throw new RuntimeException("Input \"" + inputString + "\" is missing from the alphabet");
@@ -105,29 +108,30 @@ public class TestParser<I> {
      * It stops reading once it reaches EOF, or an empty (or blank) line.
      * A non-empty line may contain:
      * <ul>
-     * <li> reset - marking the end of the current test, and the beginning of a new test
-     * <li> space-separated regular inputs and resets
-     * <li> a single mutated input (starts with @)
-     * <li> commented line (starts with # or !)
+     * <li>reset - marking the end of the current test, and the beginning of a new test
+     * <li>space-separated regular inputs and resets
+     * <li>a single mutated input (starts with @)
+     * <li>commented line (starts with # or !)
      * </ul>
      *
-     * @param alphabet  the alphabet of the tests
-     * @param filename  the name of the source file
-     * @return          the tests as a list of words of inputs, where each word
-     *                  is a test specified in the source file
+     * @param  alphabet    the alphabet of the tests
+     * @param  filename    the name of the source file
      *
-     * @throws IOException  if an error during reading occurs
+     * @return             the tests as a list of words of inputs, where each word
+     *                         is a test specified in the source file
+     *
+     * @throws IOException if an error during reading occurs
      */
     public List<Word<I>> readTests(Alphabet<I> alphabet, String filename) throws IOException {
         List<String> inputStrings = parseTestFile(filename);
         List<String> flattenedInputStrings = inputStrings.stream()
-                .map(i -> i.startsWith("@") ? new String[]{i} : i.split("\\s+"))
-                .flatMap(Arrays::stream)
-                .toList();
+            .map(i -> i.startsWith("@") ? new String[] {i} : i.split("\\s+"))
+            .flatMap(Arrays::stream)
+            .toList();
 
         List<Word<I>> tests = new ArrayList<>();
         List<String> currentTestStrings = new ArrayList<>();
-        for (String inputString : flattenedInputStrings) {
+        for (String inputString: flattenedInputStrings) {
             if (inputString.equals("reset")) {
                 tests.add(readTest(alphabet, currentTestStrings));
                 currentTestStrings.clear();
@@ -147,10 +151,11 @@ public class TestParser<I> {
      * Commented lines (starting with # or !) are ignored and not included
      * in the result and the parsing stops at the first empty/blank line.
      *
-     * @param filename  the name of the source file
-     * @return          the parsed and non-ignored lines of the file
+     * @param  filename    the name of the source file
      *
-     * @throws IOException  if an error during reading occurs
+     * @return             the parsed and non-ignored lines of the file
+     *
+     * @throws IOException if an error during reading occurs
      */
     protected List<String> parseTestFile(String filename) throws IOException {
         String line;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunner.java
@@ -12,11 +12,12 @@ public interface TestRunner {
     /**
      * Runs a single test multiple times against a specified sulOracle.
      *
-     * @param <I>        the type of inputs
-     * @param <O>        the type of outputs
-     * @param test       the test to be run in an input word format
-     * @param times      the number of times to repeat the test
-     * @param sulOracle  the Oracle against which the test will be run
+     * @param  <I>       the type of inputs
+     * @param  <O>       the type of outputs
+     * @param  test      the test to be run in an input word format
+     * @param  times     the number of times to repeat the test
+     * @param  sulOracle the Oracle against which the test will be run
+     *
      * @return           the corresponding {@link TestRunnerResult}
      */
     static <I, O> TestRunnerResult<Word<I>, O> runTest(Word<I> test, int times, MembershipOracle<I, O> sulOracle) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerBuilder.java
@@ -9,7 +9,8 @@ public interface TestRunnerBuilder {
     /**
      * Builds a new TestRunner instance.
      *
-     * @param testRunnerEnabler  the configuration that enables the testing
+     * @param  testRunnerEnabler the configuration that enables the testing
+     *
      * @return                   a new TestRunner instance
      */
     TestRunner build(TestRunnerEnabler testRunnerEnabler);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerRA.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerRA.java
@@ -33,8 +33,8 @@ import java.util.List;
 /**
  * The standard implementation of the TestRunner Interface.
  *
- * @param <I>  the type of input parameters
- * @param <E>  the type of execution context
+ * @param <I> the type of input parameters
+ * @param <E> the type of execution context
  */
 public class TestRunnerRA<I, E> implements TestRunner {
 
@@ -49,7 +49,10 @@ public class TestRunnerRA<I, E> implements TestRunner {
     /** Transformer to convert mealy input symbols into Ralib input symbols, */
     protected AlphabetBuilderTransformer<I, ParameterizedSymbol> inputTransformer;
 
-    /** The Oracle that contains the SUL built via SULBuilder and wrapped via SULWrapper constructor parameters. */
+    /**
+     * The Oracle that contains the SUL built via SULBuilder and wrapped via SULWrapper constructor
+     * parameters.
+     */
     protected SULOracle sulOracle;
 
     /** Stores the cleanup tasks of the TestRunner. */
@@ -61,30 +64,28 @@ public class TestRunnerRA<I, E> implements TestRunner {
      * The {@link #sulOracle} contains the wrapped (and built) SUL.
      * Invoke {@link #initialize()} afterwards.
      *
-     * @param testRunnerEnabler            the configuration that enables the testing
-     * @param alphabetBuilder              the builder of the alphabet
-     * @param alphabetBuilderTransformer   the transformer used to translate inputs
-     * @param sulBuilder                   the builder of the SUL
+     * @param testRunnerEnabler          the configuration that enables the testing
+     * @param alphabetBuilder            the builder of the alphabet
+     * @param alphabetBuilderTransformer the transformer used to translate inputs
+     * @param sulBuilder                 the builder of the SUL
      */
     public TestRunnerRA(
         TestRunnerEnabler testRunnerEnabler,
         AlphabetBuilder<I> alphabetBuilder,
         AlphabetBuilderTransformer<I, ParameterizedSymbol> alphabetBuilderTransformer,
-        SULBuilder<PSymbolInstance, PSymbolInstance, E> sulBuilder
-    ) {
+        SULBuilder<PSymbolInstance, PSymbolInstance, E> sulBuilder) {
         this.testRunnerEnabler = testRunnerEnabler;
         this.alphabet = alphabetBuilder.build(testRunnerEnabler.getLearnerConfig());
         this.inputTransformer = alphabetBuilderTransformer;
         this.cleanupTasks = new CleanupTasks();
 
-        AbstractSUL<PSymbolInstance, PSymbolInstance, E> abstractSUL =
-            sulBuilder.buildSUL(testRunnerEnabler.getSULConfig(), cleanupTasks);
+        AbstractSUL<PSymbolInstance, PSymbolInstance, E> abstractSUL = sulBuilder
+            .buildSUL(testRunnerEnabler.getSULConfig(), cleanupTasks);
         SULWrapper<PSymbolInstance, PSymbolInstance, E> sulWrapper = sulBuilder.buildWrapper();
         SUL<PSymbolInstance, PSymbolInstance> sul = sulWrapper.wrap(abstractSUL).getWrappedSUL();
 
         this.sulOracle = new SULOracle(
-            new DataWordSULWrapper(sul), new OutputSymbol("_io_err")
-        );
+            new DataWordSULWrapper(sul), new OutputSymbol("_io_err"));
     }
 
     /**
@@ -93,7 +94,7 @@ public class TestRunnerRA<I, E> implements TestRunner {
      * It checks if the TestRunnerConfig from the TestRunnerEnabler contains
      * any test specification that needs to be built and used.
      *
-     * @return  the same instance
+     * @return the same instance
      */
     public TestRunnerRA<I, E> initialize() {
         if (this.testRunnerEnabler.getTestRunnerConfig().getTestSpecification() != null) {
@@ -105,7 +106,7 @@ public class TestRunnerRA<I, E> implements TestRunner {
     /**
      * Returns the alphabet to be used during testing.
      *
-     * @return  the alphabet to be used during testing
+     * @return the alphabet to be used during testing
      */
     public Alphabet<I> getAlphabet() {
         return alphabet;
@@ -114,7 +115,7 @@ public class TestRunnerRA<I, E> implements TestRunner {
     /**
      * Returns the SULConfig of the {@link #testRunnerEnabler}.
      *
-     * @return  the SULConfig of the {@link #testRunnerEnabler}
+     * @return the SULConfig of the {@link #testRunnerEnabler}
      */
     public SULConfig getSULConfig() {
         return testRunnerEnabler.getSULConfig();
@@ -126,20 +127,20 @@ public class TestRunnerRA<I, E> implements TestRunner {
     @Override
     public void run() {
         try {
-            List<
-                TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>>
-            > results = runTests();
+            List<TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>>> results = runTests();
 
-            for (TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>> result : results) {
+            for (TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>> result: results) {
                 LOGGER.info(result.toString());
                 if (testRunnerEnabler.getTestRunnerConfig().isShowTransitionSequence()) {
                     LOGGER.info("Displaying Transition Sequence\n{}", result);
                 }
             }
-        } catch (IOException | FormatException e) {
+        }
+        catch (IOException | FormatException e) {
             LOGGER.error(e.getMessage());
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             terminate();
         }
     }
@@ -156,10 +157,10 @@ public class TestRunnerRA<I, E> implements TestRunner {
      * Reads the tests provided in the TestRunnerConfig of {@link #testRunnerEnabler},
      * executes each one of them using {@link #runTest(Word)} and collects the results.
      *
-     * @return  a list with the test results
+     * @return                 a list with the test results
      *
-     * @throws IOException      if an error during reading occurs
-     * @throws FormatException  if an invalid format was encountered
+     * @throws IOException     if an error during reading occurs
+     * @throws FormatException if an invalid format was encountered
      */
     protected List<TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>>> runTests()
         throws IOException, FormatException {
@@ -169,20 +170,18 @@ public class TestRunnerRA<I, E> implements TestRunner {
             .getTestRunnerConfig()
             .getTest();
 
-        ListAlphabet<I> inputAlphabet = new ListAlphabet<> (alphabet.stream()
-                .filter(i -> inputTransformer.toTransformedInput(i) instanceof InputSymbol).toList());
+        ListAlphabet<I> inputAlphabet = new ListAlphabet<>(alphabet.stream()
+            .filter(i -> inputTransformer.toTransformedInput(i) instanceof InputSymbol).toList());
 
         if (new File(testFileOrTestString).exists()) {
             tests = testParser.readTests(inputAlphabet, testFileOrTestString);
         } else {
             LOGGER.info(
                 "File {} does not exist, interpreting argument as test",
-                testFileOrTestString
-            );
+                testFileOrTestString);
             String[] testStrings = testFileOrTestString.split("\\s+");
             tests = List.of(
-                testParser.readTest(inputAlphabet, Arrays.asList(testStrings))
-            );
+                testParser.readTest(inputAlphabet, Arrays.asList(testStrings)));
         }
 
         // net.automatalib.word.WordCollector<I> exists but is not explicitly marked public.
@@ -190,15 +189,15 @@ public class TestRunnerRA<I, E> implements TestRunner {
         // Using that would allow us to skip using WordBuilder directly.
         // TODO: Open an issue or otherwise notify about this.
         List<Word<PSymbolInstance>> convertedTests = new ArrayList<>(tests.size());
-        for (Word<I> test : tests) {
+        for (Word<I> test: tests) {
             WordBuilder<PSymbolInstance> wordBuilder = new WordBuilder<>();
-            for (I input : test) {
+            for (I input: test) {
                 wordBuilder.append(new PSymbolInstance(inputTransformer.toTransformedInput(input)));
             }
             convertedTests.add(wordBuilder.toWord());
         }
         List<TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>>> results = new ArrayList<>();
-        for (Word<PSymbolInstance> test : convertedTests) {
+        for (Word<PSymbolInstance> test: convertedTests) {
             results.add(runTest(test));
         }
         return results;
@@ -207,19 +206,15 @@ public class TestRunnerRA<I, E> implements TestRunner {
     /**
      * Runs a single test and collects the result.
      *
-     * @param test  the test to be run against the stored {@link #sulOracle}
+     * @param  test the test to be run against the stored {@link #sulOracle}
+     *
      * @return      the result of the test
      */
-    protected TestRunnerResult<
-        Word<PSymbolInstance>,
-        Word<PSymbolInstance>
-    > runTest(Word<PSymbolInstance> test) {
-        TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>> result =
-            TestRunner.runTest(
-                test,
-                testRunnerEnabler.getTestRunnerConfig().getTimes(),
-                new MembershipOracleWrapperRA(sulOracle)
-            );
+    protected TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>> runTest(Word<PSymbolInstance> test) {
+        TestRunnerResult<Word<PSymbolInstance>, Word<PSymbolInstance>> result = TestRunner.runTest(
+            test,
+            testRunnerEnabler.getTestRunnerConfig().getTimes(),
+            new MembershipOracleWrapperRA(sulOracle));
         return result;
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerResult.java
@@ -5,8 +5,8 @@ import java.util.Map;
 /**
  * Represents the result of a single test run.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class TestRunnerResult<I, O> {
 
@@ -22,8 +22,8 @@ public class TestRunnerResult<I, O> {
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param inputWord         the test used for the run
-     * @param generatedOutputs  the map of generated outputs to their frequency
+     * @param inputWord        the test used for the run
+     * @param generatedOutputs the map of generated outputs to their frequency
      */
     public TestRunnerResult(I inputWord, Map<O, Integer> generatedOutputs) {
         this.inputWord = inputWord;
@@ -33,7 +33,7 @@ public class TestRunnerResult<I, O> {
     /**
      * Sets the expected output word.
      *
-     * @param outputWord  the output word to be expected
+     * @param outputWord the output word to be expected
      */
     public void setExpectedOutputWord(O outputWord) {
         expectedOutputWord = outputWord;
@@ -42,7 +42,7 @@ public class TestRunnerResult<I, O> {
     /**
      * Returns the input word (test) provided in the constructor.
      *
-     * @return  the input word (test) provided in the constructor
+     * @return the input word (test) provided in the constructor
      */
     public I getInputWord() {
         return inputWord;
@@ -51,7 +51,7 @@ public class TestRunnerResult<I, O> {
     /**
      * Returns the map provided in the constructor.
      *
-     * @return  the map provided in the constructor
+     * @return the map provided in the constructor
      */
     public Map<O, Integer> getGeneratedOutputs() {
         return generatedOutputs;
@@ -60,7 +60,7 @@ public class TestRunnerResult<I, O> {
     /**
      * Overrides the default method.
      *
-     * @return  the string representation of this instance
+     * @return the string representation of this instance
      */
     @Override
     public String toString() {
@@ -68,7 +68,7 @@ public class TestRunnerResult<I, O> {
 
         sb.append("Test: ").append(inputWord).append(System.lineSeparator());
 
-        for (Map.Entry<O, Integer> entry : generatedOutputs.entrySet()) {
+        for (Map.Entry<O, Integer> entry: generatedOutputs.entrySet()) {
             sb.append(entry.getValue())
                 .append(" times outputs: ")
                 .append(entry.getKey().toString())

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/TestRunnerStandard.java
@@ -28,10 +28,10 @@ import java.util.List;
 /**
  * The standard implementation of the TestRunner Interface.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
 public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implements TestRunner {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -60,15 +60,14 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      * The {@link #sulOracle} contains the wrapped (and built) sul.
      * Invoke {@link #initialize()} afterwards.
      *
-     * @param testRunnerEnabler        the configuration that enables the testing
-     * @param alphabetBuilder          the builder of the alphabet
-     * @param sulBuilder               the builder of the sul
+     * @param testRunnerEnabler the configuration that enables the testing
+     * @param alphabetBuilder   the builder of the alphabet
+     * @param sulBuilder        the builder of the sul
      */
     public TestRunnerStandard(
         TestRunnerEnabler testRunnerEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SULBuilder<I, O, E> sulBuilder
-    ) {
+        SULBuilder<I, O, E> sulBuilder) {
         this.testRunnerEnabler = testRunnerEnabler;
         this.alphabet = alphabetBuilder.build(testRunnerEnabler.getLearnerConfig());
         this.cleanupTasks = new CleanupTasks();
@@ -86,7 +85,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      * It checks if the TestRunnerConfig from the TestRunnerEnabler contains
      * any test specification that needs to be built and used.
      *
-     * @return  the same instance
+     * @return the same instance
      */
     public TestRunnerStandard<I, O, P, E> initialize() {
         if (this.testSpec == null &&
@@ -95,10 +94,10 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
             try {
                 this.testSpec = ModelFactory.buildProtocolModel(
                     testRunnerEnabler.getTestRunnerConfig().getTestSpecification(),
-                    new MealyIOProcessor<>(alphabet, mapper.getOutputBuilder())
-                );
+                    new MealyIOProcessor<>(alphabet, mapper.getOutputBuilder()));
 
-            } catch (IOException | FormatException e) {
+            }
+            catch (IOException | FormatException e) {
                 throw new RuntimeException("Could not build protocol model from test specification: " + e.getMessage());
             }
         }
@@ -108,7 +107,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
     /**
      * Returns the alphabet to be used during testing.
      *
-     * @return  the alphabet to be used during testing
+     * @return the alphabet to be used during testing
      */
     public Alphabet<I> getAlphabet() {
         return alphabet;
@@ -117,7 +116,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
     /**
      * Returns the SULConfig of the {@link #testRunnerEnabler}.
      *
-     * @return  the SULConfig of the {@link #testRunnerEnabler}
+     * @return the SULConfig of the {@link #testRunnerEnabler}
      */
     public SULConfig getSULConfig() {
         return testRunnerEnabler.getSULConfig();
@@ -131,16 +130,18 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
         try {
             List<TestRunnerResult<Word<I>, Word<O>>> results = runTests();
 
-            for (TestRunnerResult<Word<I>, Word<O>> result : results) {
+            for (TestRunnerResult<Word<I>, Word<O>> result: results) {
                 LOGGER.info(result.toString());
                 if (testRunnerEnabler.getTestRunnerConfig().isShowTransitionSequence()) {
                     LOGGER.info("Displaying Transition Sequence\n{}", getTransitionSequenceString(result));
                 }
             }
-        } catch (IOException | FormatException e) {
+        }
+        catch (IOException | FormatException e) {
             LOGGER.error(e.getMessage());
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             terminate();
         }
     }
@@ -157,10 +158,10 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      * Reads the tests provided in the TestRunnerConfig of {@link #testRunnerEnabler},
      * executes each one of them using {@link #runTest(Word)} and collects the results.
      *
-     * @return  a list with the test results
+     * @return                 a list with the test results
      *
-     * @throws IOException      if an error during reading occurs
-     * @throws FormatException  if an invalid format was encountered
+     * @throws IOException     if an error during reading occurs
+     * @throws FormatException if an invalid format was encountered
      */
     protected List<TestRunnerResult<Word<I>, Word<O>>> runTests() throws IOException, FormatException {
         TestParser<I> testParser = new TestParser<>();
@@ -176,7 +177,7 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
         }
 
         List<TestRunnerResult<Word<I>, Word<O>>> results = new ArrayList<>();
-        for (Word<I> test : tests) {
+        for (Word<I> test: tests) {
             results.add(runTest(test));
         }
         return results;
@@ -188,12 +189,13 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      * If a {@link #testSpec} is present then its output to the provided test
      * is computed and stored also in the TestRunnerResult as the expected output.
      *
-     * @param test  the test to be run against the stored {@link #sulOracle}
+     * @param  test the test to be run against the stored {@link #sulOracle}
+     *
      * @return      the result of the test
      */
     protected TestRunnerResult<Word<I>, Word<O>> runTest(Word<I> test) {
         TestRunnerResult<Word<I>, Word<O>> result = TestRunner.runTest(test,
-                testRunnerEnabler.getTestRunnerConfig().getTimes(), sulOracle);
+            testRunnerEnabler.getTestRunnerConfig().getTimes(), sulOracle);
 
         if (testSpec != null) {
             Word<O> outputWord = testSpec.computeOutput(test);
@@ -206,22 +208,23 @@ public class TestRunnerStandard<I, O extends MapperOutput<O, P>, P, E> implement
      * Returns a nice representation of the corresponding input and outputs
      * obtained from the result of a test run.
      *
-     * @param result  the test run result to be read
+     * @param  result the test run result to be read
+     *
      * @return        the transition sequence string
      */
     protected String getTransitionSequenceString(TestRunnerResult<Word<I>, Word<O>> result) {
 
         StringBuilder sb = new StringBuilder();
 
-        for (Word<O> answer : result.getGeneratedOutputs().keySet()) {
+        for (Word<O> answer: result.getGeneratedOutputs().keySet()) {
             sb.append(System.lineSeparator());
 
             for (int i = 0; i < result.getInputWord().size(); i++) {
                 List<O> atomicOutputs = new ArrayList<O>(answer.getSymbol(i).getAtomicOutputs(2));
 
                 if (getSULConfig().isFuzzingClient()
-                     && i == 0
-                     && mapper.getOutputChecker().hasInitialClientMessage(atomicOutputs.get(0))) {
+                    && i == 0
+                    && mapper.getOutputChecker().hasInitialClientMessage(atomicOutputs.get(0))) {
 
                     sb.append("- / ").append(atomicOutputs.get(0)).append(System.lineSeparator());
                     atomicOutputs.remove(0);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfig.java
@@ -12,7 +12,7 @@ public interface TestRunnerConfig {
      * <p>
      * Default value: null.
      *
-     * @return  null or a single test string or a file that contains tests
+     * @return null or a single test string or a file that contains tests
      */
     default String getTest() {
         return null;
@@ -23,7 +23,7 @@ public interface TestRunnerConfig {
      * <p>
      * Default value: 1.
      *
-     * @return  the number of times the tests should be run
+     * @return the number of times the tests should be run
      */
     default Integer getTimes() {
         return 1;
@@ -35,7 +35,7 @@ public interface TestRunnerConfig {
      * <p>
      * Default value: null.
      *
-     * @return  null or the path of a DOT model
+     * @return null or the path of a DOT model
      */
     default String getTestSpecification() {
         return null;
@@ -46,8 +46,8 @@ public interface TestRunnerConfig {
      * <p>
      * Default value: false.
      *
-     * @return  {@code true} if the sequence of transitions should be shown at
-     *          the end in a nicer form.
+     * @return {@code true} if the sequence of transitions should be shown at
+     *             the end in a nicer form.
      */
     default boolean isShowTransitionSequence() {
         return false;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigStandard.java
@@ -17,8 +17,8 @@ public class TestRunnerConfigStandard implements TestRunnerConfig {
      * Default value: null.
      */
     @Parameter(names = "-test", description = "This is the option that enables testing and "
-            + "should either point to a file that contains tests or should be a string "
-            + "space-separated sequence of inputs that represent a test.")
+        + "should either point to a file that contains tests or should be a string "
+        + "space-separated sequence of inputs that represent a test.")
     protected String test = null;
 
     /**
@@ -40,7 +40,7 @@ public class TestRunnerConfigStandard implements TestRunnerConfig {
      * Default value: null.
      */
     @Parameter(names = "-testSpecification", description = "A DOT model against which the resulting outputs are "
-            + "compared. If provided, the test will be run both on the system and on the model.")
+        + "compared. If provided, the test will be run both on the system and on the model.")
     protected String testSpecification = null;
 
     /**
@@ -51,18 +51,18 @@ public class TestRunnerConfigStandard implements TestRunnerConfig {
      * Default value: false.
      */
     @Parameter(names = "-showTransitionSequence", description = "Show the sequence of transitions at the end in a "
-            + "nicer form.")
+        + "nicer form.")
     protected boolean showTransitionSequence = false;
 
     /**
      * Constructor
      */
-    public TestRunnerConfigStandard() { }
+    public TestRunnerConfigStandard() {}
 
     /**
      * Returns the value of {@link #test}.
      *
-     * @return  the value of {@link #test}
+     * @return the value of {@link #test}
      */
     @Override
     public String getTest() {
@@ -72,7 +72,7 @@ public class TestRunnerConfigStandard implements TestRunnerConfig {
     /**
      * Returns the value of {@link #times}.
      *
-     * @return  the value of {@link #times}
+     * @return the value of {@link #times}
      */
     @Override
     public Integer getTimes() {
@@ -82,7 +82,7 @@ public class TestRunnerConfigStandard implements TestRunnerConfig {
     /**
      * Returns the value of {@link #testSpecification}.
      *
-     * @return  the value of {@link #testSpecification}
+     * @return the value of {@link #testSpecification}
      */
     @Override
     public String getTestSpecification() {
@@ -92,7 +92,7 @@ public class TestRunnerConfigStandard implements TestRunnerConfig {
     /**
      * Returns the value of {@link #showTransitionSequence}.
      *
-     * @return  the value of {@link #showTransitionSequence}
+     * @return the value of {@link #showTransitionSequence}
      */
     @Override
     public boolean isShowTransitionSequence() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerEnabler.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerEnabler.java
@@ -11,21 +11,21 @@ public interface TestRunnerEnabler {
     /**
      * Returns the LearnerConfig.
      *
-     * @return  the LearnerConfig
+     * @return the LearnerConfig
      */
     LearnerConfig getLearnerConfig();
 
     /**
      * Returns the SULConfig.
      *
-     * @return  the SULConfig
+     * @return the SULConfig
      */
     SULConfig getSULConfig();
 
     /**
      * Returns the TestRunnerConfig.
      *
-     * @return  the TestRunnerConfig
+     * @return the TestRunnerConfig
      */
     TestRunnerConfig getTestRunnerConfig();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeException.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeException.java
@@ -13,7 +13,7 @@ public class ProbeException extends Exception {
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param msg  the message related to the exception
+     * @param msg the message related to the exception
      */
     public ProbeException(String msg) {
         super(msg);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/ProbeTestRunner.java
@@ -17,12 +17,12 @@ import java.util.Map;
 /**
  * TestRunnerStandard extended to be used by the TimingProbe.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
-public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends TestRunnerStandard<I, O, P, E>  {
+public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends TestRunnerStandard<I, O, P, E> {
 
     /** Stores a list of results. */
     protected List<TestRunnerResult<Word<I>, Word<O>>> cachedResults = null;
@@ -30,15 +30,14 @@ public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends Test
     /**
      * Constructs a new instance from the given parameters.
      *
-     * @param testRunnerEnabler  the configuration that enables the testing
-     * @param alphabetBuilder    the builder of the alphabet
-     * @param sulBuilder         the builder of the SUL
+     * @param testRunnerEnabler the configuration that enables the testing
+     * @param alphabetBuilder   the builder of the alphabet
+     * @param sulBuilder        the builder of the SUL
      */
     public ProbeTestRunner(
         TestRunnerEnabler testRunnerEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SULBuilder<I, O, E> sulBuilder
-    ) {
+        SULBuilder<I, O, E> sulBuilder) {
         super(testRunnerEnabler, alphabetBuilder, sulBuilder);
     }
 
@@ -48,12 +47,13 @@ public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends Test
      * If there are {@link #cachedResults}, then any new result should correspond
      * to a cached one, with which should have the same outputs.
      *
-     * @param cacheFoundResults  cache the found results to {@link #cachedResults}
-     * @return                   {@code true} if any result is found to be
-     *                           non-deterministic
+     * @param  cacheFoundResults cache the found results to {@link #cachedResults}
      *
-     * @throws IOException      if an error occurs during {@link #runTests()}
-     * @throws FormatException  if an invalid format was encountered
+     * @return                   {@code true} if any result is found to be
+     *                               non-deterministic
+     *
+     * @throws IOException       if an error occurs during {@link #runTests()}
+     * @throws FormatException   if an invalid format was encountered
      */
     public boolean isNonDeterministic(boolean cacheFoundResults) throws IOException, FormatException {
         List<TestRunnerResult<Word<I>, Word<O>>> results = super.runTests();
@@ -63,7 +63,7 @@ public class ProbeTestRunner<I, O extends MapperOutput<O, P>, P, E> extends Test
             iterator = cachedResults.iterator();
         }
 
-        for (TestRunnerResult<Word<I>, Word<O>> result : results) {
+        for (TestRunnerResult<Word<I>, Word<O>> result: results) {
             Map<Word<O>, Integer> resultOutputs = result.getGeneratedOutputs();
 
             if (resultOutputs == null) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbe.java
@@ -10,7 +10,8 @@ public interface TimingProbe {
     /**
      * Returns a nice representation of a String to Integer map.
      *
-     * @param map  the map to be represented
+     * @param  map the map to be represented
+     *
      * @return     the string representation
      */
     public static String present(Map<String, Integer> map) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeBuilder.java
@@ -10,7 +10,8 @@ public interface TimingProbeBuilder {
     /**
      * Builds a new TimingProbe instance.
      *
-     * @param timingProbeEnabler  the configuration that enables the timing probe testing
+     * @param  timingProbeEnabler the configuration that enables the timing probe testing
+     *
      * @return                    a new TimingProbe instance
      */
     TimingProbe build(TimingProbeEnabler timingProbeEnabler);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/TimingProbeStandard.java
@@ -18,12 +18,13 @@ import java.util.Map;
 /**
  * The standard implementation of the TimingProbe interface.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <P>  the type of protocol messages
- * @param <E>  the type of execution context
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <P> the type of protocol messages
+ * @param <E> the type of execution context
  */
-public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends MapperOutput<O, P>, P, E> implements TimingProbe {
+public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends MapperOutput<O, P>, P, E>
+    implements TimingProbe {
     private static final Logger LOGGER = LogManager.getLogger();
 
     /** Stores the TimingProbeConfig from the TimingProbeEnabler constructor parameter. */
@@ -37,26 +38,23 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
 
     /**
      * Constructs a new instance from the given parameters.
-     *
      * <p>
      * Invoke {@link #initialize()} afterwards.
      *
-     * @param timingProbeEnabler  the configuration that enables testing with the timing probe
-     * @param alphabetBuilder     the builder of the alphabet
-     * @param sulBuilder          the builder of the SUL
+     * @param timingProbeEnabler the configuration that enables testing with the timing probe
+     * @param alphabetBuilder    the builder of the alphabet
+     * @param sulBuilder         the builder of the SUL
      */
     public TimingProbeStandard(
         TimingProbeEnabler timingProbeEnabler,
         AlphabetBuilder<I> alphabetBuilder,
-        SULBuilder<I, O, E> sulBuilder
-    ) {
+        SULBuilder<I, O, E> sulBuilder) {
         this.timingProbeConfig = timingProbeEnabler.getTimingProbeConfig();
         this.alphabetBuilder = alphabetBuilder;
 
         if (timingProbeConfig.getProbeCmd() != null) { // inlined isActive()
             this.probeTestRunner = new ProbeTestRunner<>(
-                timingProbeEnabler, alphabetBuilder, sulBuilder
-            );
+                timingProbeEnabler, alphabetBuilder, sulBuilder);
         }
     }
 
@@ -65,7 +63,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * <p>
      * It initializes the {@link #probeTestRunner} if the probe is active.
      *
-     * @return  the same instance
+     * @return the same instance
      */
     public TimingProbeStandard<I, O, P, E> initialize() {
         if (isActive() && this.probeTestRunner != null) {
@@ -102,11 +100,13 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
                 }
             }
 
-        } catch (ProbeException | IOException | FormatException | AlphabetSerializerException e) {
+        }
+        catch (ProbeException | IOException | FormatException | AlphabetSerializerException e) {
             LOGGER.error(e.getMessage());
             e.printStackTrace();
 
-        } finally {
+        }
+        finally {
             probeTestRunner.terminate();
         }
     }
@@ -118,18 +118,18 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * parameters to the probe high value of {@link #timingProbeConfig}
      * and then finding the first value that leads to deterministic results.
      *
-     * @return  the map from commands to lowest timing probe values
+     * @return                 the map from commands to lowest timing probe values
      *
-     * @throws IOException      from {@link ProbeTestRunner#isNonDeterministic(boolean)} or
-     *                          from {@link #findProbeLimitRange(String)}
-     * @throws FormatException  if an invalid format was encountered
-     * @throws ProbeException   if non-determinism is found at max timing values
+     * @throws IOException     from {@link ProbeTestRunner#isNonDeterministic(boolean)} or
+     *                             from {@link #findProbeLimitRange(String)}
+     * @throws FormatException if an invalid format was encountered
+     * @throws ProbeException  if non-determinism is found at max timing values
      */
     public Map<String, Integer> findDeterministicTimesValues() throws IOException, FormatException, ProbeException {
         Map<String, Integer> map = new HashMap<>();
         String[] cmds = timingProbeConfig.getProbeCmd().split(",", -1);
 
-        for (String cmd : cmds) {
+        for (String cmd: cmds) {
             setTimingParameter(cmd, timingProbeConfig.getProbeHi());
         }
 
@@ -141,7 +141,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
         Integer bestTime;
         ProbeLimitRange probeLimitRange;
 
-        for (String cmd : cmds) {
+        for (String cmd: cmds) {
             probeLimitRange = findProbeLimitRange(cmd);
 
             if (probeLimitRange.isHiDeterministic()) {
@@ -160,7 +160,8 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
     /**
      * Checks if this TimingProbe is active.
      *
-     * @return  {@code true} if there is at least one specified probe command in {@link #timingProbeConfig}
+     * @return {@code true} if there is at least one specified probe command in
+     *             {@link #timingProbeConfig}
      */
     public boolean isActive() {
         return timingProbeConfig.getProbeCmd() != null;
@@ -169,7 +170,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
     /**
      * Checks the validity of each specified probe command in {@link #timingProbeConfig}.
      *
-     * @return  {@code true} if all specified commands {@link #timingProbeConfig} are valid
+     * @return {@code true} if all specified commands {@link #timingProbeConfig} are valid
      */
     public boolean isValid() {
         boolean success = true;
@@ -190,7 +191,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
 
         String[] cmds = timingProbeConfig.getProbeCmd().split(",", -1);
 
-        for (String cmd : cmds) {
+        for (String cmd: cmds) {
             if (!isValid(cmd)) {
                 LOGGER.warn("Invalid probe command: {}", cmd);
                 success = false;
@@ -203,7 +204,8 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
     /**
      * Checks the validity of the provided command.
      *
-     * @param cmd  the command to be checked
+     * @param  cmd the command to be checked
+     *
      * @return     {@code true} if the given command is valid
      */
     public boolean isValid(String cmd) {
@@ -212,7 +214,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
         }
 
         // check if the command is an alphabet input
-        for (I in : probeTestRunner.getAlphabet()) {
+        for (I in: probeTestRunner.getAlphabet()) {
             if (in.toString().contentEquals(cmd)) {
                 return true;
             }
@@ -226,18 +228,19 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * <p>
      * Specifically in the returned ProbeLimitRange:
      * <ul>
-     * <li> hi is set to the first encountered deterministic value
-     *      (starts from probeLo in {@link #timingProbeConfig} and doubles in each iteration)
-     * <li> lo is set to the last encountered non-deterministic value
+     * <li>hi is set to the first encountered deterministic value
+     * (starts from probeLo in {@link #timingProbeConfig} and doubles in each iteration)
+     * <li>lo is set to the last encountered non-deterministic value
      * </ul>
      *
-     * @param cmd  the command for which the limits will be found
-     * @return     the ProbeLimitRange holding the range found. If a deterministic
-     *             value for hi is found on the first try then this is reflected in
-     *             the in the hiDeterministic variable of ProbeLimitRange
+     * @param  cmd             the command for which the limits will be found
      *
-     * @throws IOException      from {@link ProbeTestRunner#isNonDeterministic(boolean)}
-     * @throws FormatException  if an invalid format was encountered
+     * @return                 the ProbeLimitRange holding the range found. If a deterministic
+     *                             value for hi is found on the first try then this is reflected in
+     *                             the in the hiDeterministic variable of ProbeLimitRange
+     *
+     * @throws IOException     from {@link ProbeTestRunner#isNonDeterministic(boolean)}
+     * @throws FormatException if an invalid format was encountered
      */
     protected ProbeLimitRange findProbeLimitRange(String cmd) throws IOException, FormatException {
         Integer probeLo = timingProbeConfig.getProbeLo();
@@ -285,12 +288,13 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * The condition of the search is {@code hi - lo > probeTol},
      * where probeTol is the one specified in {@link #timingProbeConfig}.
      *
-     * @param cmd              the command for which the final value will be found
-     * @param probeLimitRange  the  ProbeLimitRange holding the search interval
+     * @param  cmd             the command for which the final value will be found
+     * @param  probeLimitRange the ProbeLimitRange holding the search interval
+     *
      * @return                 the found deterministic timing probe value
      *
-     * @throws IOException      from {@link ProbeTestRunner#isNonDeterministic(boolean)}
-     * @throws FormatException  if an invalid format was encountered
+     * @throws IOException     from {@link ProbeTestRunner#isNonDeterministic(boolean)}
+     * @throws FormatException if an invalid format was encountered
      */
     protected Integer binarySearch(String cmd, ProbeLimitRange probeLimitRange) throws IOException, FormatException {
         Integer hi = probeLimitRange.getHi();
@@ -319,8 +323,8 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
      * In case the command is an alphabet input, then the extendedWait parameter
      * of this input is set.
      *
-     * @param cmd   the command, whose timing parameter will change
-     * @param time  the time to be set
+     * @param cmd  the command, whose timing parameter will change
+     * @param time the time to be set
      */
     protected void setTimingParameter(String cmd, Integer time) {
         Long timeL = time == null ? Long.valueOf(0) : Long.valueOf(time);
@@ -335,7 +339,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
             probeTestRunner.getSULConfig().setStartWait(timeL);
 
         } else {
-            for (I in : probeTestRunner.getAlphabet()) {
+            for (I in: probeTestRunner.getAlphabet()) {
                 if (in.toString().contentEquals(cmd)) {
                     found = true;
                     in.setExtendedWait(timeL);
@@ -367,10 +371,10 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
         /**
          * Constructs a new instance from the given parameters.
          *
-         * @param lo               the low value of the range
-         * @param hi               the high value of the range
-         * @param hiDeterministic  {@code true} if the provided hi is known to be
-         *                         a deterministic value
+         * @param lo              the low value of the range
+         * @param hi              the high value of the range
+         * @param hiDeterministic {@code true} if the provided hi is known to be
+         *                            a deterministic value
          */
         public ProbeLimitRange(Integer lo, Integer hi, boolean hiDeterministic) {
             this.lo = lo;
@@ -381,7 +385,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
         /**
          * Returns the stored value of {@link #lo}.
          *
-         * @return  the stored value of {@link #lo}
+         * @return the stored value of {@link #lo}
          */
         public Integer getLo() {
             return lo;
@@ -390,7 +394,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
         /**
          * Returns the stored value of {@link #hi}.
          *
-         * @return  the stored value of {@link #hi}
+         * @return the stored value of {@link #hi}
          */
         public Integer getHi() {
             return hi;
@@ -399,7 +403,7 @@ public class TimingProbeStandard<I extends MapperInput<O, P, E>, O extends Mappe
         /**
          * Returns the stored value of {@link #hiDeterministic}.
          *
-         * @return  the stored value of {@link #hiDeterministic}
+         * @return the stored value of {@link #hiDeterministic}
          */
         public boolean isHiDeterministic() {
             return hiDeterministic;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfig.java
@@ -12,7 +12,7 @@ public interface TimingProbeConfig {
      * <p>
      * Default value: null.
      *
-     * @return  a single command or comma-separated commands
+     * @return a single command or comma-separated commands
      */
     default String getProbeCmd() {
         return null;
@@ -23,7 +23,7 @@ public interface TimingProbeConfig {
      * <p>
      * Default value: 0.
      *
-     * @return  the lowest timing value of probe
+     * @return the lowest timing value of probe
      */
     default Integer getProbeLo() {
         return 0;
@@ -34,7 +34,7 @@ public interface TimingProbeConfig {
      * <p>
      * Default value: 1000.
      *
-     * @return  the highest timing value of probe
+     * @return the highest timing value of probe
      */
     default Integer getProbeHi() {
         return 1000;
@@ -48,7 +48,7 @@ public interface TimingProbeConfig {
      * <p>
      * Default value: 10.
      *
-     * @return  the search tolerance value of probe
+     * @return the search tolerance value of probe
      */
     default Integer getProbeTol() {
         return 10;
@@ -59,7 +59,7 @@ public interface TimingProbeConfig {
      * <p>
      * Default value: null.
      *
-     * @return  the output file to store the modified alphabet
+     * @return the output file to store the modified alphabet
      */
     default String getProbeExport() {
         return null;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigStandard.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigStandard.java
@@ -66,12 +66,12 @@ public class TimingProbeConfigStandard implements TimingProbeConfig {
     /**
      * Constructor
      */
-    public TimingProbeConfigStandard() { }
+    public TimingProbeConfigStandard() {}
 
     /**
      * Returns the value of {@link #probeCmd}.
      *
-     * @return  the value of {@link #probeCmd}
+     * @return the value of {@link #probeCmd}
      */
     @Override
     public String getProbeCmd() {
@@ -81,7 +81,7 @@ public class TimingProbeConfigStandard implements TimingProbeConfig {
     /**
      * Returns the value of {@link #probeLo}.
      *
-     * @return  the value of {@link #probeLo}
+     * @return the value of {@link #probeLo}
      */
     @Override
     public Integer getProbeLo() {
@@ -91,7 +91,7 @@ public class TimingProbeConfigStandard implements TimingProbeConfig {
     /**
      * Returns the value of {@link #probeHi}.
      *
-     * @return  the value of {@link #probeHi}
+     * @return the value of {@link #probeHi}
      */
     @Override
     public Integer getProbeHi() {
@@ -101,7 +101,7 @@ public class TimingProbeConfigStandard implements TimingProbeConfig {
     /**
      * Returns the value of {@link #probeTol}.
      *
-     * @return  the value of {@link #probeTol}
+     * @return the value of {@link #probeTol}
      */
     @Override
     public Integer getProbeTol() {
@@ -111,7 +111,7 @@ public class TimingProbeConfigStandard implements TimingProbeConfig {
     /**
      * Returns the value of {@link #probeExport}.
      *
-     * @return  the value of {@link #probeExport}
+     * @return the value of {@link #probeExport}
      */
     @Override
     public String getProbeExport() {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeEnabler.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeEnabler.java
@@ -10,7 +10,7 @@ public interface TimingProbeEnabler extends TestRunnerEnabler {
     /**
      * Returns the TimingProbeConfig.
      *
-     * @return  the TimingProbeConfig
+     * @return the TimingProbeConfig
      */
     TimingProbeConfig getTimingProbeConfig();
 }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/AutomatonUtils.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/AutomatonUtils.java
@@ -20,21 +20,20 @@ public class AutomatonUtils {
     /**
      * Constructor
      */
-    public AutomatonUtils() { }
+    public AutomatonUtils() {}
 
     /**
      * Provides all the reachable states from the initial state of the
      * automaton.
      *
-     * @param <S>              the type of states
-     * @param <I>              the type of inputs
-     *
-     * @param automaton        the automaton to be searched
-     * @param inputs           the inputs to be used
-     * @param reachableStates  the modifiable collection to be used for
-     *                         storing the reachable states
+     * @param <S>             the type of states
+     * @param <I>             the type of inputs
+     * @param automaton       the automaton to be searched
+     * @param inputs          the inputs to be used
+     * @param reachableStates the modifiable collection to be used for
+     *                            storing the reachable states
      */
-    public static <S,I> void reachableStates(
+    public static <S, I> void reachableStates(
         UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
         Collection<I> inputs, Collection<S> reachableStates) {
 
@@ -49,17 +48,16 @@ public class AutomatonUtils {
      * Provides all the reachable states from a given state of the
      * automaton.
      *
-     * @param <S>              the type of states
-     * @param <I>              the type of inputs
-     *
-     * @param automaton        the automaton to be searched
-     * @param inputs           the inputs to be used
-     * @param fromState        the state from which the search will start
-     * @param reachableStates  the modifiable collection to be used for
-     *                         storing the reachable states
+     * @param <S>             the type of states
+     * @param <I>             the type of inputs
+     * @param automaton       the automaton to be searched
+     * @param inputs          the inputs to be used
+     * @param fromState       the state from which the search will start
+     * @param reachableStates the modifiable collection to be used for
+     *                            storing the reachable states
      */
-    public static <S,I> void reachableStates(
-        UniversalDeterministicAutomaton<S, I, ?, ?, ?>  automaton,
+    public static <S, I> void reachableStates(
+        UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
         Collection<I> inputs, S fromState, Collection<S> reachableStates) {
 
         Queue<S> toVisit = new ArrayDeque<>();
@@ -73,8 +71,8 @@ public class AutomatonUtils {
             visited.add(state);
             reachable.add(state);
 
-            for (I input : inputs) {
-                for (S nextState : automaton.getSuccessors(state, input)) {
+            for (I input: inputs) {
+                for (S nextState: automaton.getSuccessors(state, input)) {
                     if (!visited.contains(nextState)) {
                         toVisit.add(nextState);
                     }
@@ -90,20 +88,19 @@ public class AutomatonUtils {
      * target state of the automaton using a predecessor map generated with
      * {@link #generatePredecessorMap}.
      *
-     * @param <S>          the type of states
-     * @param <I>          the type of inputs
-     *
-     * @param automaton    the automaton to be used
-     * @param inputs       the inputs to be used
-     * @param targetState  the target state where the words will lead to
-     * @param words        the modifiable collection that will be used to
-     *                     store the resulting words
+     * @param <S>         the type of states
+     * @param <I>         the type of inputs
+     * @param automaton   the automaton to be used
+     * @param inputs      the inputs to be used
+     * @param targetState the target state where the words will lead to
+     * @param words       the modifiable collection that will be used to
+     *                        store the resulting words
      */
-    public static <S,I> void wordsToTargetState(
-        UniversalDeterministicAutomaton<S, I, ?, ?, ?>  automaton,
+    public static <S, I> void wordsToTargetState(
+        UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
         Collection<I> inputs, S targetState, Collection<Word<I>> words) {
 
-        PredMap<S,I> predMap = generatePredecessorMap(automaton, inputs);
+        PredMap<S, I> predMap = generatePredecessorMap(automaton, inputs);
         wordsToTargetState(automaton, inputs, targetState, predMap, words);
     }
 
@@ -111,22 +108,21 @@ public class AutomatonUtils {
      * Provides all the words of inputs that lead from the initial state to the
      * target state of the automaton using the provided predecessor map.
      *
-     * @param <S>          the type of states
-     * @param <I>          the type of inputs
-     *
-     * @param automaton    the automaton to be used
-     * @param inputs       the inputs to be used
-     * @param targetState  the target state where the words will lead to
-     * @param map          the predecessor map to be used
-     * @param words        the modifiable collection that will be used to
-     *                     store the resulting words
+     * @param <S>         the type of states
+     * @param <I>         the type of inputs
+     * @param automaton   the automaton to be used
+     * @param inputs      the inputs to be used
+     * @param targetState the target state where the words will lead to
+     * @param map         the predecessor map to be used
+     * @param words       the modifiable collection that will be used to
+     *                        store the resulting words
      */
-    public static <S,I> void wordsToTargetState(
-        UniversalDeterministicAutomaton<S, I, ?, ?, ?>  automaton,
-        Collection<I> inputs, S targetState, PredMap<S,I> map,
+    public static <S, I> void wordsToTargetState(
+        UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
+        Collection<I> inputs, S targetState, PredMap<S, I> map,
         Collection<Word<I>> words) {
 
-        Queue<VisitStruct<S,I>> toVisit = new ArrayDeque<>();
+        Queue<VisitStruct<S, I>> toVisit = new ArrayDeque<>();
         Set<S> hs = new HashSet<>();
 
         hs.add(targetState);
@@ -134,13 +130,13 @@ public class AutomatonUtils {
 
         while (!toVisit.isEmpty()) {
             VisitStruct<S, I> visitStruct = toVisit.poll();
-            Collection<PredStruct<S,I>> predStructs = map.get(visitStruct.getState());
+            Collection<PredStruct<S, I>> predStructs = map.get(visitStruct.getState());
 
             if (predStructs == null) {
                 continue;
             }
 
-            for (PredStruct<S,I> predStruct : predStructs) {
+            for (PredStruct<S, I> predStruct: predStructs) {
                 if (predStruct.getState().equals(automaton.getInitialState())) {
                     words.add(Word.fromLetter(predStruct.getInput()).concat(visitStruct.getWord()));
                     continue;
@@ -162,20 +158,20 @@ public class AutomatonUtils {
      * Generates a {@link AutomatonUtils.PredMap} of the automaton using the
      * given inputs.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param  <S>       the type of states
+     * @param  <I>       the type of inputs
+     * @param  automaton the automaton to be used
+     * @param  inputs    the inputs to be used
      *
-     * @param automaton  the automaton to be used
-     * @param inputs     the inputs to be used
      * @return           the generated {@link AutomatonUtils.PredMap}
      */
-    public static <S,I> PredMap<S,I> generatePredecessorMap(
+    public static <S, I> PredMap<S, I> generatePredecessorMap(
         UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
         Collection<I> inputs) {
 
-        PredMap<S,I> predMap = new PredMap<>();
-        for (S s : automaton.getStates()) {
-            for (I input : inputs) {
+        PredMap<S, I> predMap = new PredMap<>();
+        for (S s: automaton.getStates()) {
+            for (I input: inputs) {
                 S succ = automaton.getSuccessor(s, input);
                 if (succ != null) {
                     predMap.putIfAbsent(succ, new LinkedHashSet<>());
@@ -190,10 +186,10 @@ public class AutomatonUtils {
      * Contains information about a specific state, like the word leading to it
      * and the states that are visited from it.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param <S> the type of states
+     * @param <I> the type of inputs
      */
-    protected static class VisitStruct<S,I> {
+    protected static class VisitStruct<S, I> {
 
         /** Stores the constructor parameter. */
         protected S state;
@@ -207,9 +203,9 @@ public class AutomatonUtils {
         /**
          * Constructs a new instance from the given parameters.
          *
-         * @param state    the specified state
-         * @param word     the word leading to this state
-         * @param visited  the set of states that have been visited
+         * @param state   the specified state
+         * @param word    the word leading to this state
+         * @param visited the set of states that have been visited
          */
         public VisitStruct(S state, Word<I> word, Set<S> visited) {
             this.state = state;
@@ -220,7 +216,7 @@ public class AutomatonUtils {
         /**
          * Returns the word leading to the state.
          *
-         * @return  the word leading to the state
+         * @return the word leading to the state
          */
         public Word<I> getWord() {
             return word;
@@ -229,7 +225,7 @@ public class AutomatonUtils {
         /**
          * Returns the state provided in the constructor.
          *
-         * @return  the state provided in the constructor
+         * @return the state provided in the constructor
          */
         public S getState() {
             return state;
@@ -238,9 +234,10 @@ public class AutomatonUtils {
         /**
          * Checks if the given state is contained in the visited set of states.
          *
-         * @param state  the state that should be checked
+         * @param  state the state that should be checked
+         *
          * @return       {@code true} if the given state is contained in
-         *               the visited set of states {@link #visited}
+         *                   the visited set of states {@link #visited}
          */
         public boolean hasVisited(S state) {
             return visited.contains(state);
@@ -249,31 +246,29 @@ public class AutomatonUtils {
         /**
          * Returns the set of visited states.
          *
-         * @return  the set of visited states
+         * @return the set of visited states
          */
         public Set<S> getVisited() {
             return visited;
         }
     }
 
-
     /**
      * Maps a state of an automaton to a collection of
      * {@link AutomatonUtils.PredStruct}.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param <S> the type of states
+     * @param <I> the type of inputs
      */
-    public static class PredMap<S,I> extends LinkedHashMap<S, Collection<PredStruct<S, I>>> {
+    public static class PredMap<S, I> extends LinkedHashMap<S, Collection<PredStruct<S, I>>> {
         @Serial
         private static final long serialVersionUID = 1L;
 
         /**
          * Constructor
          */
-        public PredMap() { }
+        public PredMap() {}
     }
-
 
     /**
      * Holds information about a predecessor state of a specified state and
@@ -282,10 +277,10 @@ public class AutomatonUtils {
      * The specified state and this class are used in
      * {@link AutomatonUtils.PredMap}.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param <S> the type of states
+     * @param <I> the type of inputs
      */
-    public static class PredStruct<S,I> {
+    public static class PredStruct<S, I> {
 
         /** Stores the constructor parameter. */
         protected S state;
@@ -296,9 +291,9 @@ public class AutomatonUtils {
         /**
          * Constructs a new instance from the given parameters.
          *
-         * @param state  the predecessor state of a specified state
-         * @param input  the input from the predecessor state to the specified
-         *               state
+         * @param state the predecessor state of a specified state
+         * @param input the input from the predecessor state to the specified
+         *                  state
          */
         public PredStruct(S state, I input) {
             this.state = state;
@@ -308,7 +303,7 @@ public class AutomatonUtils {
         /**
          * Returns the predecessor state.
          *
-         * @return  the predecessor state
+         * @return the predecessor state
          */
         public S getState() {
             return state;
@@ -317,7 +312,7 @@ public class AutomatonUtils {
         /**
          * Returns the input from the predecessor state to the specified state.
          *
-         * @return  the input from the predecessor state to the specified state
+         * @return the input from the predecessor state to the specified state
          */
         public I getInput() {
             return input;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/CleanupTasks.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/CleanupTasks.java
@@ -21,7 +21,7 @@ public class CleanupTasks {
     /**
      * Adds a new runnable task.
      *
-     * @param runnable  task to be run during {@link #execute()}
+     * @param runnable task to be run during {@link #execute()}
      */
     public void submit(Runnable runnable) {
         tasks.add(runnable);
@@ -31,7 +31,7 @@ public class CleanupTasks {
      * Executes the stored {@link #tasks} consecutively.
      */
     public void execute() {
-        for (Runnable task : tasks) {
+        for (Runnable task: tasks) {
             task.run();
         }
     }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DFAUtils.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DFAUtils.java
@@ -197,23 +197,6 @@ public class DFAUtils extends AutomatonUtils {
     public static <S,I> Word<I> findShortestAcceptingWord(DFA<S, I> automaton, Collection<I> alphabet) {
 
         return DeterministicEquivalenceTest.findSeparatingWord(DFAs.complete(automaton, new ListAlphabet<>(new ArrayList<>(alphabet))), buildRejecting(alphabet), alphabet);
-
-        /*
-        ModelExplorer<S, I> explorer = new ModelExplorer<S, I>(automaton, inputs);
-        List<S> acceptingStates = automaton.getStates().stream()
-                .filter(s -> automaton.isAccepting(s))
-                .collect(Collectors.toList());
-        if (!acceptingStates.isEmpty()) {
-            SearchConfig config = new SearchConfig();
-            config.setStateVisitBound(1);
-            Iterable<Word<I>> words = explorer.wordsToTargetStates(acceptingStates, config);
-            Iterator<Word<I>> iter = words.iterator();
-            if (iter.hasNext()) {
-                return iter.next();
-            }
-        }
-        return null;
-        */
     }
 
     /**

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DFAUtils.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DFAUtils.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 /**
  * Collection of DFA automata related methods.
  */
@@ -30,7 +29,7 @@ public class DFAUtils extends AutomatonUtils {
     /**
      * Constructor
      */
-    public DFAUtils() { }
+    public DFAUtils() {}
 
     /**
      * Converts a deterministic Mealy Machine to an equivalent DFA.
@@ -39,40 +38,40 @@ public class DFAUtils extends AutomatonUtils {
      * input and output mappings. An output can be mapped to zero, one or
      * several labels (which will be chained one after the other in the model).
      *
-     * @param <MI>           the type of Mealy Machine inputs
-     * @param <MS>           the type of Mealy Machine states
-     * @param <MO>           the type of Mealy Machine outputs
-     * @param <DI>           the type of DFA inputs
-     * @param <DS>           the type of DFA states
-     * @param <DA>           the type of DFA automaton
+     * @param  <MI>          the type of Mealy Machine inputs
+     * @param  <MS>          the type of Mealy Machine states
+     * @param  <MO>          the type of Mealy Machine outputs
+     * @param  <DI>          the type of DFA inputs
+     * @param  <DS>          the type of DFA states
+     * @param  <DA>          the type of DFA automaton
+     * @param  mealy         the Mealy Machine to be converted
+     * @param  inputs        the inputs of the Mealy Machine
+     * @param  labels        the labels used during the completion of the DFA
+     * @param  inputMapping  the mapping from Mealy Machine inputs to DFA
+     *                           alphabet symbols
+     * @param  outputMapping the mapping from Pairs of Mealy Machine state
+     *                           and output to a list of DFA alphabet symbols
+     * @param  stateMapping  the modifiable mapping from Mealy Machine states
+     *                           to DFA states, which is populated after the conversion
+     * @param  dfa           the modifiable DFA which is altered and also returned
      *
-     * @param mealy          the Mealy Machine to be converted
-     * @param inputs         the inputs of the Mealy Machine
-     * @param labels         the labels used during the completion of the DFA
-     * @param inputMapping   the mapping from Mealy Machine inputs to DFA
-     *                       alphabet symbols
-     * @param outputMapping  the mapping from Pairs of Mealy Machine state
-     *                       and output to a list of DFA alphabet symbols
-     * @param stateMapping   the modifiable mapping from Mealy Machine states
-     *                       to DFA states, which is populated after the conversion
-     * @param dfa            the modifiable DFA which is altered and also returned
-     *
-     * @return   The provided parameter dfa after modification that led to an
-     *           alphabet-complete DFA non-minimized so as to resemble the original
-     *           model. Minimization can be achieved via minimize methods in
-     *           net.automatalib.util.automata.Automata
+     * @return               The provided parameter dfa after modification that led to an
+     *                           alphabet-complete DFA non-minimized so as to resemble the original
+     *                           model. Minimization can be achieved via minimize methods in
+     *                           net.automatalib.util.automata.Automata
      */
     public static <MI, MS, MO, DI, DS, DA extends MutableDFA<DS, DI>> DA convertMealyToDFA(
         MealyMachine<MS, MI, ?, MO> mealy, Collection<MI> inputs, Collection<DI> labels,
-        Mapping<MI,DI> inputMapping, Mapping<Pair<MS,MO>, List<DI>> outputMapping,
-        Map<MS,DS> stateMapping, DA dfa) {
+        Mapping<MI, DI> inputMapping, Mapping<Pair<MS, MO>, List<DI>> outputMapping,
+        Map<MS, DS> stateMapping, DA dfa) {
 
         MS mealyState = mealy.getInitialState();
         Map<MS, DS> inputStateMapping = new HashMap<>();
         DS dfaState = dfa.addInitialState(true);
         inputStateMapping.put(mealyState, dfaState);
         Set<MS> visited = new HashSet<>();
-        convertMealyToDFA(mealyState, dfaState, mealy, inputs, inputMapping, outputMapping, inputStateMapping, visited, dfa);
+        convertMealyToDFA(mealyState, dfaState, mealy, inputs, inputMapping, outputMapping, inputStateMapping, visited,
+            dfa);
         MutableDFAs.complete(dfa, labels, false, false);
         stateMapping.putAll(inputStateMapping);
         return dfa;
@@ -85,37 +84,36 @@ public class DFAUtils extends AutomatonUtils {
      * input and output mappings. An output can be mapped to zero, one or
      * several labels (which will be chained one after the other in the model).
      *
-     * @param <MI>               the type of Mealy Machine inputs
-     * @param <MS>               the type of Mealy Machine states
-     * @param <MO>               the type of Mealy Machine outputs
-     * @param <DI>               the type of DFA inputs
-     * @param <DS>               the type of DFA states
-     * @param <DA>               the type of DFA automaton
-     *
-     * @param mealyState         the initial Mealy Machine state
-     * @param dfaState           the initial DFA state
-     * @param mealy              the Mealy Machine to be converted
-     * @param inputs             the inputs of the Mealy Machine
-     * @param inputMapping       the mapping from Mealy Machine inputs to DFA
-     *                           alphabet symbols
-     * @param outputMapping      the mapping from Pairs of Mealy Machine state
-     *                           and output to a list of DFA alphabet symbols
-     * @param inputStateMapping  the modifiable mapping from Mealy Machine states
-     *                           to DFA states, which is populated after the conversion
-     * @param visited            a modifiable set for the visited Mealy Machine states
-     * @param dfa                the modifiable DFA which is altered
+     * @param <MI>              the type of Mealy Machine inputs
+     * @param <MS>              the type of Mealy Machine states
+     * @param <MO>              the type of Mealy Machine outputs
+     * @param <DI>              the type of DFA inputs
+     * @param <DS>              the type of DFA states
+     * @param <DA>              the type of DFA automaton
+     * @param mealyState        the initial Mealy Machine state
+     * @param dfaState          the initial DFA state
+     * @param mealy             the Mealy Machine to be converted
+     * @param inputs            the inputs of the Mealy Machine
+     * @param inputMapping      the mapping from Mealy Machine inputs to DFA
+     *                              alphabet symbols
+     * @param outputMapping     the mapping from Pairs of Mealy Machine state
+     *                              and output to a list of DFA alphabet symbols
+     * @param inputStateMapping the modifiable mapping from Mealy Machine states
+     *                              to DFA states, which is populated after the conversion
+     * @param visited           a modifiable set for the visited Mealy Machine states
+     * @param dfa               the modifiable DFA which is altered
      */
     protected static <MI, MS, MO, DI, DS, DA extends MutableDFA<DS, DI>> void convertMealyToDFA(
         MS mealyState, DS dfaState, MealyMachine<MS, MI, ?, MO> mealy,
         Collection<MI> inputs, Mapping<MI, DI> inputMapping,
-        Mapping<Pair<MS,MO>, List<DI>> outputMapping,
+        Mapping<Pair<MS, MO>, List<DI>> outputMapping,
         Map<MS, DS> inputStateMapping, Set<MS> visited, DA dfa) {
 
         inputStateMapping.put(mealyState, dfaState);
         DS inputState = dfaState;
         visited.add(mealyState);
         DS nextInputState;
-        for (MI input : inputs) {
+        for (MI input: inputs) {
             DI inputLabel = inputMapping.get(input);
             MO output = mealy.getOutput(mealyState, input);
             MS nextMealyState = mealy.getSuccessor(mealyState, input);
@@ -127,7 +125,7 @@ public class DFAUtils extends AutomatonUtils {
             }
 
             Collection<DI> outputLabels = outputMapping.get(Pair.of(mealyState, output));
-            List<DI> labels = new ArrayList<>(outputLabels.size()+1);
+            List<DI> labels = new ArrayList<>(outputLabels.size() + 1);
             labels.add(inputLabel);
             labels.addAll(outputLabels);
 
@@ -143,7 +141,8 @@ public class DFAUtils extends AutomatonUtils {
             dfa.addTransition(lastState, labels.get(labels.size() - 1), nextInputState);
 
             if (!visited.contains(nextMealyState)) {
-                convertMealyToDFA(nextMealyState, nextInputState, mealy, inputs, inputMapping, outputMapping, inputStateMapping, visited, dfa);
+                convertMealyToDFA(nextMealyState, nextInputState, mealy, inputs, inputMapping, outputMapping,
+                    inputStateMapping, visited, dfa);
             }
         }
     }
@@ -152,15 +151,15 @@ public class DFAUtils extends AutomatonUtils {
      * Generates a rejecting DFA that consists of a single non-accepting state
      * with all inputs causing self-loop transitions from/to this single state.
      *
-     * @param <I>       the type of inputs
+     * @param  <I>      the type of inputs
+     * @param  alphabet the alphabet of the DFA
      *
-     * @param alphabet  the alphabet of the DFA
      * @return          the rejecting DFA
      */
-    public static <I> DFA<?,I> buildRejecting(Collection<I> alphabet) {
+    public static <I> DFA<?, I> buildRejecting(Collection<I> alphabet) {
         FastDFA<I> rejectingModel = new FastDFA<>(new ListAlphabet<>(new ArrayList<>(alphabet)));
         FastDFAState rej = rejectingModel.addInitialState(false);
-        for (I label : alphabet) {
+        for (I label: alphabet) {
             rejectingModel.addTransition(rej, label, rej);
         }
         return rejectingModel;
@@ -170,15 +169,15 @@ public class DFAUtils extends AutomatonUtils {
      * Determines if there is any path that leads from a given state of the DFA
      * after any number of inputs to an accepting state of the DFA.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param  <S>       the type of states
+     * @param  <I>       the type of inputs
+     * @param  state     the state from which the search will start
+     * @param  automaton the DFA automaton
+     * @param  alphabet  the alphabet of the DFA
      *
-     * @param state      the state from which the search will start
-     * @param automaton  the DFA automaton
-     * @param alphabet   the alphabet of the DFA
      * @return           {@code true} if there is such a path
      */
-    public static <S,I> boolean hasAcceptingPaths(S state, DFA<S, I> automaton, Collection<I> alphabet) {
+    public static <S, I> boolean hasAcceptingPaths(S state, DFA<S, I> automaton, Collection<I> alphabet) {
         Set<S> reachableStates = new HashSet<>();
         reachableStates(automaton, alphabet, state, reachableStates);
         return reachableStates.stream().anyMatch(automaton::isAccepting);
@@ -187,35 +186,37 @@ public class DFAUtils extends AutomatonUtils {
     /**
      * Finds the shortest accepting word in a DFA.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param  <S>       the type of states
+     * @param  <I>       the type of inputs
+     * @param  automaton the DFA automaton
+     * @param  alphabet  the alphabet of the DFA
      *
-     * @param automaton  the DFA automaton
-     * @param alphabet   the alphabet of the DFA
      * @return           the word of alphabet symbols or null if there is no such word
      */
-    public static <S,I> Word<I> findShortestAcceptingWord(DFA<S, I> automaton, Collection<I> alphabet) {
+    public static <S, I> Word<I> findShortestAcceptingWord(DFA<S, I> automaton, Collection<I> alphabet) {
 
-        return DeterministicEquivalenceTest.findSeparatingWord(DFAs.complete(automaton, new ListAlphabet<>(new ArrayList<>(alphabet))), buildRejecting(alphabet), alphabet);
+        return DeterministicEquivalenceTest.findSeparatingWord(
+            DFAs.complete(automaton, new ListAlphabet<>(new ArrayList<>(alphabet))), buildRejecting(alphabet),
+            alphabet);
     }
 
     /**
      * Finds the shortest non-accepting prefix of a word of alphabet symbols
      * in a DFA.
      *
-     * @param <S>        the type of states
-     * @param <I>        the type of inputs
+     * @param  <S>       the type of states
+     * @param  <I>       the type of inputs
+     * @param  automaton the DFA automaton
+     * @param  word      the word of alphabet symbols of the DFA
      *
-     * @param automaton  the DFA automaton
-     * @param word       the word of alphabet symbols of the DFA
      * @return           the desired prefix of the word or null if there is no
-     *                   such prefix
+     *                       such prefix
      */
-    public static <S,I> Word<I> findShortestNonAcceptingPrefix(DFA<S, I> automaton, Word<I> word) {
+    public static <S, I> Word<I> findShortestNonAcceptingPrefix(DFA<S, I> automaton, Word<I> word) {
         int prefixLen = 0;
         S currState = automaton.getInitialState();
 
-        for (I input : word) {
+        for (I input: word) {
             if (currState == null || !automaton.isAccepting(currState)) {
                 return word.prefix(prefixLen);
             }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DotProcessor.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/DotProcessor.java
@@ -16,7 +16,7 @@ public class DotProcessor {
     /**
      * Constructor
      */
-    public DotProcessor() { }
+    public DotProcessor() {}
 
     /**
      * Exports the provided DOT file to PDF using the {@code dot} utility in
@@ -25,16 +25,17 @@ public class DotProcessor {
      * If the {@code dot} utility is not present in the system's PATH, then
      * a warning is logged.
      *
-     * @param dotInput  the DOT input file to be exported to PDF
+     * @param dotInput the DOT input file to be exported to PDF
      */
     public static void exportToPDF(File dotInput) {
         String dotFilename = dotInput.getAbsolutePath();
         String pdfFilename = dotFilename.endsWith(".dot") ? dotFilename.replace(".dot", ".pdf") : dotFilename + ".pdf";
 
         try {
-            String[] cmdArray = new String[]{"dot", "-Tpdf", dotFilename, "-o", pdfFilename};
+            String[] cmdArray = new String[] {"dot", "-Tpdf", dotFilename, "-o", pdfFilename};
             Runtime.getRuntime().exec(cmdArray);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             LOGGER.warn("Could not export {} to {}: {}", dotFilename, pdfFilename, e.getMessage());
         }
     }
@@ -45,7 +46,7 @@ public class DotProcessor {
      * <p>
      * If the contained DOT file is null, then a warning is logged.
      *
-     * @param learnerResult  the LearnerResult to be used
+     * @param learnerResult the LearnerResult to be used
      */
     public static void exportToPDF(LearnerResult<?> learnerResult) {
         if (learnerResult.isEmpty()) {

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ExportableResult.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ExportableResult.java
@@ -19,7 +19,7 @@ public abstract class ExportableResult {
     /**
      * Constructor
      */
-    public ExportableResult() { }
+    public ExportableResult() {}
 
     /**
      * Uses the {@link #doExport(PrintWriter)} method and closes the writer
@@ -28,7 +28,7 @@ public abstract class ExportableResult {
      * A PrintWriter instance is used to wrap the writer parameter, in case the
      * writer parameter is not an instance of PrintWriter.
      *
-     * @param writer  the writer to be used
+     * @param writer the writer to be used
      */
     public void export(Writer writer) {
         PrintWriter printWriter = writer instanceof PrintWriter pw ? pw : new PrintWriter(writer);
@@ -39,7 +39,7 @@ public abstract class ExportableResult {
     /**
      * Method to be overridden with the appropriate exporting behavior.
      *
-     * @param printWriter  the printWriter to be used
+     * @param printWriter the printWriter to be used
      */
     protected abstract void doExport(PrintWriter printWriter);
 
@@ -49,8 +49,8 @@ public abstract class ExportableResult {
      * Above and below the title is a line of {@link #TITLE_DELIM} and
      * an empty line.
      *
-     * @param title        the results' title to be printed
-     * @param printWriter  the printWriter to be used
+     * @param title       the results' title to be printed
+     * @param printWriter the printWriter to be used
      */
     protected void title(String title, PrintWriter printWriter) {
         printWriter.println();
@@ -66,8 +66,8 @@ public abstract class ExportableResult {
      * Above and below the title is a line of {@link #SECTION_TITLE_DELIM} and
      * an empty line.
      *
-     * @param title        the section title to be printed
-     * @param printWriter  the printWriter to be used
+     * @param title       the section title to be printed
+     * @param printWriter the printWriter to be used
      */
     protected void sectionTitle(String title, PrintWriter printWriter) {
         printWriter.println();
@@ -83,8 +83,8 @@ public abstract class ExportableResult {
      * The title is surrounded by ==.
      * Above and below the title is an empty line.
      *
-     * @param title        the subsection title to be printed
-     * @param printWriter  the printWriter to be used
+     * @param title       the subsection title to be printed
+     * @param printWriter the printWriter to be used
      */
     protected void subsectionTitle(String title, PrintWriter printWriter) {
         printWriter.println();
@@ -96,7 +96,7 @@ public abstract class ExportableResult {
      * Uses the {@link #doExport(PrintWriter)} and turns its output to
      * string.
      *
-     * @return  the output of {@link #doExport(PrintWriter)}
+     * @return the output of {@link #doExport(PrintWriter)}
      */
     public String exportToString() {
         StringWriter sw = new StringWriter();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/Flow.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/Flow.java
@@ -11,9 +11,9 @@ import java.util.stream.Stream;
  * word of output symbols with 1:1 correspondence between input and output symbols
  * in the words.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- * @param <F>  the type of flow
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
+ * @param <F> the type of flow
  */
 public abstract class Flow<I, O, F extends Flow<I, O, F>> {
 
@@ -42,9 +42,9 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
      * Every input in the inputWord corresponds to a single output symbol in
      * the outputWord.
      *
-     * @param inputWord   the word containing the input symbols
-     * @param outputWord  the word containing the output symbols
-     * @param fromStart   indicates if the flow starts from the initial state
+     * @param inputWord  the word containing the input symbols
+     * @param outputWord the word containing the output symbols
+     * @param fromStart  indicates if the flow starts from the initial state
      */
     public Flow(Word<I> inputWord, Word<O> outputWord, boolean fromStart) {
         this.inputWord = inputWord;
@@ -55,7 +55,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Returns {@code true} if the current instance is a valid flow.
      *
-     * @return  {@code true} if the current instance is a valid flow
+     * @return {@code true} if the current instance is a valid flow
      */
     public boolean isValid() {
         return inputWord != null
@@ -66,7 +66,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Returns the word of input symbols.
      *
-     * @return  the word of input symbols
+     * @return the word of input symbols
      */
     public Word<I> getInputWord() {
         return inputWord;
@@ -75,7 +75,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Returns the word of output symbols.
      *
-     * @return  the word of output symbols
+     * @return the word of output symbols
      */
     public Word<O> getOutputWord() {
         return outputWord;
@@ -84,7 +84,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Returns {@code true} if the flow starts from the initial state.
      *
-     * @return  {@code true} if the flow starts from the initial state
+     * @return {@code true} if the flow starts from the initial state
      */
     public boolean isFromStart() {
         return fromStart;
@@ -93,10 +93,11 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Provides the input symbol of the inputWord at the given index.
      *
-     * @param index  the index of the input symbol in the inputWord
-     * @return       the requested input symbol
+     * @param  index                     the index of the input symbol in the inputWord
      *
-     * @throws IndexOutOfBoundsException  if there is no such index
+     * @return                           the requested input symbol
+     *
+     * @throws IndexOutOfBoundsException if there is no such index
      */
     public I getInput(int index) {
         return inputWord.getSymbol(index);
@@ -105,10 +106,11 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Provides the output symbol of the outputWord at the given index.
      *
-     * @param index  the index of the output symbol in the outputWord
-     * @return       the requested output symbol
+     * @param  index                     the index of the output symbol in the outputWord
      *
-     * @throws IndexOutOfBoundsException  if there is no such index
+     * @return                           the requested output symbol
+     *
+     * @throws IndexOutOfBoundsException if there is no such index
      */
     public O getOutput(int index) {
         return outputWord.getSymbol(index);
@@ -117,7 +119,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Provides a stream of input, output symbol pairs.
      *
-     * @return  the input, output symbol pair stream
+     * @return the input, output symbol pair stream
      */
     public Stream<Pair<I, O>> getInputOutputStream() {
         Stream.Builder<Pair<I, O>> builder = Stream.builder();
@@ -130,7 +132,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Provides an iterable of input, output symbol pairs.
      *
-     * @return  the input, output symbol pair iterable
+     * @return the input, output symbol pair iterable
      */
     public Iterable<Pair<I, O>> getInputOutputIterable() {
         return getInputOutputStream().collect(Collectors.toList());
@@ -139,8 +141,9 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Appends an input and output symbol to current flow using {@link #build}.
      *
-     * @param input   the input symbol
-     * @param output  the output symbol corresponding to the input symbol
+     * @param  input  the input symbol
+     * @param  output the output symbol corresponding to the input symbol
+     *
      * @return        the flow containing the given input, output symbols
      */
     public F append(I input, O output) {
@@ -151,12 +154,13 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
      * Concatenates this flow with another flow, only if this flow starts from
      * the initial state and the other one does not using {@link #build}.
      *
-     * @param other  the other flow to be concatenated with the current one
-     * @return       the concatenated flow, consisting of both flows
+     * @param  other            the other flow to be concatenated with the current one
      *
-     * @throws RuntimeException  if the other flow starts from the initial state
-     *                           or the current one does not start from the
-     *                           initial state (indicated by {@link #fromStart})
+     * @return                  the concatenated flow, consisting of both flows
+     *
+     * @throws RuntimeException if the other flow starts from the initial state
+     *                              or the current one does not start from the
+     *                              initial state (indicated by {@link #fromStart})
      */
     public F concat(F other) {
         if (!this.isFromStart()) {
@@ -174,11 +178,12 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
      * Generates a flow that is the prefix of a given length of the
      * current flow using {@link #build}.
      *
-     * @param length  the length of the flow's prefix
-     * @return        the desired prefix-flow
+     * @param  length           the length of the flow's prefix
      *
-     * @throws RuntimeException  if the provided length is greater than the
-     *                           length of the current flow
+     * @return                  the desired prefix-flow
+     *
+     * @throws RuntimeException if the provided length is greater than the
+     *                              length of the current flow
      */
     public F prefix(int length) {
         if (length > getLength()) {
@@ -191,10 +196,11 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Builds a flow from the initial parameters, a method to be overridden.
      *
-     * @param inputWord      the word containing the input symbols
-     * @param outputWord     the word containing the output symbols
-     * @param fromStart      indicates if the flow starts from the initial state
-     * @return               the built flow
+     * @param  inputWord  the word containing the input symbols
+     * @param  outputWord the word containing the output symbols
+     * @param  fromStart  indicates if the flow starts from the initial state
+     *
+     * @return            the built flow
      */
     protected abstract F build(Word<I> inputWord, Word<O> outputWord, boolean fromStart);
 
@@ -202,8 +208,8 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
      * Returns the length of the flow, which equals to the length of either
      * the inputWord or the outputWord.
      *
-     * @return  the length of the flow, which equals to the length of either
-     *          the inputWord or the outputWord.
+     * @return the length of the flow, which equals to the length of either
+     *             the inputWord or the outputWord.
      */
     public int getLength() {
         return inputWord.length();
@@ -212,7 +218,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Provides a single-line string representation of the current flow.
      *
-     * @return  the string representation
+     * @return the string representation
      */
     public String toCompactString() {
         StringBuilder builder = new StringBuilder();
@@ -226,7 +232,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Provides a three-line string representation of the current flow.
      *
-     * @return  the string representation
+     * @return the string representation
      */
     @Override
     public String toString() {
@@ -236,7 +242,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Overrides the default method.
      *
-     * @return  the string representation of this instance
+     * @return the string representation of this instance
      */
     @Override
     public int hashCode() {
@@ -251,7 +257,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
     /**
      * Overrides the default method.
      *
-     * @return  {@code true} if this instance is equal to the provided object
+     * @return {@code true} if this instance is equal to the provided object
      */
     @Override
     public boolean equals(Object obj) {
@@ -263,7 +269,7 @@ public abstract class Flow<I, O, F extends Flow<I, O, F>> {
             return false;
         }
 
-        if (! (obj instanceof Flow)) {
+        if (!(obj instanceof Flow)) {
             return false;
         }
 

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyDotParser.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyDotParser.java
@@ -19,25 +19,27 @@ public class MealyDotParser {
     /**
      * Constructor
      */
-    public MealyDotParser() { }
+    public MealyDotParser() {}
 
     /**
      * Parses the contents of a Mealy Machine DOT file.
      *
-     * @param <S>          the type of states
-     * @param <I>          the type of inputs
-     * @param <O>          the type of outputs
-     * @param <A>          the type of automaton
-     * @param creator      the automaton creator
-     * @param inputStream  the file input stream
-     * @param processor    the input output processor
-     * @return             the parsed model instance
+     * @param  <S>             the type of states
+     * @param  <I>             the type of inputs
+     * @param  <O>             the type of outputs
+     * @param  <A>             the type of automaton
+     * @param  creator         the automaton creator
+     * @param  inputStream     the file input stream
+     * @param  processor       the input output processor
      *
-     * @throws IOException      in case of an error reading from the inputStream
-     * @throws FormatException  if an invalid format was encountered
+     * @return                 the parsed model instance
+     *
+     * @throws IOException     in case of an error reading from the inputStream
+     * @throws FormatException if an invalid format was encountered
      */
-    public static <S, I, O, A extends MutableMealyMachine<S, I, ?, O>> InputModelData<I, A>
-    parse(AutomatonCreator<A, I> creator, InputStream inputStream, MealyInputOutputProcessor<I, O> processor) throws IOException, FormatException {
+    public static <S, I, O, A extends MutableMealyMachine<S, I, ?, O>> InputModelData<I, A> parse(
+        AutomatonCreator<A, I> creator, InputStream inputStream, MealyInputOutputProcessor<I, O> processor)
+        throws IOException, FormatException {
 
         DOTInputModelDeserializer<S, I, A> parser = DOTParsers.mealy(creator, (map) -> {
             Pair<String, String> ioStringPair = DOTParsers.DEFAULT_MEALY_EDGE_PARSER.apply(map);
@@ -49,16 +51,18 @@ public class MealyDotParser {
 
     /**
      * Interface for processing input, output pairs of a Mealy Machine.
-     * @param <I>  the type of inputs
-     * @param <O>  the type of outputs
+     *
+     * @param <I> the type of inputs
+     * @param <O> the type of outputs
      */
     public interface MealyInputOutputProcessor<I, O> {
 
         /**
          * Processes the symbols of an input and an output and pairs together their symbols.
          *
-         * @param inputName   the name of the input
-         * @param outputName  the name of the output
+         * @param  inputName  the name of the input
+         * @param  outputName the name of the output
+         *
          * @return            the pair of the input and output symbols
          */
         Pair<I, O> processMealyInputOutput(String inputName, String outputName);

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyIOProcessor.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyIOProcessor.java
@@ -9,9 +9,8 @@ import java.util.LinkedHashMap;
 /**
  * Implementation of Mealy Machine input and output pair processor.
  *
- * @param <I>  the type of inputs
- * @param <O>  the type of outputs
- *
+ * @param <I> the type of inputs
+ * @param <O> the type of outputs
  */
 public class MealyIOProcessor<I, O> implements MealyDotParser.MealyInputOutputProcessor<I, O> {
 
@@ -24,8 +23,8 @@ public class MealyIOProcessor<I, O> implements MealyDotParser.MealyInputOutputPr
     /**
      * Constructs a new instance from the given parameter.
      *
-     * @param inputs         the collection of input symbols
-     * @param outputBuilder  the builder for the output symbols
+     * @param inputs        the collection of input symbols
+     * @param outputBuilder the builder for the output symbols
      */
     public MealyIOProcessor(Collection<I> inputs, OutputBuilder<O> outputBuilder) {
         this.inputMap = new LinkedHashMap<>();

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyUtils.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/MealyUtils.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 
-
 /**
  * Collection of Mealy Machine automata related methods.
  */
@@ -17,30 +16,29 @@ public class MealyUtils extends AutomatonUtils {
     /**
      * Constructor
      */
-    public MealyUtils() { }
+    public MealyUtils() {}
 
     /**
      * Provides all the outputs a Mealy Machine automaton can generate in
      * response to the given inputs.
      *
-     * @param <S>               the type of states
-     * @param <I>               the type of inputs
-     * @param <O>               the type of outputs
-     *
-     * @param automaton         the Mealy Machine automaton to be used
-     * @param inputs            the inputs of the automaton to be used
-     * @param reachableOutputs  the modifiable collection to be used for storing
-     *                          the reachable outputs
+     * @param <S>              the type of states
+     * @param <I>              the type of inputs
+     * @param <O>              the type of outputs
+     * @param automaton        the Mealy Machine automaton to be used
+     * @param inputs           the inputs of the automaton to be used
+     * @param reachableOutputs the modifiable collection to be used for storing
+     *                             the reachable outputs
      */
-    public static <S,I,O> void reachableOutputs(
+    public static <S, I, O> void reachableOutputs(
         MealyMachine<S, I, ?, O> automaton, Collection<I> inputs,
         Collection<O> reachableOutputs) {
 
         Queue<S> reachableStates = new ArrayDeque<>();
         Set<O> outputs = new HashSet<>();
         reachableStates(automaton, inputs, reachableStates);
-        for (S state : reachableStates) {
-            for (I input : inputs) {
+        for (S state: reachableStates) {
+            for (I input: inputs) {
                 outputs.add(automaton.getOutput(state, input));
             }
         }

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ModelFactory.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/utils/ModelFactory.java
@@ -17,30 +17,29 @@ public class ModelFactory {
     /**
      * Constructor
      */
-    public ModelFactory() { }
+    public ModelFactory() {}
 
     /**
      * Builds a Mealy Machine from an alphabet and a DOT file.
      *
-     * @param <I>          the type of inputs
-     * @param <O>          the type of outputs
-     * @param dotFilename  the filename of the DOT file
-     * @param processor    the processor for the inputs and outputs
-     * @return             the built model after parsing
+     * @param  <I>             the type of inputs
+     * @param  <O>             the type of outputs
+     * @param  dotFilename     the filename of the DOT file
+     * @param  processor       the processor for the inputs and outputs
      *
-     * @throws IOException      if an error parsing the DOT file occurs
-     * @throws FormatException  if an invalid format was encountered
+     * @return                 the built model after parsing
+     *
+     * @throws IOException     if an error parsing the DOT file occurs
+     * @throws FormatException if an invalid format was encountered
      */
     public static <I, O> MealyMachine<?, I, ?, O> buildProtocolModel(
         String dotFilename,
-        MealyInputOutputProcessor<I, O> processor
-    ) throws IOException, FormatException {
+        MealyInputOutputProcessor<I, O> processor) throws IOException, FormatException {
 
         InputModelData<I, CompactMealy<I, O>> result = MealyDotParser.parse(
             new CompactMealy.Creator<I, O>(),
             new FileInputStream(dotFilename),
-            processor
-        );
+            processor);
 
         return result.model;
     }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigTest.java
@@ -54,21 +54,32 @@ public class LearnerConfigTest<M> {
         Long testLimit = 13L;
         Integer roundLimit = 14;
 
+        // @formatter:off
         LearnerConfig[] learnerConfigs = parseWithStandard(stateFuzzerConfigBuilder,
-            new String[] {"-alphabet", alphabet, "-learningAlgorithm", learningAlgorithm
-                .name(), "-equivalenceAlgorithms", equivalenceAlgorithmsString, "-depth", String
-                    .valueOf(depth), "-minLength", String.valueOf(minLength), "-maxLength", String
-                        .valueOf(maxLength), "-randLength", String.valueOf(randLength), "-equivalenceQueryBound", String
-                            .valueOf(equivalenceQueryBound), "-memQueryRuns", String
-                                .valueOf(memQueryRuns), "-memQueryRetries", String
-                                    .valueOf(memQueryRetries), "-logQueries", "-probReset", String
-                                        .valueOf(probReset), "-testFile", testFile, "-seed", String.valueOf(
-                                            seed), "-cacheTests", "-ceSanitizationDisable", "-skipNonDetTests", "-ceReruns", String
-                                                .valueOf(
-                                                    ceReruns), "-probabilisticSanitizationDisable", "-timeLimit", timeLimit
-                                                        .toString(), "-testLimit", String.valueOf(
-                                                            testLimit), "-roundLimit", String.valueOf(roundLimit),
+            new String[] {
+                "-alphabet", alphabet,
+                "-learningAlgorithm", learningAlgorithm.name(),
+                "-equivalenceAlgorithms", equivalenceAlgorithmsString,
+                "-depth", String.valueOf(depth),
+                "-minLength", String.valueOf(minLength),
+                "-maxLength", String.valueOf(maxLength),
+                "-randLength", String.valueOf(randLength),
+                "-equivalenceQueryBound", String.valueOf(equivalenceQueryBound),
+                "-memQueryRuns", String.valueOf(memQueryRuns),
+                "-memQueryRetries", String.valueOf(memQueryRetries),
+                "-logQueries", "-probReset", String.valueOf(probReset),
+                "-testFile", testFile,
+                "-seed", String.valueOf(seed),
+                "-cacheTests",
+                "-ceSanitizationDisable",
+                "-skipNonDetTests",
+                "-ceReruns", String.valueOf(ceReruns),
+                "-probabilisticSanitizationDisable",
+                "-timeLimit", timeLimit.toString(),
+                "-testLimit", String.valueOf(testLimit),
+                "-roundLimit", String.valueOf(roundLimit),
             });
+        // @formatter:on
 
         for (LearnerConfig learnerConfig: learnerConfigs) {
             Assert.assertNotNull(learnerConfig);
@@ -180,8 +191,7 @@ public class LearnerConfigTest<M> {
     private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {"-alphabet", "alphabetPath"
-        };
+        String[] partialArgs = new String[] {"-alphabet", "alphabetPath"};
 
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
         CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/config/LearnerConfigTest.java
@@ -24,19 +24,21 @@ public class LearnerConfigTest<M> {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(new LearnerConfigStandard(), null, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(new LearnerConfigStandard(), null, null, null);
                 }
-            }
-        );
+            });
     }
 
     private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         String alphabet = "alphabetFile";
         LearningAlgorithmName learningAlgorithm = LearningAlgorithmName.LSTAR;
-        List<EquivalenceAlgorithmName> equivalenceAlgorithms = List.of(EquivalenceAlgorithmName.W_METHOD, EquivalenceAlgorithmName.WP_METHOD);
-        String equivalenceAlgorithmsString = EquivalenceAlgorithmName.W_METHOD.name() + "," + EquivalenceAlgorithmName.WP_METHOD.name();
+        List<EquivalenceAlgorithmName> equivalenceAlgorithms = List.of(EquivalenceAlgorithmName.W_METHOD,
+            EquivalenceAlgorithmName.WP_METHOD);
+        String equivalenceAlgorithmsString = EquivalenceAlgorithmName.W_METHOD.name() + ","
+            + EquivalenceAlgorithmName.WP_METHOD.name();
         int depth = 3;
         int minLength = 4;
         int maxLength = 5;
@@ -52,32 +54,23 @@ public class LearnerConfigTest<M> {
         Long testLimit = 13L;
         Integer roundLimit = 14;
 
-        LearnerConfig[] learnerConfigs = parseWithStandard(stateFuzzerConfigBuilder, new String[]{
-            "-alphabet", alphabet,
-            "-learningAlgorithm", learningAlgorithm.name(),
-            "-equivalenceAlgorithms", equivalenceAlgorithmsString,
-            "-depth", String.valueOf(depth),
-            "-minLength", String.valueOf(minLength),
-            "-maxLength", String.valueOf(maxLength),
-            "-randLength", String.valueOf(randLength),
-            "-equivalenceQueryBound", String.valueOf(equivalenceQueryBound),
-            "-memQueryRuns", String.valueOf(memQueryRuns),
-            "-memQueryRetries", String.valueOf(memQueryRetries),
-            "-logQueries",
-            "-probReset", String.valueOf(probReset),
-            "-testFile", testFile,
-            "-seed", String.valueOf(seed),
-            "-cacheTests",
-            "-ceSanitizationDisable",
-            "-skipNonDetTests",
-            "-ceReruns", String.valueOf(ceReruns),
-            "-probabilisticSanitizationDisable",
-            "-timeLimit", timeLimit.toString(),
-            "-testLimit", String.valueOf(testLimit),
-            "-roundLimit", String.valueOf(roundLimit),
-        });
+        LearnerConfig[] learnerConfigs = parseWithStandard(stateFuzzerConfigBuilder,
+            new String[] {"-alphabet", alphabet, "-learningAlgorithm", learningAlgorithm
+                .name(), "-equivalenceAlgorithms", equivalenceAlgorithmsString, "-depth", String
+                    .valueOf(depth), "-minLength", String.valueOf(minLength), "-maxLength", String
+                        .valueOf(maxLength), "-randLength", String.valueOf(randLength), "-equivalenceQueryBound", String
+                            .valueOf(equivalenceQueryBound), "-memQueryRuns", String
+                                .valueOf(memQueryRuns), "-memQueryRetries", String
+                                    .valueOf(memQueryRetries), "-logQueries", "-probReset", String
+                                        .valueOf(probReset), "-testFile", testFile, "-seed", String.valueOf(
+                                            seed), "-cacheTests", "-ceSanitizationDisable", "-skipNonDetTests", "-ceReruns", String
+                                                .valueOf(
+                                                    ceReruns), "-probabilisticSanitizationDisable", "-timeLimit", timeLimit
+                                                        .toString(), "-testLimit", String.valueOf(
+                                                            testLimit), "-roundLimit", String.valueOf(roundLimit),
+            });
 
-        for (LearnerConfig learnerConfig : learnerConfigs) {
+        for (LearnerConfig learnerConfig: learnerConfigs) {
             Assert.assertNotNull(learnerConfig);
             Assert.assertEquals(alphabet, learnerConfig.getAlphabetFilename());
             Assert.assertEquals(learningAlgorithm, learnerConfig.getLearningAlgorithm());
@@ -126,14 +119,14 @@ public class LearnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(new LearnerConfig(){}, null, null, null);
+                    return new StateFuzzerClientConfigStandard(new LearnerConfig() {}, null, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(new LearnerConfig(){}, null, null, null);
+                    return new StateFuzzerServerConfigStandard(new LearnerConfig() {}, null, null, null);
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -142,14 +135,14 @@ public class LearnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(new LearnerConfig(){}, null, null, null);
+                    return new StateFuzzerClientConfigStandard(new LearnerConfig() {}, null, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -158,14 +151,14 @@ public class LearnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(new LearnerConfig(){}, null, null, null);
+                    return new StateFuzzerServerConfigStandard(new LearnerConfig() {}, null, null, null);
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -174,21 +167,20 @@ public class LearnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {
-            "-alphabet", "alphabetPath"
+        String[] partialArgs = new String[] {"-alphabet", "alphabetPath"
         };
 
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfigTest.java
@@ -32,8 +32,7 @@ public class SULClientConfigTest<M> extends SULConfigTest {
         String fuzzingRole = "client";
 
         SULConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder,
-            new String[] {"-clientWait", String.valueOf(clientWait), "-port", String.valueOf(port)
-            });
+            new String[] {"-clientWait", String.valueOf(clientWait), "-port", String.valueOf(port)});
 
         Assert.assertTrue(sulConfig instanceof SULClientConfigStandard);
         SULClientConfigStandard sulClientConfigStandard = (SULClientConfigStandard) sulConfig;
@@ -72,8 +71,7 @@ public class SULClientConfigTest<M> extends SULConfigTest {
                     return new StateFuzzerServerConfig() {};
                 }
             },
-            new String[] {"-port", "portValue"
-            });
+            new String[] {"-port", "portValue"});
     }
 
     @Test
@@ -90,8 +88,7 @@ public class SULClientConfigTest<M> extends SULConfigTest {
                     return new StateFuzzerServerConfig() {};
                 }
             },
-            new String[] {"-port", "portValue"
-            });
+            new String[] {"-port", "portValue"});
     }
 
     @Override

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULClientConfigTest.java
@@ -18,12 +18,12 @@ public class SULClientConfigTest<M> extends SULConfigTest {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(new SULClientConfigStandard());
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
@@ -31,10 +31,9 @@ public class SULClientConfigTest<M> extends SULConfigTest {
         Integer port = 8;
         String fuzzingRole = "client";
 
-        SULConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder, new String[]{
-            "-clientWait", String.valueOf(clientWait),
-            "-port", String.valueOf(port)
-        });
+        SULConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder,
+            new String[] {"-clientWait", String.valueOf(clientWait), "-port", String.valueOf(port)
+            });
 
         Assert.assertTrue(sulConfig instanceof SULClientConfigStandard);
         SULClientConfigStandard sulClientConfigStandard = (SULClientConfigStandard) sulConfig;
@@ -46,10 +45,12 @@ public class SULClientConfigTest<M> extends SULConfigTest {
     }
 
     @Override
-    protected SULClientConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+    protected SULClientConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        StateFuzzerClientConfig stateFuzzerClientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, partialArgs);
+        StateFuzzerClientConfig stateFuzzerClientConfig = CommandLineParserTest.parseClientArgs(commandLineParser,
+            partialArgs);
 
         Assert.assertNotNull(stateFuzzerClientConfig);
         Assert.assertNotNull(stateFuzzerClientConfig);
@@ -63,17 +64,16 @@ public class SULClientConfigTest<M> extends SULConfigTest {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(new SULClientConfig(){});
+                    return new StateFuzzerClientConfigStandard(new SULClientConfig() {});
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
-            new String[]{
-                "-port", "portValue"
-            }
-        );
+            new String[] {"-port", "portValue"
+            });
     }
 
     @Test
@@ -82,21 +82,21 @@ public class SULClientConfigTest<M> extends SULConfigTest {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
-            new String[]{
-                "-port", "portValue"
-            }
-        );
+            new String[] {"-port", "portValue"
+            });
     }
 
     @Override
-    protected void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+    protected void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
     }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfigTest.java
@@ -8,7 +8,8 @@ import org.junit.Assert;
 import java.util.HashMap;
 
 public abstract class SULConfigTest {
-    protected SULConfig parseAllOptionsWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder ,String[] reqArgs) {
+    protected SULConfig parseAllOptionsWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] reqArgs) {
         Long responseWait = 1L;
         HashMap<String, Long> inputResponseTimeout = new HashMap<>();
         inputResponseTimeout.put("IN_2", 2L);
@@ -20,15 +21,9 @@ public abstract class SULConfigTest {
         ProcessLaunchTrigger processTrigger = ProcessLaunchTrigger.NEW_TEST;
         Long startWait = 4L;
 
-        String commonArgs[] = new String[]{
-            "-responseWait", String.valueOf(responseWait),
-            "-inputResponseTimeout", inputResponseTimeoutString,
-            "-command", sulCommand,
-            "-terminateCommand", terminateCommand,
-            "-processDir", processDir,
-            "-redirectOutputStreams",
-            "-processTrigger", processTrigger.name(),
-            "-startWait", String.valueOf(startWait),
+        String commonArgs[] = new String[] {"-responseWait", String.valueOf(
+            responseWait), "-inputResponseTimeout", inputResponseTimeoutString, "-command", sulCommand, "-terminateCommand", terminateCommand, "-processDir", processDir, "-redirectOutputStreams", "-processTrigger", processTrigger
+                .name(), "-startWait", String.valueOf(startWait),
         };
         String[] partialArgs = CommandLineParserTest.concatArgs(commonArgs, reqArgs);
 
@@ -52,14 +47,16 @@ public abstract class SULConfigTest {
     }
 
     protected void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] reqArgs) {
-        String commonArgs[] = new String[]{
-            "-responseWait", "responseWaitTime"
+        String commonArgs[] = new String[] {"-responseWait", "responseWaitTime"
         };
         String[] partialArgs = CommandLineParserTest.concatArgs(commonArgs, reqArgs);
 
         assertInvalidParseWithEmpty(stateFuzzerConfigBuilder, partialArgs);
     }
 
-    protected abstract SULConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs);
-    protected abstract void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs);
+    protected abstract SULConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs);
+
+    protected abstract void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs);
 }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULConfigTest.java
@@ -21,10 +21,19 @@ public abstract class SULConfigTest {
         ProcessLaunchTrigger processTrigger = ProcessLaunchTrigger.NEW_TEST;
         Long startWait = 4L;
 
-        String commonArgs[] = new String[] {"-responseWait", String.valueOf(
-            responseWait), "-inputResponseTimeout", inputResponseTimeoutString, "-command", sulCommand, "-terminateCommand", terminateCommand, "-processDir", processDir, "-redirectOutputStreams", "-processTrigger", processTrigger
-                .name(), "-startWait", String.valueOf(startWait),
+        // @formatter:off
+        String commonArgs[] = new String[] {
+            "-responseWait", String.valueOf(responseWait),
+            "-inputResponseTimeout", inputResponseTimeoutString,
+            "-command", sulCommand,
+            "-terminateCommand", terminateCommand,
+            "-processDir", processDir,
+            "-redirectOutputStreams",
+            "-processTrigger", processTrigger.name(),
+            "-startWait", String.valueOf(startWait),
         };
+        // @formatter:on
+
         String[] partialArgs = CommandLineParserTest.concatArgs(commonArgs, reqArgs);
 
         SULConfig sulConfig = parseWithStandard(stateFuzzerConfigBuilder, partialArgs);
@@ -47,8 +56,7 @@ public abstract class SULConfigTest {
     }
 
     protected void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] reqArgs) {
-        String commonArgs[] = new String[] {"-responseWait", "responseWaitTime"
-        };
+        String commonArgs[] = new String[] {"-responseWait", "responseWaitTime"};
         String[] partialArgs = CommandLineParserTest.concatArgs(commonArgs, reqArgs);
 
         assertInvalidParseWithEmpty(stateFuzzerConfigBuilder, partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfigTest.java
@@ -16,23 +16,23 @@ public class SULServerConfigTest<M> extends SULConfigTest {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(new SULServerConfigStandard());
                 }
-            }
-        );
+            });
     }
 
     private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         String connect = "host:1234";
         String fuzzingRole = "server";
 
-        SULConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder, new String[]{
-                "-connect", connect
-        });
+        SULConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder,
+            new String[] {"-connect", connect
+            });
 
         Assert.assertTrue(sulConfig instanceof SULServerConfigStandard);
         SULServerConfigStandard sulServerConfigStandard = (SULServerConfigStandard) sulConfig;
@@ -43,10 +43,12 @@ public class SULServerConfigTest<M> extends SULConfigTest {
     }
 
     @Override
-    protected SULServerConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+    protected SULServerConfig parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        StateFuzzerServerConfig stateFuzzerServerConfig = CommandLineParserTest.parseServerArgs(commandLineParser, partialArgs);
+        StateFuzzerServerConfig stateFuzzerServerConfig = CommandLineParserTest.parseServerArgs(commandLineParser,
+            partialArgs);
 
         Assert.assertNotNull(stateFuzzerServerConfig);
         Assert.assertNotNull(stateFuzzerServerConfig);
@@ -60,17 +62,16 @@ public class SULServerConfigTest<M> extends SULConfigTest {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(new SULServerConfig(){});
+                    return new StateFuzzerServerConfigStandard(new SULServerConfig() {});
                 }
             },
-            new String[]{
-                "-connect", "connectString"
-            }
-        );
+            new String[] {"-connect", "connectString"
+            });
     }
 
     @Test
@@ -79,20 +80,21 @@ public class SULServerConfigTest<M> extends SULConfigTest {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
-            new String[]{
-                "-connect", "connectString"
-            }
-        );
+            new String[] {"-connect", "connectString"
+            });
     }
+
     @Override
-    protected void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+    protected void assertInvalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
         CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);
     }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/core/config/SULServerConfigTest.java
@@ -31,8 +31,7 @@ public class SULServerConfigTest<M> extends SULConfigTest {
         String fuzzingRole = "server";
 
         SULConfig sulConfig = super.parseAllOptionsWithStandard(stateFuzzerConfigBuilder,
-            new String[] {"-connect", connect
-            });
+            new String[] {"-connect", connect});
 
         Assert.assertTrue(sulConfig instanceof SULServerConfigStandard);
         SULServerConfigStandard sulServerConfigStandard = (SULServerConfigStandard) sulConfig;
@@ -70,8 +69,7 @@ public class SULServerConfigTest<M> extends SULConfigTest {
                     return new StateFuzzerServerConfigStandard(new SULServerConfig() {});
                 }
             },
-            new String[] {"-connect", "connectString"
-            });
+            new String[] {"-connect", "connectString"});
     }
 
     @Test
@@ -88,8 +86,7 @@ public class SULServerConfigTest<M> extends SULConfigTest {
                     return new StateFuzzerServerConfig() {};
                 }
             },
-            new String[] {"-connect", "connectString"
-            });
+            new String[] {"-connect", "connectString"});
     }
 
     @Override

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigTest.java
@@ -45,9 +45,15 @@ public class MapperConfigTest<M> {
         String mapperConnectionConfig = "mapperConnectionConfigFile";
         List<String> repeatingOutputs = List.of("OUT_1", "OUT_2");
 
-        String[] partialArgs = new String[] {"-mapperConnectionConfig", mapperConnectionConfig, "-repeatingOutputs", String
-            .join(",", repeatingOutputs), "-socketClosedAsTimeout", "-disabledAsTimeout", "-dontMergeRepeating"
+        // @formatter:off
+        String[] partialArgs = new String[] {
+            "-mapperConnectionConfig", mapperConnectionConfig,
+            "-repeatingOutputs", String.join(",", repeatingOutputs),
+            "-socketClosedAsTimeout",
+            "-disabledAsTimeout",
+            "-dontMergeRepeating"
         };
+        // @formatter:on
 
         MapperConfig[] mapperConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs,
             serverReqArgs);
@@ -260,8 +266,7 @@ public class MapperConfigTest<M> {
         String[] serverReqArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {"-mapperConnectionConfig", "mapperConnectionConfigPath",
-        };
+        String[] partialArgs = new String[] {"-mapperConnectionConfig", "mapperConnectionConfigPath"};
 
         clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
         String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/MapperConfigTest.java
@@ -17,8 +17,8 @@ import org.junit.Test;
 import java.util.List;
 
 public class MapperConfigTest<M> {
-    public static String[] SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS = new String[] { "-port", "1234" };
-    public static String[] SUL_SERVER_CONFIG_STANDARD_REQ_ARGS = new String[] { "-connect", "host:1234" };
+    public static String[] SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS = new String[] {"-port", "1234"};
+    public static String[] SUL_SERVER_CONFIG_STANDARD_REQ_ARGS = new String[] {"-connect", "host:1234"};
 
     @Test
     public void parseAllOptions_SFCstd_SULCstd_SFSstd_SULSstd() {
@@ -26,33 +26,33 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(new MapperConfigStandard(), null), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(new MapperConfigStandard(), null), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(new MapperConfigStandard(), null), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(new MapperConfigStandard(), null), null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
-    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs,
+        String[] serverReqArgs) {
         String mapperConnectionConfig = "mapperConnectionConfigFile";
         List<String> repeatingOutputs = List.of("OUT_1", "OUT_2");
 
-        String[] partialArgs = new String[] {
-            "-mapperConnectionConfig", mapperConnectionConfig,
-            "-repeatingOutputs", String.join(",", repeatingOutputs),
-            "-socketClosedAsTimeout",
-            "-disabledAsTimeout",
-            "-dontMergeRepeating"
+        String[] partialArgs = new String[] {"-mapperConnectionConfig", mapperConnectionConfig, "-repeatingOutputs", String
+            .join(",", repeatingOutputs), "-socketClosedAsTimeout", "-disabledAsTimeout", "-dontMergeRepeating"
         };
 
-        MapperConfig[] mapperConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs, serverReqArgs);
+        MapperConfig[] mapperConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs,
+            serverReqArgs);
 
-        for (MapperConfig mapperConfig : mapperConfigs) {
+        for (MapperConfig mapperConfig: mapperConfigs) {
             Assert.assertNotNull(mapperConfig);
             Assert.assertEquals(mapperConnectionConfig, mapperConfig.getMapperConnectionConfig());
             Assert.assertEquals(repeatingOutputs, mapperConfig.getRepeatingOutputs());
@@ -71,14 +71,16 @@ public class MapperConfigTest<M> {
 
         clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
         String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);
-        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, clientPartialArgs);
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser,
+            clientPartialArgs);
         Assert.assertNotNull(clientConfig);
         Assert.assertNotNull(clientConfig.getSULConfig());
         mapperConfigs[0] = clientConfig.getSULConfig().getMapperConfig();
 
         serverReqArgs = serverReqArgs == null ? new String[0] : serverReqArgs;
         String[] serverPartialArgs = CommandLineParserTest.concatArgs(partialArgs, serverReqArgs);
-        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, serverPartialArgs);
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser,
+            serverPartialArgs);
         Assert.assertNotNull(serverConfig);
         Assert.assertNotNull(serverConfig.getSULConfig());
         mapperConfigs[1] = serverConfig.getSULConfig().getMapperConfig();
@@ -92,16 +94,18 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(new MapperConfig(){}, null), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(new MapperConfig() {}, null), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(new MapperConfig(){}, null), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(new MapperConfig() {}, null), null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -110,16 +114,17 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(new MapperConfig(){}, null), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(new MapperConfig() {}, null), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig(){}, null, null);
+                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig() {}, null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            null
-        );
+            null);
     }
 
     @Test
@@ -128,16 +133,17 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(new MapperConfig(){}, null), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(new MapperConfig() {}, null), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -146,16 +152,17 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig(){}, null, null);
+                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig() {}, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(new MapperConfig(){}, null), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(new MapperConfig() {}, null), null, null);
                 }
             },
             null,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -164,16 +171,17 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(new MapperConfig(){}, null), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(new MapperConfig() {}, null), null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -182,16 +190,16 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig(){}, null, null);
+                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig() {}, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig(){}, null, null);
+                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig() {}, null, null);
                 }
             },
             null,
-            null
-        );
+            null);
     }
 
     @Test
@@ -200,16 +208,16 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig(){}, null, null);
+                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig() {}, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             null,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -218,16 +226,16 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -236,23 +244,23 @@ public class MapperConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig(){}, null, null);
+                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig() {}, null, null);
                 }
             },
             null,
-            null
-        );
+            null);
     }
 
-    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs,
+        String[] serverReqArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {
-            "-mapperConnectionConfig", "mapperConnectionConfigPath",
+        String[] partialArgs = new String[] {"-mapperConnectionConfig", "mapperConnectionConfigPath",
         };
 
         clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/SULAdapterConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/SULAdapterConfigTest.java
@@ -17,8 +17,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class SULAdapterConfigTest<M> {
-    public static String[] SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS = new String[] { "-port", "1234" };
-    public static String[] SUL_SERVER_CONFIG_STANDARD_REQ_ARGS = new String[] { "-connect", "host:1234" };
+    public static String[] SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS = new String[] {"-port", "1234"};
+    public static String[] SUL_SERVER_CONFIG_STANDARD_REQ_ARGS = new String[] {"-connect", "host:1234"};
 
     @Test
     public void parseAllOptions_SFCstd_SULCstd_SFSstd_SULSstd() {
@@ -26,30 +26,33 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(null, new SULAdapterConfigStandard()), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(null, new SULAdapterConfigStandard()), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(null, new SULAdapterConfigStandard()), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(null, new SULAdapterConfigStandard()), null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
-    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+    private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs,
+        String[] serverReqArgs) {
         Integer adapterPort = 1;
         String adapterAddress = "adapterAddress";
 
-        String[] partialArgs = new String[] {
-            "-adapterPort", String.valueOf(adapterPort),
-            "-adapterAddress", adapterAddress,
+        String[] partialArgs = new String[] {"-adapterPort", String
+            .valueOf(adapterPort), "-adapterAddress", adapterAddress,
         };
 
-        SULAdapterConfig[] sulAdapterConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs, serverReqArgs);
+        SULAdapterConfig[] sulAdapterConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs,
+            serverReqArgs);
 
-        for (SULAdapterConfig sulAdapterConfig : sulAdapterConfigs) {
+        for (SULAdapterConfig sulAdapterConfig: sulAdapterConfigs) {
             Assert.assertNotNull(sulAdapterConfig);
             Assert.assertEquals(adapterPort, sulAdapterConfig.getAdapterPort());
             Assert.assertEquals(adapterAddress, sulAdapterConfig.getAdapterAddress());
@@ -65,14 +68,16 @@ public class SULAdapterConfigTest<M> {
 
         clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
         String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);
-        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser, clientPartialArgs);
+        StateFuzzerClientConfig clientConfig = CommandLineParserTest.parseClientArgs(commandLineParser,
+            clientPartialArgs);
         Assert.assertNotNull(clientConfig);
         Assert.assertNotNull(clientConfig.getSULConfig());
         sulAdapterConfigs[0] = clientConfig.getSULConfig().getSULAdapterConfig();
 
         serverReqArgs = serverReqArgs == null ? new String[0] : serverReqArgs;
         String[] serverPartialArgs = CommandLineParserTest.concatArgs(partialArgs, serverReqArgs);
-        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser, serverPartialArgs);
+        StateFuzzerServerConfig serverConfig = CommandLineParserTest.parseServerArgs(commandLineParser,
+            serverPartialArgs);
         Assert.assertNotNull(serverConfig);
         Assert.assertNotNull(serverConfig.getSULConfig());
         sulAdapterConfigs[1] = serverConfig.getSULConfig().getSULAdapterConfig();
@@ -86,16 +91,18 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(null, new SULAdapterConfig(){}), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(null, new SULAdapterConfig() {}), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(null, new SULAdapterConfig(){}), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(null, new SULAdapterConfig() {}), null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -104,16 +111,17 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(null, new SULAdapterConfig(){}), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(null, new SULAdapterConfig() {}), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig(){}, null, null);
+                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig() {}, null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            null
-        );
+            null);
     }
 
     @Test
@@ -122,16 +130,17 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfigStandard(null, new SULAdapterConfig(){}), null, null);
+                    return new StateFuzzerClientConfigStandard(null,
+                        new SULClientConfigStandard(null, new SULAdapterConfig() {}), null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -140,16 +149,17 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig(){}, null, null);
+                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig() {}, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(null, new SULAdapterConfig(){}), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(null, new SULAdapterConfig() {}), null, null);
                 }
             },
             null,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -158,16 +168,17 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfigStandard(null, new SULAdapterConfig(){}), null, null);
+                    return new StateFuzzerServerConfigStandard(null,
+                        new SULServerConfigStandard(null, new SULAdapterConfig() {}), null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -176,16 +187,16 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig(){}, null, null);
+                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig() {}, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig(){}, null, null);
+                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig() {}, null, null);
                 }
             },
             null,
-            null
-        );
+            null);
     }
 
     @Test
@@ -194,16 +205,16 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig(){}, null, null);
+                    return new StateFuzzerServerConfigStandard(null, new SULServerConfig() {}, null, null);
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            null
-        );
+            null);
     }
 
     @Test
@@ -212,16 +223,16 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig(){}, null, null);
+                    return new StateFuzzerClientConfigStandard(null, new SULClientConfig() {}, null, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             null,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
     @Test
@@ -230,23 +241,23 @@ public class SULAdapterConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             SUL_CLIENT_CONFIG_STANDARD_REQ_ARGS,
-            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS
-        );
+            SUL_SERVER_CONFIG_STANDARD_REQ_ARGS);
     }
 
-    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs, String[] serverReqArgs) {
+    private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] clientReqArgs,
+        String[] serverReqArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {
-            "-adapterPort", "adapterPortValue"
+        String[] partialArgs = new String[] {"-adapterPort", "adapterPortValue"
         };
 
         clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/SULAdapterConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/components/sul/mapper/config/SULAdapterConfigTest.java
@@ -45,9 +45,12 @@ public class SULAdapterConfigTest<M> {
         Integer adapterPort = 1;
         String adapterAddress = "adapterAddress";
 
-        String[] partialArgs = new String[] {"-adapterPort", String
-            .valueOf(adapterPort), "-adapterAddress", adapterAddress,
+        // @formatter:off
+        String[] partialArgs = new String[] {
+            "-adapterPort", String.valueOf(adapterPort),
+            "-adapterAddress", adapterAddress,
         };
+        // @formatter:on
 
         SULAdapterConfig[] sulAdapterConfigs = parseWithStandard(stateFuzzerConfigBuilder, partialArgs, clientReqArgs,
             serverReqArgs);
@@ -257,8 +260,7 @@ public class SULAdapterConfigTest<M> {
         String[] serverReqArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {"-adapterPort", "adapterPortValue"
-        };
+        String[] partialArgs = new String[] {"-adapterPort", "adapterPortValue"};
 
         clientReqArgs = clientReqArgs == null ? new String[0] : clientReqArgs;
         String[] clientPartialArgs = CommandLineParserTest.concatArgs(partialArgs, clientReqArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParserTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParserTest.java
@@ -17,13 +17,11 @@ public class CommandLineParserTest<M> {
     public void parseDynamicOptionsBeforeUsage() {
         String output = "test_out_dir";
 
-        String[] partialArgs = new String[] {
-            "-Dpre.fix=test_",
-            "-Dpostfix=_dir",
-            "-output", "${pre.fix}out${postfix}"
+        String[] partialArgs = new String[] {"-Dpre.fix=test_", "-Dpostfix=_dir", "-output", "${pre.fix}out${postfix}"
         };
 
-        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null, null, null);
+        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
+            null, null);
 
         // parse as client command
         StateFuzzerClientConfig stateFuzzerClientConfig = parseClientArgs(commandLineParser, partialArgs);
@@ -38,13 +36,11 @@ public class CommandLineParserTest<M> {
     public void parseDynamicOptionsAfterUsage() {
         String output = "test_out_dir";
 
-        String[] partialArgs = new String[] {
-            "-output", "${pre.fix}out${postfix}",
-            "-Dpre.fix=test_",
-            "-Dpostfix=_dir"
+        String[] partialArgs = new String[] {"-output", "${pre.fix}out${postfix}", "-Dpre.fix=test_", "-Dpostfix=_dir"
         };
 
-        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null, null, null);
+        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
+            null, null);
 
         // parse as client command
         StateFuzzerClientConfig stateFuzzerClientConfig = parseClientArgs(commandLineParser, partialArgs);
@@ -59,13 +55,11 @@ public class CommandLineParserTest<M> {
     public void parseDynamicOptionsBeforeAndAfterUsage() {
         String output = "test_out_dir";
 
-        String[] partialArgs = new String[] {
-            "-Dpre.fix=test_",
-            "-output", "${pre.fix}out${postfix}",
-            "-Dpostfix=_dir"
+        String[] partialArgs = new String[] {"-Dpre.fix=test_", "-output", "${pre.fix}out${postfix}", "-Dpostfix=_dir"
         };
 
-        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null, null, null);
+        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
+            null, null);
 
         // parse as client command
         StateFuzzerClientConfig stateFuzzerClientConfig = parseClientArgs(commandLineParser, partialArgs);
@@ -78,10 +72,10 @@ public class CommandLineParserTest<M> {
 
     @Test
     public void parseInvalidCommand() {
-        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null, null, null);
+        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
+            null, null);
 
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[]{
-            "invalidCommand"
+        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[] {"invalidCommand"
         });
 
         Assert.assertNull(parseResult);
@@ -89,11 +83,11 @@ public class CommandLineParserTest<M> {
 
     @Test
     public void parseInvalidOption() {
-        String[] partialArgs = new String[] {
-            "-invalidOption"
+        String[] partialArgs = new String[] {"-invalidOption"
         };
 
-        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null, null, null);
+        CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
+            null, null);
 
         assertInvalidClientParse(commandLineParser, partialArgs);
         assertInvalidServerParse(commandLineParser, partialArgs);
@@ -107,6 +101,7 @@ public class CommandLineParserTest<M> {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(new SULClientConfigStandard());
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(new SULServerConfigStandard());
@@ -126,9 +121,10 @@ public class CommandLineParserTest<M> {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return null;
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             }, null, null, null);
 
@@ -141,8 +137,9 @@ public class CommandLineParserTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return null;
@@ -157,6 +154,7 @@ public class CommandLineParserTest<M> {
         public StateFuzzerClientConfig buildClientConfig() {
             return new StateFuzzerClientConfigStandard(null);
         }
+
         @Override
         public StateFuzzerServerConfig buildServerConfig() {
             return new StateFuzzerServerConfigStandard(null);
@@ -171,7 +169,8 @@ public class CommandLineParserTest<M> {
         return args;
     }
 
-    public static <M> StateFuzzerClientConfig parseClientArgs(CommandLineParser<M> commandLineParser, String[] partialArgs) {
+    public static <M> StateFuzzerClientConfig parseClientArgs(CommandLineParser<M> commandLineParser,
+        String[] partialArgs) {
         String[] args = concatArgs(new String[] {CommandLineParser.CMD_STATE_FUZZER_CLIENT}, partialArgs);
         CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(args);
 
@@ -183,7 +182,8 @@ public class CommandLineParserTest<M> {
         return (StateFuzzerClientConfig) parseResult.getObjectFromParsedCommand();
     }
 
-    public static <M> StateFuzzerServerConfig parseServerArgs(CommandLineParser<M> commandLineParser, String[] partialArgs) {
+    public static <M> StateFuzzerServerConfig parseServerArgs(CommandLineParser<M> commandLineParser,
+        String[] partialArgs) {
         String[] args = concatArgs(new String[] {CommandLineParser.CMD_STATE_FUZZER_SERVER}, partialArgs);
         CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(args);
 

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParserTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/entrypoints/CommandLineParserTest.java
@@ -17,8 +17,7 @@ public class CommandLineParserTest<M> {
     public void parseDynamicOptionsBeforeUsage() {
         String output = "test_out_dir";
 
-        String[] partialArgs = new String[] {"-Dpre.fix=test_", "-Dpostfix=_dir", "-output", "${pre.fix}out${postfix}"
-        };
+        String[] partialArgs = new String[] {"-Dpre.fix=test_", "-Dpostfix=_dir", "-output", "${pre.fix}out${postfix}"};
 
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
             null, null);
@@ -36,8 +35,7 @@ public class CommandLineParserTest<M> {
     public void parseDynamicOptionsAfterUsage() {
         String output = "test_out_dir";
 
-        String[] partialArgs = new String[] {"-output", "${pre.fix}out${postfix}", "-Dpre.fix=test_", "-Dpostfix=_dir"
-        };
+        String[] partialArgs = new String[] {"-output", "${pre.fix}out${postfix}", "-Dpre.fix=test_", "-Dpostfix=_dir"};
 
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
             null, null);
@@ -55,8 +53,7 @@ public class CommandLineParserTest<M> {
     public void parseDynamicOptionsBeforeAndAfterUsage() {
         String output = "test_out_dir";
 
-        String[] partialArgs = new String[] {"-Dpre.fix=test_", "-output", "${pre.fix}out${postfix}", "-Dpostfix=_dir"
-        };
+        String[] partialArgs = new String[] {"-Dpre.fix=test_", "-output", "${pre.fix}out${postfix}", "-Dpostfix=_dir"};
 
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
             null, null);
@@ -75,16 +72,14 @@ public class CommandLineParserTest<M> {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
             null, null);
 
-        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[] {"invalidCommand"
-        });
+        CommandLineParser.ParseResult parseResult = commandLineParser.parseCommand(new String[] {"invalidCommand"});
 
         Assert.assertNull(parseResult);
     }
 
     @Test
     public void parseInvalidOption() {
-        String[] partialArgs = new String[] {"-invalidOption"
-        };
+        String[] partialArgs = new String[] {"-invalidOption"};
 
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(new StateFuzzerConfigBuilderSimple(), null,
             null, null);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/MockMapper.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/MockMapper.java
@@ -6,7 +6,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abst
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
 import de.learnlib.ralib.words.PSymbolInstance;
 
-public class MockMapper  implements Mapper<PSymbolInstance, PSymbolInstance, Object> {
+public class MockMapper implements Mapper<PSymbolInstance, PSymbolInstance, Object> {
 
     private OutputBuilder<PSymbolInstance> outputBuilder;
     private OutputChecker<PSymbolInstance> outputChecker;
@@ -55,7 +55,7 @@ public class MockMapper  implements Mapper<PSymbolInstance, PSymbolInstance, Obj
 
     @Override
     public MapperConfig getMapperConfig() {
-        return new MapperConfig(){};
+        return new MapperConfig() {};
     }
 
     @Override

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/ParameterizedServer.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/ParameterizedServer.java
@@ -5,7 +5,9 @@ import java.util.Random;
 
 public class ParameterizedServer {
     private static final Integer MAX_MSG_ID = Integer.MAX_VALUE;
+
     public static record Msg(BigDecimal msgId) {};
+
     public static record Ack(BigDecimal nextMsgId) {};
 
     private BigDecimal nextMsgId;

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/ParameterizedServerRA.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/ParameterizedServerRA.java
@@ -21,20 +21,19 @@ import gov.nasa.jpf.constraints.expressions.NumericComparator;
 import gov.nasa.jpf.constraints.util.ExpressionUtil;
 
 /*
- * --- MSG 0  -->
+ * --- MSG 0 -->
  * <-- ACK 10 ---
  * --- MSG 10 -->
  * <-- ACK 20 ---
  * --- MSG 20 -->
- *
  * ACK generates the message id that is in the next MSG.
  */
 
 public class ParameterizedServerRA {
     public static final DataType MSG_ID = new DataType("msg_id");
 
-    public static final InputSymbol I_MSG = new InputSymbol("IMSG", new DataType[] { MSG_ID });
-    public static final OutputSymbol O_ACK = new OutputSymbol("OACK", new DataType[] { MSG_ID });
+    public static final InputSymbol I_MSG = new InputSymbol("IMSG", new DataType[] {MSG_ID});
+    public static final OutputSymbol O_ACK = new OutputSymbol("OACK", new DataType[] {MSG_ID});
     public static final OutputSymbol O_TIMEOUT = new OutputSymbol("OTIMEOUT");
 
     public static final RegisterAutomaton AUTOMATON = buildParameterizedServerWithFreshOutputValues();

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/ParameterizedServerSUL.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/ParameterizedServerSUL.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * A SUL implementing {@link ParameterizedServerRA}
  */
 public class ParameterizedServerSUL extends DataWordSUL
-        implements AbstractSUL<PSymbolInstance, PSymbolInstance, Object> {
+    implements AbstractSUL<PSymbolInstance, PSymbolInstance, Object> {
 
     private final Map<DataType, Map<DataValue, BigDecimal>> buckets = new HashMap<>();
     private ParameterizedServer server;
@@ -41,8 +41,7 @@ public class ParameterizedServerSUL extends DataWordSUL
     }
 
     @Override
-    public void post() {
-    }
+    public void post() {}
 
     @Override
     public PSymbolInstance step(PSymbolInstance in) {
@@ -50,9 +49,9 @@ public class ParameterizedServerSUL extends DataWordSUL
         assert in.getBaseSymbol().equals(I_MSG);
 
         DataValue[] values = Stream
-                .of(in.getParameterValues())
-                .map(this::remapDataValue)
-                .toArray(DataValue[]::new);
+            .of(in.getParameterValues())
+            .map(this::remapDataValue)
+            .toArray(DataValue[]::new);
 
         Ack ack = server.send(new Msg(values[0].getValue()));
         if (ack != null) {
@@ -75,8 +74,7 @@ public class ParameterizedServerSUL extends DataWordSUL
     }
 
     @Override
-    public void setDynamicPortProvider(DynamicPortProvider dynamicPortProvider) {
-    }
+    public void setDynamicPortProvider(DynamicPortProvider dynamicPortProvider) {}
 
     @Override
     public DynamicPortProvider getDynamicPortProvider() {

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RAAlphabetBuilder.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RAAlphabetBuilder.java
@@ -15,7 +15,7 @@ public class RAAlphabetBuilder implements AlphabetBuilder<ParameterizedSymbol> {
 
     private ParameterizedSymbol[] symbols;
 
-    public RAAlphabetBuilder(ParameterizedSymbol ...symbols) {
+    public RAAlphabetBuilder(ParameterizedSymbol... symbols) {
         this.symbols = symbols;
     }
 
@@ -36,7 +36,6 @@ public class RAAlphabetBuilder implements AlphabetBuilder<ParameterizedSymbol> {
 
     @Override
     public void exportAlphabetToFile(String outputFileName, Alphabet<ParameterizedSymbol> alphabet)
-            throws IOException, AlphabetSerializerException {
-    }
+        throws IOException, AlphabetSerializerException {}
 
 }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASUL.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASUL.java
@@ -53,8 +53,7 @@ public class RASUL implements AbstractSUL<PSymbolInstance, PSymbolInstance, Obje
     }
 
     @Override
-    public void setDynamicPortProvider(DynamicPortProvider dynamicPortProvider) {
-    }
+    public void setDynamicPortProvider(DynamicPortProvider dynamicPortProvider) {}
 
     @Override
     public DynamicPortProvider getDynamicPortProvider() {
@@ -120,7 +119,7 @@ public class RASUL implements AbstractSUL<PSymbolInstance, PSymbolInstance, Obje
 
         @Override
         public MapperConfig getMapperConfig() {
-            return new MapperConfig(){};
+            return new MapperConfig() {};
         }
 
         @Override

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASULBuilder.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/RASULBuilder.java
@@ -27,7 +27,8 @@ public class RASULBuilder implements SULBuilder<PSymbolInstance, PSymbolInstance
     }
 
     @Override
-    public AbstractSUL<PSymbolInstance, PSymbolInstance, Object> buildSUL(SULConfig sulConfig, CleanupTasks cleanupTasks) {
+    public AbstractSUL<PSymbolInstance, PSymbolInstance, Object> buildSUL(SULConfig sulConfig,
+        CleanupTasks cleanupTasks) {
         return new RASUL(ra, teachers, consts);
     }
 

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerRATest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/StateFuzzerRATest.java
@@ -49,7 +49,7 @@ public class StateFuzzerRATest {
 
     static class QuietStateFuzzerServerConfigStandard extends StateFuzzerServerConfigStandard {
         public QuietStateFuzzerServerConfigStandard(LearnerConfig learnerConfig, SULServerConfig sulServerConfig,
-                TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
+            TestRunnerConfig testRunnerConfig, TimingProbeConfig timingProbeConfig) {
             super(learnerConfig, sulServerConfig, testRunnerConfig, timingProbeConfig);
             super.quiet = true;
         }
@@ -64,29 +64,29 @@ public class StateFuzzerRATest {
     @Test
     public void testInferBasicServer() {
         RegisterAutomaton basicServerRA = BasicServerRA.AUTOMATON;
-        InputSymbol[] inputs = new InputSymbol[] { BasicServerRA.I_CONNECT, BasicServerRA.I_MSG };
+        InputSymbol[] inputs = new InputSymbol[] {BasicServerRA.I_CONNECT, BasicServerRA.I_MSG};
         Constants consts = new Constants();
         Map<DataType, Theory> teachers = new LinkedHashMap<>();
 
         RASULBuilder raSULBuilder = new RASULBuilder(basicServerRA, teachers, new Constants());
 
         StateFuzzerServerConfigStandard enabler = new QuietStateFuzzerServerConfigStandard(
-                new ShortRunningLearnerConfigRA(), new SULServerConfigStandard(), new TestRunnerConfigStandard(),
-                new TimingProbeConfigStandard());
+            new ShortRunningLearnerConfigRA(), new SULServerConfigStandard(), new TestRunnerConfigStandard(),
+            new TimingProbeConfigStandard());
 
         RAAlphabetBuilder alphabetBuilder = new RAAlphabetBuilder(BasicServerRA.I_CONNECT, BasicServerRA.I_MSG,
-                BasicServerRA.O_TIMEOUT, BasicServerRA.O_ACK);
+            BasicServerRA.O_TIMEOUT, BasicServerRA.O_ACK);
 
         StateFuzzerComposerRA<ParameterizedSymbol, Object> composer = new StateFuzzerComposerRA<ParameterizedSymbol, Object>(
-                enabler, alphabetBuilder, raSULBuilder, teachers);
+            enabler, alphabetBuilder, raSULBuilder, teachers);
         composer.initialize();
 
         StateFuzzerRA<ParameterizedSymbol, Object> fuzzer = new StateFuzzerRA<>(composer);
         LearnerResult<RegisterAutomatonWrapper<ParameterizedSymbol, PSymbolInstance>> result = fuzzer
-                .inferRegisterAutomata();
+            .inferRegisterAutomata();
         IOEquivalenceTest test = new IOEquivalenceTest(basicServerRA, teachers, consts, false, inputs);
         DefaultQuery<PSymbolInstance, Boolean> ce = test
-                .findCounterExample(result.getLearnedModel().getRegisterAutomaton(), null);
+            .findCounterExample(result.getLearnedModel().getRegisterAutomaton(), null);
         Assert.assertNull(ce);
     }
 
@@ -94,7 +94,7 @@ public class StateFuzzerRATest {
     public void testInferParameterizedServer() {
         RegisterAutomaton parameterizedServerRA = ParameterizedServerRA.AUTOMATON;
         ParameterizedServerSUL parameterizedServerSUL = new ParameterizedServerSUL();
-        InputSymbol[] inputs = new InputSymbol[] { ParameterizedServerRA.I_MSG };
+        InputSymbol[] inputs = new InputSymbol[] {ParameterizedServerRA.I_MSG};
         Constants consts = new Constants();
         Map<DataType, Theory> teachers = new LinkedHashMap<>();
         IntegerEqualityTheory theory = new IntegerEqualityTheory(ParameterizedServerRA.MSG_ID);
@@ -104,7 +104,7 @@ public class StateFuzzerRATest {
         SULBuilder<PSymbolInstance, PSymbolInstance, Object> sulBuilder = new SULBuilder<>() {
             @Override
             public AbstractSUL<PSymbolInstance, PSymbolInstance, Object> buildSUL(SULConfig sulConfig,
-                    CleanupTasks cleanupTasks) {
+                CleanupTasks cleanupTasks) {
                 return new ParameterizedServerSUL();
             }
 
@@ -116,20 +116,20 @@ public class StateFuzzerRATest {
         };
 
         StateFuzzerServerConfigStandard enabler = new QuietStateFuzzerServerConfigStandard(
-                new ShortRunningLearnerConfigRA(), new SULServerConfigStandard(), new TestRunnerConfigStandard(),
-                new TimingProbeConfigStandard());
+            new ShortRunningLearnerConfigRA(), new SULServerConfigStandard(), new TestRunnerConfigStandard(),
+            new TimingProbeConfigStandard());
         RAAlphabetBuilder alphabetBuilder = new RAAlphabetBuilder(ParameterizedServerRA.I_MSG,
-                ParameterizedServerRA.O_ACK, ParameterizedServerRA.O_TIMEOUT);
+            ParameterizedServerRA.O_ACK, ParameterizedServerRA.O_TIMEOUT);
         StateFuzzerComposerRA<ParameterizedSymbol, Object> composer = new StateFuzzerComposerRA<ParameterizedSymbol, Object>(
-                enabler, alphabetBuilder, sulBuilder, teachers);
+            enabler, alphabetBuilder, sulBuilder, teachers);
         composer.initialize();
 
         StateFuzzerRA<ParameterizedSymbol, Object> fuzzer = new StateFuzzerRA<>(composer);
         LearnerResult<RegisterAutomatonWrapper<ParameterizedSymbol, PSymbolInstance>> result = fuzzer
-                .inferRegisterAutomata();
+            .inferRegisterAutomata();
         IOEquivalenceTest test = new IOEquivalenceTest(parameterizedServerRA, teachers, consts, false, inputs);
         DefaultQuery<PSymbolInstance, Boolean> ce = test
-                .findCounterExample(result.getLearnedModel().getRegisterAutomaton(), null);
+            .findCounterExample(result.getLearnedModel().getRegisterAutomaton(), null);
         Assert.assertNull(ce);
     }
 }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerClientConfigTest.java
@@ -23,6 +23,7 @@ public class StateFuzzerClientConfigTest<M> extends StateFuzzerConfigTest {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(null);
@@ -39,8 +40,9 @@ public class StateFuzzerClientConfigTest<M> extends StateFuzzerConfigTest {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(null);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigTest.java
@@ -25,8 +25,7 @@ public abstract class StateFuzzerConfigTest {
         String output = prefix + "${timestamp}";
         String dateFormat = "yyyy-MM-dd_HH-mm-ss";
 
-        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[] {"-output", output
-        });
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[] {"-output", output});
 
         String outputDir = stateFuzzerConfig.getOutputDir();
         Assert.assertTrue(outputDir.startsWith(prefix));
@@ -40,8 +39,7 @@ public abstract class StateFuzzerConfigTest {
         String dateFormat = "yyyy-MM-dd";
 
         StateFuzzerConfig stateFuzzerConfig = parseWithStandard(
-            new String[] {"-Dtimestamp.format=" + dateFormat, "-output", output
-            });
+            new String[] {"-Dtimestamp.format=" + dateFormat, "-output", output});
 
         String outputDir = stateFuzzerConfig.getOutputDir();
         Assert.assertTrue(outputDir.startsWith(prefix));
@@ -52,8 +50,7 @@ public abstract class StateFuzzerConfigTest {
         String output = "output";
 
         StateFuzzerConfig stateFuzzerConfig = parseWithStandard(
-            new String[] {"-help", "-debug", "-quiet", "-output", output
-            });
+            new String[] {"-help", "-debug", "-quiet", "-output", output});
 
         Assert.assertTrue(stateFuzzerConfig.isHelp());
         Assert.assertTrue(stateFuzzerConfig.isDebug());
@@ -71,8 +68,7 @@ public abstract class StateFuzzerConfigTest {
 
     @Test
     public void invalidParseWithEmpty() {
-        assertInvalidParseWithEmpty(new String[] {"-help",
-        });
+        assertInvalidParseWithEmpty(new String[] {"-help"});
     }
 
     protected abstract StateFuzzerConfig parseWithStandard(String[] partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerConfigTest.java
@@ -25,8 +25,7 @@ public abstract class StateFuzzerConfigTest {
         String output = prefix + "${timestamp}";
         String dateFormat = "yyyy-MM-dd_HH-mm-ss";
 
-        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[]{
-            "-output", output
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[] {"-output", output
         });
 
         String outputDir = stateFuzzerConfig.getOutputDir();
@@ -40,10 +39,9 @@ public abstract class StateFuzzerConfigTest {
         String output = prefix + "${timestamp}";
         String dateFormat = "yyyy-MM-dd";
 
-        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[]{
-            "-Dtimestamp.format=" + dateFormat,
-            "-output", output
-        });
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(
+            new String[] {"-Dtimestamp.format=" + dateFormat, "-output", output
+            });
 
         String outputDir = stateFuzzerConfig.getOutputDir();
         Assert.assertTrue(outputDir.startsWith(prefix));
@@ -53,12 +51,9 @@ public abstract class StateFuzzerConfigTest {
     protected StateFuzzerConfig parseAllOptionsWithStandard() {
         String output = "output";
 
-        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(new String[]{
-            "-help",
-            "-debug",
-            "-quiet",
-            "-output", output
-        });
+        StateFuzzerConfig stateFuzzerConfig = parseWithStandard(
+            new String[] {"-help", "-debug", "-quiet", "-output", output
+            });
 
         Assert.assertTrue(stateFuzzerConfig.isHelp());
         Assert.assertTrue(stateFuzzerConfig.isDebug());
@@ -76,11 +71,11 @@ public abstract class StateFuzzerConfigTest {
 
     @Test
     public void invalidParseWithEmpty() {
-        assertInvalidParseWithEmpty(new String[] {
-            "-help",
+        assertInvalidParseWithEmpty(new String[] {"-help",
         });
     }
 
     protected abstract StateFuzzerConfig parseWithStandard(String[] partialArgs);
+
     protected abstract void assertInvalidParseWithEmpty(String[] partialArgs);
 }

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/core/config/StateFuzzerServerConfigTest.java
@@ -22,6 +22,7 @@ public class StateFuzzerServerConfigTest<M> extends StateFuzzerConfigTest {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(null);
@@ -40,9 +41,10 @@ public class StateFuzzerServerConfigTest<M> extends StateFuzzerConfigTest {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
             },
             null, null, null);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigTest.java
@@ -32,10 +32,15 @@ public class TestRunnerConfigTest<M> {
         Integer times = 2;
         String testSpecification = "testSpecificationModel";
 
+        // @formatter:off
         TestRunnerConfig[] testRunnerConfigs = parseWithStandard(stateFuzzerConfigBuilder,
-            new String[] {"-test", test, "-times", String
-                .valueOf(times), "-testSpecification", testSpecification, "-showTransitionSequence",
+            new String[] {
+                "-test", test,
+                "-times", String.valueOf(times),
+                "-testSpecification", testSpecification,
+                "-showTransitionSequence",
             });
+        // @formatter:on
 
         for (TestRunnerConfig testRunnerConfig: testRunnerConfigs) {
             Assert.assertNotNull(testRunnerConfig);
@@ -130,8 +135,7 @@ public class TestRunnerConfigTest<M> {
     private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {"-test", "testPath",
-        };
+        String[] partialArgs = new String[] {"-test", "testPath"};
 
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
         CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/core/config/TestRunnerConfigTest.java
@@ -19,12 +19,12 @@ public class TestRunnerConfigTest<M> {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfigStandard(), null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfigStandard(), null);
                 }
-            }
-        );
+            });
     }
 
     private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
@@ -32,14 +32,12 @@ public class TestRunnerConfigTest<M> {
         Integer times = 2;
         String testSpecification = "testSpecificationModel";
 
-        TestRunnerConfig[] testRunnerConfigs = parseWithStandard(stateFuzzerConfigBuilder, new String[]{
-            "-test", test,
-            "-times", String.valueOf(times),
-            "-testSpecification", testSpecification,
-            "-showTransitionSequence",
-        });
+        TestRunnerConfig[] testRunnerConfigs = parseWithStandard(stateFuzzerConfigBuilder,
+            new String[] {"-test", test, "-times", String
+                .valueOf(times), "-testSpecification", testSpecification, "-showTransitionSequence",
+            });
 
-        for (TestRunnerConfig testRunnerConfig : testRunnerConfigs) {
+        for (TestRunnerConfig testRunnerConfig: testRunnerConfigs) {
             Assert.assertNotNull(testRunnerConfig);
             Assert.assertEquals(test, testRunnerConfig.getTest());
             Assert.assertEquals(times, testRunnerConfig.getTimes());
@@ -48,7 +46,8 @@ public class TestRunnerConfigTest<M> {
         }
     }
 
-    private TestRunnerConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+    private TestRunnerConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
         TestRunnerConfig[] testRunnerConfigs = new TestRunnerConfig[2];
@@ -70,14 +69,14 @@ public class TestRunnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfig(){}, null);
+                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfig() {}, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfig(){}, null);
+                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfig() {}, null);
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -86,14 +85,14 @@ public class TestRunnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfig(){}, null);
+                    return new StateFuzzerClientConfigStandard(null, null, new TestRunnerConfig() {}, null);
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -102,14 +101,14 @@ public class TestRunnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfig(){}, null);
+                    return new StateFuzzerServerConfigStandard(null, null, new TestRunnerConfig() {}, null);
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -118,21 +117,20 @@ public class TestRunnerConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {
-            "-test", "testPath",
+        String[] partialArgs = new String[] {"-test", "testPath",
         };
 
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigTest.java
@@ -19,12 +19,12 @@ public class TimingProbeConfigTest<M> {
                 public StateFuzzerClientConfig buildClientConfig() {
                     return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfigStandard());
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
                     return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfigStandard());
                 }
-            }
-        );
+            });
     }
 
     private void parseAllOptions(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
@@ -34,15 +34,12 @@ public class TimingProbeConfigTest<M> {
         Integer probeHigh = 3;
         String probeExport = "probeExportFile";
 
-        TimingProbeConfig[] timingProbeConfigs = parseWithStandard(stateFuzzerConfigBuilder, new String[]{
-            "-timingProbe", timingProbe,
-            "-probeTol", String.valueOf(probeTol),
-            "-probeLow", String.valueOf(probeLow),
-            "-probeHigh", String.valueOf(probeHigh),
-            "-probeExport", probeExport,
-        });
+        TimingProbeConfig[] timingProbeConfigs = parseWithStandard(stateFuzzerConfigBuilder,
+            new String[] {"-timingProbe", timingProbe, "-probeTol", String.valueOf(probeTol), "-probeLow", String
+                .valueOf(probeLow), "-probeHigh", String.valueOf(probeHigh), "-probeExport", probeExport,
+            });
 
-        for (TimingProbeConfig timingProbeConfig : timingProbeConfigs) {
+        for (TimingProbeConfig timingProbeConfig: timingProbeConfigs) {
             Assert.assertNotNull(timingProbeConfig);
             Assert.assertEquals(timingProbe, timingProbeConfig.getProbeCmd());
             Assert.assertEquals(probeTol, timingProbeConfig.getProbeTol());
@@ -52,7 +49,8 @@ public class TimingProbeConfigTest<M> {
         }
     }
 
-    private TimingProbeConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder, String[] partialArgs) {
+    private TimingProbeConfig[] parseWithStandard(StateFuzzerConfigBuilder stateFuzzerConfigBuilder,
+        String[] partialArgs) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
         TimingProbeConfig[] timingProbeConfigs = new TimingProbeConfig[2];
@@ -74,14 +72,14 @@ public class TimingProbeConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfig(){});
+                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfig() {});
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfig(){});
+                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfig() {});
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -90,14 +88,14 @@ public class TimingProbeConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfig(){});
+                    return new StateFuzzerClientConfigStandard(null, null, null, new TimingProbeConfig() {});
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -106,14 +104,14 @@ public class TimingProbeConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfig(){});
+                    return new StateFuzzerServerConfigStandard(null, null, null, new TimingProbeConfig() {});
                 }
-            }
-        );
+            });
     }
 
     @Test
@@ -122,21 +120,20 @@ public class TimingProbeConfigTest<M> {
             new StateFuzzerConfigBuilder() {
                 @Override
                 public StateFuzzerClientConfig buildClientConfig() {
-                    return new StateFuzzerClientConfig(){};
+                    return new StateFuzzerClientConfig() {};
                 }
+
                 @Override
                 public StateFuzzerServerConfig buildServerConfig() {
-                    return new StateFuzzerServerConfig(){};
+                    return new StateFuzzerServerConfig() {};
                 }
-            }
-        );
+            });
     }
 
     private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {
-            "-timingProbe", "timingProbeCommand"
+        String[] partialArgs = new String[] {"-timingProbe", "timingProbeCommand"
         };
 
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);

--- a/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigTest.java
+++ b/src/test/java/com/github/protocolfuzzing/protocolstatefuzzer/statefuzzer/testrunner/timingprobe/config/TimingProbeConfigTest.java
@@ -34,10 +34,16 @@ public class TimingProbeConfigTest<M> {
         Integer probeHigh = 3;
         String probeExport = "probeExportFile";
 
+        // @formatter:off
         TimingProbeConfig[] timingProbeConfigs = parseWithStandard(stateFuzzerConfigBuilder,
-            new String[] {"-timingProbe", timingProbe, "-probeTol", String.valueOf(probeTol), "-probeLow", String
-                .valueOf(probeLow), "-probeHigh", String.valueOf(probeHigh), "-probeExport", probeExport,
+            new String[] {
+                "-timingProbe", timingProbe,
+                "-probeTol", String.valueOf(probeTol),
+                "-probeLow", String.valueOf(probeLow),
+                "-probeHigh", String.valueOf(probeHigh),
+                "-probeExport", probeExport
             });
+        // @formatter:on
 
         for (TimingProbeConfig timingProbeConfig: timingProbeConfigs) {
             Assert.assertNotNull(timingProbeConfig);
@@ -133,8 +139,7 @@ public class TimingProbeConfigTest<M> {
     private void invalidParseWithEmpty(StateFuzzerConfigBuilder stateFuzzerConfigBuilder) {
         CommandLineParser<M> commandLineParser = new CommandLineParser<>(stateFuzzerConfigBuilder, null, null, null);
 
-        String[] partialArgs = new String[] {"-timingProbe", "timingProbeCommand"
-        };
+        String[] partialArgs = new String[] {"-timingProbe", "timingProbeCommand"};
 
         CommandLineParserTest.assertInvalidClientParse(commandLineParser, partialArgs);
         CommandLineParserTest.assertInvalidServerParse(commandLineParser, partialArgs);


### PR DESCRIPTION
This PR updates the `spotless` configuration to perform code formatting using the `eclipse_jdt` backend. Before this, `spotless` was responsible for some minor enhancements on the files but not the code itself.

Having an automated code-formatter will save us effort from manual formatting and from formatting differences of our possibly different local formatting configurations.

### Why eclipse_jdt

Among the available formatters that `spotless` [supports](https://github.com/diffplug/spotless/tree/main/plugin-maven), I found the `eclipse_jdt` backend to be the most configurable, so that we can tailor it to our needs if we want to.

### Configuration File

I created the `.spotless/eclipse-style.xml` configuration file that configures every element of Java. The easiest and most helpful way to modify/create this is to download the `eclipse IDE` and find the formatting configuration menu via `Window -> Preferences -> Java -> Code Style -> Formatter` and either import our `.spotless/eclipse-style.xml` or create a new profile and export it afterwards.

This way, I went through all options in `eclipse IDE` menu and created the configuration file.

### How to read the PR

The net changes are many to parse, but they are only formatting changes, so a quick skim will suffice to get an idea, how the formatter is configured.

One notable change, for example, is that the doc comments are also formatted and I configured them to align their descriptions. It was not possible to maintain the `two-spaces` that we manually respected, but it is good enough, since they are automatically organized now.

### Local Conflicts

After this PR, any local formatter (that possibly auto-formats on save) will conflict with `spotless` unless they respect the same configuration. 

One way to solve this is to always `mvn spotless:apply` before push, for instance, in order for everything to be formatted.

One other way is to point the local formatter to the same configuration file (`.spotless/eclipse-style.xml`) so that it is aligned with the project's configuration. This is possible only if the local formatter supports eclipse-style configuration. For instance `jdtls`, which I am using, do support this, so that auto-format does not conflict with `spotless`.

### Other Additions

In order to automate the checks, I configured and added two hooks under `.githooks`:
- `pre-commit`: before every `git commit`, it runs `spotless check` and if it fails runs `spotless apply`, in which case the commit fails and the user needs to commit the formatting changes
- `pre-push`: before every `git push`, it runs `mvn verify` to ensure that everything runs correctly before pushing

If in a rare occasion the hooks need to be bypassed, the corresponding commands are:
- `git commit --no-verify`
- `git push --no-verify`