### PR TITLE
Bump com.google.errorprone:error_prone_core from 2.49.0 to 2.50.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <automatalib.version>0.12.1</automatalib.version>
         <biz-aQute.version>7.3.0</biz-aQute.version>
         <checker-qual.version>4.2.0</checker-qual.version>
-        <error-prone.version>2.49.0</error-prone.version>
+        <error-prone.version>2.50.0</error-prone.version>
         <jakarta-xml.version>4.0.5</jakarta-xml.version>
         <jaxb-runtime.version>4.0.9</jaxb-runtime.version>
         <jcommander.version>1.82</jcommander.version>

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/oracles/ObservationTree.java
@@ -187,7 +187,7 @@ public class ObservationTree<I, O> {
         }
 
         for (I symbol: this.parent.children.keySet()) {
-            if (this == this.parent.children.get(symbol)) {
+            if (this.equals(this.parent.children.get(symbol))) {
                 this.parent.children.remove(symbol);
                 this.parent.outputs.remove(symbol);
                 break;

--- a/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/RunDescriptionPrinter.java
+++ b/src/main/java/com/github/protocolfuzzing/protocolstatefuzzer/components/learner/statistics/RunDescriptionPrinter.java
@@ -83,7 +83,7 @@ public interface RunDescriptionPrinter {
         if (values == null || values.isEmpty()) {
             printWriter.println("# " + name);
         } else {
-            printWriter.println(name + "\n" + values.stream().map(T::toString).collect(Collectors.joining(",")));
+            printWriter.println(name + "\n" + values.stream().map(Object::toString).collect(Collectors.joining(",")));
         }
     }
 


### PR DESCRIPTION
Fix one warning and one new error identified by the new version of error-prone.